### PR TITLE
test: rework the unit tests for the parsers to be more robust

### DIFF
--- a/test/adapters/parsers/csv.spec.js
+++ b/test/adapters/parsers/csv.spec.js
@@ -15,7 +15,7 @@ describe('parsers/csv', function() {
 
     it('fails when given an invalid CSV stream', function() {
         var csv = parsers.getParser('csv');
-        csv.parseStream(fs.createReadStream(invalidFile))
+        return csv.parseStream(fs.createReadStream(invalidFile))
         .then(function() {
             throw Error('previous statement should have failed');
         })
@@ -24,43 +24,52 @@ describe('parsers/csv', function() {
         });
     });
 
-    it('can parse a single CSV point', function(done) {
+    it('can parse a file with a single CSV point', function() {
         var csv = parsers.getParser('csv');
-        csv.parseStream(fs.createReadStream(pointFile), function(result) {
-            expect(result).to.deep.equal([
+        var results = [];
+        return csv.parseStream(fs.createReadStream(pointFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results).to.deep.equal([[
                 {
                     'time': '2014-01-01T00:00:00.000Z',
                     'foo': '1'
                 }
-            ]);
-            done();
+            ]]);
         });
     });
 
-    it('can parse a mutliple CSV points', function(done) {
+    it('can parse a file with multiple CSV points', function() {
         var csv = parsers.getParser('csv');
-        csv.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
+        var results = [];
+        return csv.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
                 { 'time': '2014-01-01T00:00:01.000Z', 'foo': '1' },
                 { 'time': '2014-01-01T00:00:02.000Z', 'foo': '2' },
                 { 'time': '2014-01-01T00:00:03.000Z', 'foo': '3' }
-            ]);
-            done();
+            ]]);
         });
     });
 
-    it('emits points with payload limit specified', function(done) {
+    it('calls emit multiple times with payload limit specified', function() {
         var csv = parsers.getParser('csv', { limit: 1 });
-        var emit = 0;
-        csv.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
-                { 'time': '2014-01-01T00:00:0' + (emit + 1) + '.000Z', 'foo': '' + (emit + 1) },
+        var results = [];
+        return csv.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(4);
+            expect(results).to.deep.equal([
+                [{ 'time': '2014-01-01T00:00:01.000Z', 'foo': '1' }],
+                [{ 'time': '2014-01-01T00:00:02.000Z', 'foo': '2' }],
+                [{ 'time': '2014-01-01T00:00:03.000Z', 'foo': '3' }],
+                []
             ]);
-
-            emit++;
-            if (emit === 3) {
-                done();
-            }
         });
     });
 });

