### PR TITLE
Parser cleanups: Structural changes

### DIFF
--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -120,6 +120,20 @@ function checkImportNode(node) {
     }
 }
 
+function processOptions(options, defaultResolver) {
+    if (options === undefined) {
+        options = {};
+    }
+
+    return _.defaults(_.clone(options), {
+        filename: 'main',
+        startRule: 'start',
+        autocompleteCallback: null,
+        modules: {},
+        moduleResolver: defaultResolver
+    });
+}
+
 /*
  parseValue(source)
  ==================
@@ -153,17 +167,7 @@ function parse(mainSource, options) {
         }
     };
 
-    if (options === undefined) {
-        options = {};
-    }
-
-    options = _.defaults(_.clone(options), {
-        filename: 'main',
-        startRule: 'start',
-        autocompleteCallback: null,
-        modules: {},
-        moduleResolver: defaultResolver
-    });
+    options = processOptions(options, defaultResolver);
 
     var isImport = function(e) { return e.type === 'ImportStatement';};
     var asts = {};
@@ -219,17 +223,7 @@ function parseSync(mainSource, options) {
         }
     };
 
-    if (options === undefined) {
-        options = {};
-    }
-
-    options = _.defaults(_.clone(options), {
-        filename: 'main',
-        startRule: 'start',
-        autocompleteCallback: null,
-        modules: {},
-        moduleResolver: defaultResolver
-    });
+    options = processOptions(options, defaultResolver);
 
     var isImport = function(e) { return e.type === 'ImportStatement';};
     var names = {};

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -134,6 +134,12 @@ function processOptions(options, defaultResolver) {
     });
 }
 
+function extractImports(ast) {
+    return _.filter(ast.elements, function(element) {
+        return element.type === 'ImportStatement';
+    });
+}
+
 /*
  parseValue(source)
  ==================
@@ -169,7 +175,6 @@ function parse(mainSource, options) {
 
     options = processOptions(options, defaultResolver);
 
-    var isImport = function(e) { return e.type === 'ImportStatement';};
     var asts = {};
     function parse_(source, name) {
         var ast, imports;
@@ -184,7 +189,7 @@ function parse(mainSource, options) {
         }
 
         asts[name] = ast;
-        imports = _.filter(ast.elements, isImport);
+        imports = extractImports(ast);
         _.each(imports, checkImportNode);
 
         return Promise.map(imports, function(imp) {
@@ -225,7 +230,6 @@ function parseSync(mainSource, options) {
 
     options = processOptions(options, defaultResolver);
 
-    var isImport = function(e) { return e.type === 'ImportStatement';};
     var names = {};
     function rec(o) {
         var ast, imports, modules;
@@ -235,7 +239,7 @@ function parseSync(mainSource, options) {
 
         names[o.name] = true;
         ast = doParse(o.source, _.extend(options, { filename: o.name }));
-        imports = _(ast.elements).filter(isImport);
+        imports = extractImports(ast);
         _.each(imports, checkImportNode);
         modules = imports.map(function(import_) {
             try {

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -230,15 +230,15 @@ function parseSync(mainSource, options) {
 
     options = processOptions(options, defaultResolver);
 
-    var names = {};
+    var asts = {};
     function rec(o) {
         var ast, imports, modules;
-        if (_.has(names, o.name)) {
+        if (_.has(asts, o.name)) {
             return [];
         }
 
-        names[o.name] = true;
         ast = doParse(o.source, _.extend(options, { filename: o.name }));
+        asts[o.name] = ast;
         imports = extractImports(ast);
         _.each(imports, checkImportNode);
         modules = imports.map(function(import_) {
@@ -255,15 +255,13 @@ function parseSync(mainSource, options) {
             }
         });
 
-        return _.reduce(modules,
-                        function (l, mod) { return l.concat(rec(mod));},
-                        [{name: o.name, ast: ast}]);
+        _.each(modules, rec);
     }
 
-    var res = rec({source: mainSource, name: 'main'});
-    var main = res[0].ast;
-    _.chain(res).indexBy('name').omit('main').each(function (unit) {
-        main.modules.push({type: "ModuleDef", name: unit.name, elements: unit.ast.elements});
+    rec({source: mainSource, name: 'main'});
+    var main = asts.main;
+    _.each(_.omit(asts, 'main'), function(ast, name) {
+        main.modules.push({type: "ModuleDef", name: name, elements: ast.elements});
     });
     return main;
 }

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -156,7 +156,7 @@ function parseValue(source) {
  instantiated.
  */
 function parse(mainSource, options) {
-    var defaultResolver = function(path, name) {
+    function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return Promise.resolve({
                 name: path,
@@ -165,7 +165,7 @@ function parse(mainSource, options) {
         } else {
             return Promise.reject(new Error('Could not find module: ' + path));
         }
-    };
+    }
 
     options = processOptions(options, defaultResolver);
 
@@ -212,7 +212,7 @@ function parse(mainSource, options) {
 }
 
 function parseSync(mainSource, options) {
-    var defaultResolver = function(path, name) {
+    function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return {
                 name: path,
@@ -221,7 +221,7 @@ function parseSync(mainSource, options) {
         } else {
             throw new Error("Could not find module: " + path);
         }
-    };
+    }
 
     options = processOptions(options, defaultResolver);
 

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -140,6 +140,12 @@ function extractImports(ast) {
     });
 }
 
+function buildModuleDefs(asts) {
+    return _.map(_.omit(asts, 'main'), function(ast, name) {
+        return { type: "ModuleDef", name: name, elements: ast.elements };
+    });
+}
+
 /*
  parseValue(source)
  ==================
@@ -207,12 +213,8 @@ function parse(mainSource, options) {
     }
     return parse_(mainSource, 'main')
         .then(function() {
-            var main = asts.main;
-            // add all module ASTs into the main AST, each one under a 'ModuleDef' node.
-            _.each(_.omit(asts, 'main'), function(ast, name) {
-                main.modules.push({type: "ModuleDef", name: name, elements: ast.elements});
-            });
-            return main;
+            asts.main.modules = buildModuleDefs(asts);
+            return asts.main;
         });
 }
 
@@ -259,11 +261,8 @@ function parseSync(mainSource, options) {
     }
 
     rec({source: mainSource, name: 'main'});
-    var main = asts.main;
-    _.each(_.omit(asts, 'main'), function(ast, name) {
-        main.modules.push({type: "ModuleDef", name: name, elements: ast.elements});
-    });
-    return main;
+    asts.main.modules = buildModuleDefs(asts);
+    return asts.main;
 }
 
 


### PR DESCRIPTION
A couple of structural changes in the `parser` module which make `parse` and `parseSync` more readable, more DRY, and closer together structurally. Eventually, they should be identical except for the sync/async difference.