### PR TITLE
Grammar: Remove hack detecting options after filter expressions

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1384,12 +1384,7 @@ SimpleFilterTerm
       }
 
 SimpleFilterTermToplevel
-    // Temporary fix for PROD-5897. Should be removed once we allow interleaving
-    // of options and non-options in PROD-6159.
-    = &('-' Identifier) expression:ShiftExpressionToplevel {
-          error('Options must be specified before filter expressions.');
-      }
-    / expression:ShiftExpressionToplevel {
+    = expression:ShiftExpressionToplevel {
           return createNode('SimpleFilterTerm', location(), {
               expression: expression
           });

--- a/test/runtime/specs/juttle-spec/filter-expressions/simple-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/simple-filter-terms.spec.md
@@ -14,14 +14,3 @@ Produces an error when used on term of invalid type
 
 The following testcase should really be in parser tests, but we don't have
 these.
-
-Produces correct error on terms that look like options
-------------------------------------------------------
-
-### Juttle
-
-    read test "abcd" -type "event"
-
-### Errors
-
-  * Options must be specified before filter expressions.


### PR DESCRIPTION
The removed hack was intended to improve error messages in programs where the author used an option after a filter expression in `read`, which is illegal:

    read file level = 'error' -file '~/my-data.json'

In these cases, the `-file` part was originally mistakenly considered a full-text term, parsed as such, and the compiler later produced an error like this:

    Error: file is not defined

The hack improved such messages. However, it also lead to many wrong error messages in cases of options used in legal position but with syntactically invalid values (such as unterminated strings):

    read file -file '~/my-data.json

In these cases, the parser produced a message:

    Options must be specified before filter expressions.

This is clearly wrong because there are no filter expressions in play here.

The hack was triggered in cases like this because the thing (`-file '~/my-data.json`) couldn’t be parsed as an option with a value, so the parser tried to parse it as a filter expression, but at that moment the
hack was triggered because the thing looked like a beginning of an option.

Rather than “hack the hack” against situations like this I chose to remove the hack completely, which changes the message in the last example to:

    Expected ";", "|" or expression but "\"" found.

This makes much more sense.

The swapped options and filter expression case now produces the original, less than ideal error message. I think this trade-off is worth it because this case occurs much less often than the case of invalid option values.

Ultimately, this will get properly resolved by either of (a) allowing mixing options and filter expressions freely and (b) changing free-text search syntax to be less implicit (to that `-file` wouldn't be a legal
full-text term syntactically).