### PR TITLE
Drop the "code " from the error string.

### DIFF
--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -49,7 +49,7 @@ var show_in_context = function(options) {
         ret += highlight + "\n";
     }
 
-    ret += options.err.message + " code (" + options.err.code + ")\n";
+    ret += options.err.message + " (" + options.err.code + ")\n";
 
     return ret;
 };

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -118,7 +118,7 @@ describe('Juttle CLI Tests', function() {
                 'emit -limit 1 | view nosink',
             ]).then(function(result) {
                 expect(result.code).to.equal(1);
-                expect(result.stderr).to.include('Error: program refers to invalid client view \"nosink\" code (RT-INVALID-VIEW)');
+                expect(result.stderr).to.include('Error: program refers to invalid client view \"nosink\" (RT-INVALID-VIEW)');
             });
         });
 


### PR DESCRIPTION
For error strings like:

<input>:1:17:
   1:read from gmail -from :1 hour ago: | view table
                     ^^^^^
Options must be specified before filter expressions. code (JUTTLE-SYNTAX-ERROR-WITHOUT-EXPECTED)

the "code " is not needed, so remove it.

@dave @mnibecker 