--- a/test/adapters/parsers/csv.spec.js
+++ b/test/adapters/parsers/csv.spec.js
@@ -15,7 +15,7 @@ describe('parsers/csv', function() {
 
     it('fails when given an invalid CSV stream', function() {
         var csv = parsers.getParser('csv');
-        return csv.parseStream(fs.createReadStream(invalidFile))
+        return csv.parseStream(fs.createReadStream(invalidFile), function() {})
         .then(function() {
             throw Error('previous statement should have failed');
         })

--- a/test/adapters/parsers/json.spec.js
+++ b/test/adapters/parsers/json.spec.js
@@ -15,7 +15,7 @@ describe('parsers/json', function() {
 
     it('fails when given an invalid JSON stream', function() {
         var json = parsers.getParser('json');
-        return json.parseStream(fs.createReadStream(invalidFile))
+        return json.parseStream(fs.createReadStream(invalidFile), function() {})
         .then(function() {
             throw Error('previous statement should have failed');
         })

--- a/test/adapters/parsers/json.spec.js
+++ b/test/adapters/parsers/json.spec.js
@@ -15,7 +15,7 @@ describe('parsers/json', function() {
 
     it('fails when given an invalid JSON stream', function() {
         var json = parsers.getParser('json');
-        json.parseStream(fs.createReadStream(invalidFile), function() {})
+        return json.parseStream(fs.createReadStream(invalidFile))
         .then(function() {
             throw Error('previous statement should have failed');
         })
@@ -24,43 +24,52 @@ describe('parsers/json', function() {
         });
     });
 
-    it('can parse a single JSON point', function(done) {
+    it('can parse a file with a single JSON point', function() {
         var json = parsers.getParser('json');
-        json.parseStream(fs.createReadStream(pointFile), function(result) {
-            expect(result).to.deep.equal([
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results).to.deep.equal([[
                 {
-                    "time": "2014-01-01T00:00:00.000Z",
-                    "foo": 1
+                    'time': '2014-01-01T00:00:00.000Z',
+                    'foo': 1
                 }
-            ]);
-            done();
+            ]]);
         });
     });
 
-    it('can parse a JSON array', function(done) {
+    it('can parse a file with multiple JSON points', function() {
         var json = parsers.getParser('json');
-        json.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
-                { "time": "2014-01-01T00:00:01.000Z", "foo": 1 },
-                { "time": "2014-01-01T00:00:02.000Z", "foo": 2 },
-                { "time": "2014-01-01T00:00:03.000Z", "foo": 3 }
-            ]);
-            done();
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
+                { 'time': '2014-01-01T00:00:01.000Z', 'foo': 1 },
+                { 'time': '2014-01-01T00:00:02.000Z', 'foo': 2 },
+                { 'time': '2014-01-01T00:00:03.000Z', 'foo': 3 }
+            ]]);
         });
     });
 
-    it('emits points with payload limit specified', function(done) {
+    it('calls emit multiple times with payload limit specified', function() {
         var json = parsers.getParser('json', { limit: 1 });
-        var emit = 0;
-        json.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
-                { "time": "2014-01-01T00:00:0" + (emit + 1) + ".000Z", "foo": (emit + 1) },
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(4);
+            expect(results).to.deep.equal([
+                [{ 'time': '2014-01-01T00:00:01.000Z', 'foo': 1 }],
+                [{ 'time': '2014-01-01T00:00:02.000Z', 'foo': 2 }],
+                [{ 'time': '2014-01-01T00:00:03.000Z', 'foo': 3 }],
+                []
             ]);
-
-            emit++;
-            if (emit === 3) {
-                done();
-            }
         });
     });
 });

--- a/test/adapters/parsers/jsonl.spec.js
+++ b/test/adapters/parsers/jsonl.spec.js
@@ -15,7 +15,7 @@ describe('parsers/jsonl', function() {
 
     it('fails when given an invalid JSONL stream', function() {
         var jsonl = parsers.getParser('jsonl');
-        jsonl.parseStream(fs.createReadStream(invalidFile))
+        return jsonl.parseStream(fs.createReadStream(invalidFile))
         .then(function() {
             throw Error('previous statement should have failed');
         })
@@ -24,43 +24,52 @@ describe('parsers/jsonl', function() {
         });
     });
 
-    it('can parse a single JSONL point', function(done) {
+    it('can parse a file with a single JSONL point', function() {
         var jsonl = parsers.getParser('jsonl');
-        jsonl.parseStream(fs.createReadStream(pointFile), function(result) {
-            expect(result).to.deep.equal([
+        var results = [];
+        return jsonl.parseStream(fs.createReadStream(pointFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results).to.deep.equal([[
                 {
-                    "time": "2014-01-01T00:00:00.000Z",
-                    "foo": 1
+                    'time': '2014-01-01T00:00:00.000Z',
+                    'foo': 1
                 }
-            ]);
-            done();
+            ]]);
         });
     });
 
-    it('can parse multiple points in JSONL format', function(done) {
+    it('can parse a file with multiple JSONL points', function() {
         var jsonl = parsers.getParser('jsonl');
-        jsonl.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
-                { "time": "2014-01-01T00:00:01.000Z", "foo": 1 },
-                { "time": "2014-01-01T00:00:02.000Z", "foo": 2 },
-                { "time": "2014-01-01T00:00:03.000Z", "foo": 3 }
-            ]);
-            done();
+        var results = [];
+        return jsonl.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
+                { 'time': '2014-01-01T00:00:01.000Z', 'foo': 1 },
+                { 'time': '2014-01-01T00:00:02.000Z', 'foo': 2 },
+                { 'time': '2014-01-01T00:00:03.000Z', 'foo': 3 }
+            ]]);
         });
     });
 
-    it('emits points with payload limit specified', function(done) {
+    it('calls emit multiple times with payload limit specified', function() {
         var jsonl = parsers.getParser('jsonl', { limit: 1 });
-        var emit = 0;
-        jsonl.parseStream(fs.createReadStream(pointsFile), function(result) {
-            expect(result).to.deep.equal([
-                { "time": "2014-01-01T00:00:0" + (emit + 1) + ".000Z", "foo": (emit + 1) },
+        var results = [];
+        return jsonl.parseStream(fs.createReadStream(pointsFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(4);
+            expect(results).to.deep.equal([
+                [{ 'time': '2014-01-01T00:00:01.000Z', 'foo': 1 }],
+                [{ 'time': '2014-01-01T00:00:02.000Z', 'foo': 2 }],
+                [{ 'time': '2014-01-01T00:00:03.000Z', 'foo': 3 }],
+                []
             ]);
-
-            emit++;
-            if (emit === 3) {
-                done();
-            }
         });
     });
 });

--- a/test/adapters/parsers/jsonl.spec.js
+++ b/test/adapters/parsers/jsonl.spec.js
@@ -15,7 +15,7 @@ describe('parsers/jsonl', function() {
 
     it('fails when given an invalid JSONL stream', function() {
         var jsonl = parsers.getParser('jsonl');
-        return jsonl.parseStream(fs.createReadStream(invalidFile))
+        return jsonl.parseStream(fs.createReadStream(invalidFile), function() {})
         .then(function() {
             throw Error('previous statement should have failed');
         })


### PR DESCRIPTION
Update the various parser tests to return a promise from each test
case and include the checks as part of the promise chain as opposed
to the previous approach in which the tests would throw expectation
errors from within the context of the emit callback.

This should help localize failures more clearly.

As part of this change, update the tests to properly handle the case
where the parser is given a limit on the number of points per emit
so that it properly expects an empty array at the end of the test.

This was causing intermittent failures in travis as identified in #13.