### PR TITLE
Address feedback on cli docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This is a partial list of adapters that can be installed separately. Make sure t
 * [PostgreSQL](https://github.com/juttle/juttle-postgres-adapter/)
 * [MySQL](https://github.com/juttle/juttle-mysql-adapter/)
 * [Twitter](https://github.com/juttle/juttle-twitter-adapter/)
-* [GMail](https://github.com/juttle/juttle-gmail-adapter/)
+* [Gmail](https://github.com/juttle/juttle-gmail-adapter/)
 
 Connections to external adapters are configured in the "adapters" section of the runtime configuration. See the [CLI reference](./docs/reference/cli.md) for specific instructions.
 
@@ -179,7 +179,7 @@ npm test
 Both are run automatically by Travis.
 
 When developing you may run into failures during linting where jscs complains
-about your coding style and an easy way to fix those files is to simply run 
+about your coding style and an easy way to fix those files is to simply run
 `jscs --fix test` or `jscs --fix lib` from the root directory of the project.
-After jscs fixes things you should proceed to check that those changes are 
+After jscs fixes things you should proceed to check that those changes are
 reasonable as auto-fixing may not produce the nicest of looking code.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -27,3 +27,4 @@ See the [Juttle README](https://github.com/juttle/juttle) for instructions on co
 * [postgres](https://github.com/juttle/juttle-postgres-adapter) (PostgreSQL)
 * [sqlite](https://github.com/juttle/juttle-sqlite-adapter) (SQLite)
 * [twitter](https://github.com/juttle/juttle-twitter-adapter) (Twitter)
+* [GMail](https://github.com/juttle/juttle-gmail-adapter/) (GMail)

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -27,4 +27,4 @@ See the [Juttle README](https://github.com/juttle/juttle) for instructions on co
 * [postgres](https://github.com/juttle/juttle-postgres-adapter) (PostgreSQL)
 * [sqlite](https://github.com/juttle/juttle-sqlite-adapter) (SQLite)
 * [twitter](https://github.com/juttle/juttle-twitter-adapter) (Twitter)
-* [GMail](https://github.com/juttle/juttle-gmail-adapter/) (GMail)
+* [Gmail](https://github.com/juttle/juttle-gmail-adapter/) (Gmail)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -226,7 +226,7 @@ The first module file found is used.
 
 ## Configuring Adapters
 
-Connections to external adapters are configured in the "adapters" section of the configuration. Each entry should be the name of the adapter along with any adapter-specific configuration. By default, the CLI will try to load the adapter by executing `require(adapter)` but if the `path` attribute exists then it will try to load the adapter from the specified path.
+Connections to [external adapters](../adapters/index.md) are configured in the "adapters" section of the configuration. Each entry should be the name of the adapter along with any adapter-specific configuration. By default, the CLI will try to load the adapter by executing `require(adapter)` but if the `path` attribute exists then it will try to load the adapter from the specified path.
 
 For example, to configure the Elasticsearch adapter, first run `npm install juttle-elastic-adapter` and add the following to your `juttle-config` file, updating the address and port to point to the location of your Elasticsearch cluster.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,9 +119,9 @@ pages:
    - '____ Object': 'modules/object.md'
    - '____ String': 'modules/string.md'
 
-   - 'CLI': 'reference/cli.md'
    - 'Time': 'reference/time.md'
    - 'Data Types': 'reference/data_types.md'
    - 'Operators': 'reference/operators.md'
    - 'Conditionals': 'reference/conditionals.md'
+   - 'CLI': 'reference/cli.md'
    - 'Style Guide': 'reference/style_guide.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ markdown_extensions:
     - markdown_include.include
     - unimoji:
         span_class: 'custom_emoji'
-        emoji: 
+        emoji:
          '<img alt="bulb" src="/images/emoji/bulb.png" width="30" height="30"/>': [ ':bulb:' ]
          '<img alt="construction" src="/images/emoji/construction.png" width="30" height="30"/>': [ ':construction:' ]
          '<img alt="warning" src="/images/emoji/warning.png" width="30" height="30"/>': [ ':warning:' ]
@@ -54,7 +54,7 @@ pages:
 
    - '____ Standard Library': 'concepts/juttle_standard_library.md'
 
-- Reference: 
+- Reference:
 
    - 'Sources': 'sources/index.md'
    - '____ emit': 'sources/emit.md'
@@ -119,6 +119,7 @@ pages:
    - '____ Object': 'modules/object.md'
    - '____ String': 'modules/string.md'
 
+   - 'CLI': 'reference/cli.md'
    - 'Time': 'reference/time.md'
    - 'Data Types': 'reference/data_types.md'
    - 'Operators': 'reference/operators.md'


### PR DESCRIPTION
Add to mkdocs.yml, add link to adapters page from adapters section,
add link for gmail adapter on adapters page.

@dmehra can you double-check that I added the link to mkdocs.yml properly?