### PR TITLE
Use more specific error for unknown views.

### DIFF
--- a/lib/sinks/client-sink-mgr.js
+++ b/lib/sinks/client-sink-mgr.js
@@ -39,8 +39,8 @@ var ClientSinkManager = Base.extend({
             if (_.has(self.sink_classes, sink.name)) {
                 sink_class = self.sink_classes[sink.name];
             } else {
-                throw JuttleErrors.syntaxError('RT-UNDEFINED', {name: sink.name,
-                                                                location: sink.location});
+                throw JuttleErrors.syntaxError('RT-INVALID-VIEW', {sink: sink.name,
+                                                                   location: sink.location});
             }
 
             self.sinks[sink.channel] = new sink_class(sink.options, self.env);

--- a/lib/strings/juttle-error-strings-en-US.json
+++ b/lib/strings/juttle-error-strings-en-US.json
@@ -116,6 +116,7 @@
     "RT-IMPORT-INTERPOLATION": "Error: Cannot use interpolation in imported module name.",
     "RT-MODULE-NOT-FOUND": "Error: could not find module \"{{info.module}}\"",
     "RT-FIELD-NOT-STRING": "Error: field {{info.field}} is not a string",
-    "RT-INVALID-OPTION-VALUE": "Error: Invalid {{info.option}} option value, must be one of the following: {{info.supported}}"
+    "RT-INVALID-OPTION-VALUE": "Error: Invalid {{info.option}} option value, must be one of the following: {{info.supported}}",
+    "RT-INVALID-VIEW": "Error: program refers to invalid client view \"{{info.sink}}\""
   }
 }

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -118,7 +118,7 @@ describe('Juttle CLI Tests', function() {
                 'emit -limit 1 | view nosink',
             ]).then(function(result) {
                 expect(result.code).to.equal(1);
-                expect(result.stderr).to.include('Error: nosink is not defined code (RT-UNDEFINED)');
+                expect(result.stderr).to.include('Error: program refers to invalid client view \"nosink\" code (RT-INVALID-VIEW)');
             });
         });
 


### PR DESCRIPTION
Use a specific error RT-INVALID-VIEW when a program refers to a view
that isn't supported by the runtime (i.e., for the cli, by the client
sink manager).

@demmer 