### PR TITLE
README: add gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Juttle
 
 [![Build Status](https://travis-ci.org/juttle/juttle.svg)](https://travis-ci.org/juttle/juttle)
+[![Join the chat at https://gitter.im/juttle/juttle](https://badges.gitter.im/juttle/juttle.svg)](https://gitter.im/juttle/juttle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Juttle is an analytics system for developers built upon
 a stream-processing core and a


### PR DESCRIPTION
This adds a gitter badge to the readme.

It is essentially the same change as #9 except it puts the badges on the same line instead of one after another, and keeps the Travis badge first.
