### PR TITLE
fix issue #1 read http not failing on bad status code

### DIFF
--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -1,8 +1,8 @@
 var _ = require('underscore');
 var contentType = require('content-type');
-var request = require('request-promise');
 var Juttle = require('../../runtime').Juttle;
 var parsers = require('../parsers');
+var request = require('request');
 
 var Read = Juttle.proc.source.extend({
     sourceType: 'batch',
@@ -53,6 +53,14 @@ var Read = Juttle.proc.source.extend({
         }
     },
 
+    triggerFailure: function(message) {
+        var runtime_error = this.runtime_error('RT-INTERNAL-ERROR', {
+            error: message
+        });
+        this.trigger('error', runtime_error);
+        this.emit_eof();
+    },
+
     start: function() {
         var self = this;
 
@@ -60,56 +68,54 @@ var Read = Juttle.proc.source.extend({
             uri: this.url,
             method: this.method,
             headers: this.headers,
-            body: JSON.stringify(this.body),
-            resolveWithFullResponse: true
-        });
+            body: JSON.stringify(this.body)
+        })
+        .on('error', function(err) {
+            self.triggerFailure(err.toString());
+        })
+        .on('response', function(res) {
+            if (!('' + res.statusCode).match(/2\d\d/)) {
+                var body = [];
+                res.on('data', function(chunk) {
+                    body.push(chunk);
+                });
 
-        req
-        .catch(function(err) {
-            var runtime_error = self.runtime_error('RT-INTERNAL-ERROR', {
-                error: err.toString()
-            });
-            self.trigger('error', runtime_error);
-            self.emit_eof();
-        });
+                res.on('end', function() {
+                    self.triggerFailure('StatusCodeError: ' + res.statusCode +
+                                        ' - ' + body.join(''));
+                });
+            } else {
+                var format;
+                try {
+                    format  = contentType.parse(res).type.split('/')[1];
+                } catch(err) {
+                    // type is undefined
+                }
 
-        req.on('response', function(res) {
-            var format;
-            try {
-                format  = contentType.parse(res).type.split('/')[1];
-            } catch(err) {
-                // type is undefined
-            }
-
-            try {
-                var parser =  parsers.getParser(format);
-                return parser.parseStream(req, function(points) {
-                    if (self.includeHeaders) {
-                        _.each(points, function(point) {
-                            _.each(res.headers, function(value, key) {
-                                point[key] = value;
+                try {
+                    var parser =  parsers.getParser(format);
+                    parser.parseStream(req, function(points) {
+                        if (self.includeHeaders) {
+                            _.each(points, function(point) {
+                                _.each(res.headers, function(value, key) {
+                                    point[key] = value;
+                                });
                             });
-                        });
-                    }
+                        }
 
-                    if (!_.isArray(points)) {
-                        points = [points];
-                    }
+                        if (!_.isArray(points)) {
+                            points = [points];
+                        }
 
-                    self.parseTime(points, self.timeField);
-                    self.emit(points);
-                    self.emit_eof();
-                })
-                .catch(function(err) {
-                    self.trigger('error', err);
-                    self.emit_eof();
-                });
-            } catch (err) {
-                var runtime_error = self.runtime_error('RT-INTERNAL-ERROR', {
-                    error: err.toString()
-                });
-                self.trigger('error', runtime_error);
-                self.emit_eof();
+                        self.parseTime(points, self.timeField);
+                        self.emit(points);
+                        self.emit_eof();
+                    }).catch(function(err) {
+                        self.triggerFailure(err.toString());
+                    });
+                } catch(err) {
+                    self.triggerFailure(err.toString());
+                }
             }
         });
     }

--- a/lib/adapters/http/write.js
+++ b/lib/adapters/http/write.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var request = require('request-promise');
+var request = require('request');
 var Juttle = require('../../runtime').Juttle;
 
 // taken from https://gist.github.com/timruffles/3377784
@@ -70,13 +70,30 @@ var Write = Juttle.proc.sink.extend({
                 body: JSON.stringify(chunk),
                 resolveWithFullResponse: true
             })
-            .catch(function(err) {
+            .on('error', function(err) {
                 var runtime_error = self.runtime_error('RT-INTERNAL-ERROR', {
                     error: err.toString()
                 });
                 self.trigger('warning', runtime_error);
+                self.emit_eof();
             })
-            .finally(function() {
+            .on('response', function(res) {
+                if (!('' + res.statusCode).match(/2\d\d/)) {
+                    var body = [];
+                    res.on('data', function(chunk) {
+                        body.push(chunk);
+                    });
+
+                    res.on('end', function() {
+                        var runtime_error = self.runtime_error('RT-INTERNAL-ERROR', {
+                            error: 'StatusCodeError: ' + res.statusCode + ' - ' + body.join('')
+                        });
+                        self.trigger('warning', runtime_error);
+                        self.emit_eof();
+                    });
+                }
+            })
+            .on('end', function() {
                 self.in_progress_writes--;
                 self._maybe_done();
             });

--- a/lib/adapters/parsers/index.js
+++ b/lib/adapters/parsers/index.js
@@ -18,7 +18,7 @@ module.exports = {
         if (parser) {
             return new parser(options);
         } else {
-            throw errors.compileError('RT-INVALID-OPTION-VALUE',{
+            throw errors.runtimeError('RT-INVALID-OPTION-VALUE',{
                 option: 'format',
                 supported: _.keys(parserLookup).join(', ')
             });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment-timezone": "^0.4.0",
     "oboe": "^2.1.2",
     "pegjs": "^0.9.0",
-    "request-promise": "^1.0.2",
+    "request": "^2.67.0",
     "seedrandom": "^2.3.6",
     "tdigest": "^0.1.1",
     "tiny-fifo-cache": "^1.0.1",

--- a/test/adapters/http.spec.js
+++ b/test/adapters/http.spec.js
@@ -363,8 +363,8 @@ describe('HTTP adapter tests', function() {
         it('can use -headers to set headers', function() {
             var self = this;
             return check_juttle({
-                program: 'read http -headers { "foo":"bar", "fizz":"buzz" } ' +
-                    '                -url "' + self.url + '/headers?foo=bar&fizz=buzz"'
+                program: 'read http -headers { foo: "bar", fizz: "buzz" } ' +
+                    '               -url "' + self.url + '/headers?foo=bar&fizz=buzz"'
             })
             .then(function(result) {
                 expect(result.errors.length).equal(0);
@@ -413,14 +413,16 @@ describe('HTTP adapter tests', function() {
             });
         });
 
-        it('fails when response is non 200', function() {
-            return check_juttle({
-                program: 'read http -url "' + this.url + '/status/500"'
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(1);
-                expect(result.warnings.length).equal(0);
-                expect(result.errors[0]).to.contain('Error: internal error StatusCodeError: 500');
+        _.each([400, 500], function(status) {
+            it('fails when response has status code of ' + status, function() {
+                return check_juttle({
+                    program: 'read http -url "' + this.url + '/status/' + status + '"'
+                })
+                .then(function(result) {
+                    expect(result.errors.length).equal(1);
+                    expect(result.warnings.length).equal(0);
+                    expect(result.errors[0]).to.contain('Error: internal error StatusCodeError: ' + status);
+                });
             });
         });
 


### PR DESCRIPTION
fixes #1 by just ripping out request-promise for now and using the
request library directly so we don't end up mixing stream events and
promise chains and having timing issues.