### PR TITLE
Add live emitter to handle batch/sort of points

### DIFF
--- a/lib/runtime/live-points-queue.js
+++ b/lib/runtime/live-points-queue.js
@@ -1,0 +1,115 @@
+var _ = require('underscore');
+
+var Base = require('extendable-base');
+var Heap = require('heap');
+var Events = require('backbone').Events;
+
+var JuttleMoment = require('../moment').JuttleMoment;
+var JuttleUtils = require('./juttle-utils');
+
+var timeSort = JuttleUtils.pointSortFunc('time');
+
+// LivePointsQueue stores incoming points over a configurable time window and
+// emits them sorted in predefined intervals. This smooths out out-of-order points
+// from live sources and maintains the 'monotonic-time' invariant of the points.
+//
+// The points are passed into the buffer via push, then periodically emitted
+// via the `points` event. If there are no points in a given time period,
+// `tick` event is emitted.
+// Points arriving late/out of order are dropped - `drop` event is fired for each
+// of those.
+var LivePointsQueue = Base.extend(Events).extend({
+    initialize: function(scheduler, options) {
+        this.scheduler = scheduler;
+
+        this.every = options.every || JuttleMoment.duration('1', 's');
+        this.delay = options.delay || JuttleMoment.duration('5', 's');
+
+        this.next_emit_time = null;
+        this.window_start_time = null;
+
+        this.heap = new Heap(timeSort);
+        this.heap_size_limit = options.heap_size_limit || 100000;
+    },
+
+    start: function() {
+        this.next_emit_time = this._now().quantize(this.every).add(this.delay);
+        this.window_start_time = this._now().quantize(this.every);
+        this.scheduler.schedule(this.next_emit_time.unixms(), this._emit.bind(this));
+    },
+
+    stop: function() {
+        this.next_emit_time = null;
+        this.window_start_time = null;
+    },
+
+    add: function(points) {
+        var self = this;
+
+        _.each(points, function(point) {
+            if (self._isLate(point)) {
+                self.trigger('drop', point);
+            } else {
+                self.heap.push(point);
+            }
+
+            if (self.heap.size() > self.heap_size_limit) {
+                var oldest_point = self.heap.pop();
+                self.trigger('drop', oldest_point);
+            }
+        });
+    },
+
+    // If any point arrives before the window starts, it is dropped - this
+    // maintains the 'points ordered by time' invariant in the flowgraph.
+    // If the queue has not been yet started, drop all points.
+    _isLate: function(point) {
+        if (this._isRunning()) {
+            return point.time.lt(this.window_start_time);
+        } else {
+            return true;
+        }
+    },
+
+    _isRunning: function() {
+        return this.next_emit_time !== null;
+    },
+
+    _emit: function() {
+        if (!this._isRunning()) { return; }
+
+        this.window_start_time = this.window_start_time.add(this.every);
+        this._emitWhile(this._pointsPending.bind(this));
+
+        // Guard against a stop call since the last check at the beginning of _emit
+        if (!this._isRunning()) { return; }
+
+        this.next_emit_time = this.next_emit_time.add(this.every);
+        this.scheduler.schedule(this.next_emit_time.unixms(), this._emit.bind(this));
+    },
+
+    _pointsPending: function() {
+        return this.heap.size() !== 0 && this.heap.peek().time.lte(this.window_start_time);
+    },
+
+    _emitWhile: function(until) {
+        var points = [];
+
+        while (until()) {
+            points.push(this.heap.pop());
+        }
+
+        if (points.length === 0) {
+            this.trigger('tick');
+        } else {
+            this.trigger('points', points);
+        }
+    },
+
+    // This can be overridden by the tests, so that we get a deterministic t0
+    _now: function() {
+        return new JuttleMoment();
+    }
+});
+
+module.exports = LivePointsQueue;

--- a/test/runtime/live-points-queue.spec.js
+++ b/test/runtime/live-points-queue.spec.js
@@ -1,0 +1,148 @@
+var _ = require('underscore');
+var expect = require('chai').expect;
+var LivePointsQueue = require('../../lib/runtime/live-points-queue');
+var Scheduler = require('../../lib/runtime/scheduler').Scheduler;
+var JuttleMoment = require('../../lib/moment').JuttleMoment;
+
+// Durations helper
+var durations  = {};
+_.each([5, 10, 15, 20, 25, 30, 100, 120, 150], function(duration) {
+    durations['_' + duration + 'ms'] = new JuttleMoment.duration(duration, 'ms');
+});
+
+// Override _now to get a deterministic initial time
+var t0 = new JuttleMoment(0);
+var LivePointsQueue = LivePointsQueue.extend({
+    _now: function() {
+        return t0;
+    }
+});
+
+describe('Live points queue', function() {
+    var scheduler = new Scheduler();
+
+    before(function() {
+        scheduler.start();
+    });
+
+    after(function() {
+        scheduler.stop();
+    });
+
+    it('adds points', function(done) {
+        var queue = new LivePointsQueue(scheduler, {
+            every: durations._25ms,
+            delay: durations._100ms,
+        });
+
+        queue.on('points', function(points) {
+            queue.stop();
+            expect(points.length).to.equal(2);
+            done();
+        });
+
+        queue.start();
+        queue.add([{time: t0.add(durations._10ms), key: "value1"}]);
+        queue.add([{time: t0.add(durations._20ms), key: "value2"}]);
+    });
+
+    it('sorts points', function(done) {
+        var queue = new LivePointsQueue(scheduler, {
+            every: durations._25ms,
+            delay: durations._100ms
+        });
+
+        queue.on('points', function(points) {
+            queue.stop();
+            expect(points.length).to.equal(2);
+            expect(points[1].time.gte(points[0].time)).to.equal(true);
+            done();
+        });
+
+        queue.start();
+        queue.add([{time: t0.add(durations._15ms), key: "value2"}]);
+        queue.add([{time: t0.add(durations._5ms), key: "value1"}]);
+    });
+
+    it('emits points continuously', function(done) {
+        var queue = new LivePointsQueue(scheduler, {
+            every: durations._25ms,
+            delay: durations._100ms
+        });
+        var calls = 0;
+
+        queue.on('points', function(points) {
+            if (calls === 0) {
+                expect(points.length).to.equal(2);
+            } else if (calls === 1) {
+                queue.stop();
+                expect(points.length).to.equal(1);
+                done();
+            }
+
+            calls += 1;
+        });
+
+        queue.start();
+        queue.add([{time: t0.add(durations._20ms), key: "value1"}]);
+        queue.add([{time: t0.add(durations._15ms), key: "value2"}]);
+        queue.add([{time: t0.add(durations._120ms), key: "value3"}]);
+    });
+
+    it('correctly mixes ticks and points', function(done) {
+        var queue = new LivePointsQueue(scheduler, {
+            every: durations._25ms,
+            delay: durations._100ms
+        });
+
+        var history = [];
+        var expected = ['tick', 'point', 'tick', 'tick', 'point'];
+
+        queue.on('tick', function() {
+            history.push('tick');
+
+            if (history.length >= expected.length) {
+                queue.stop();
+                expect(history).to.deep.equal(expected);
+                done();
+            }
+        });
+
+        queue.on('points', function() {
+            history.push('point');
+
+            if (history.length >= expected.length) {
+                queue.stop();
+                expect(history).to.deep.equal(expected);
+                done();
+            }
+        });
+
+        queue.start();
+
+        // expected: ['tick', 'point', 'tick', 'tick', 'point'];
+        // points:             30ms                     120ms
+        // scheduler:  25ms         50ms  75ms  100ms         125ms
+        queue.add([{time: t0.add(durations._30ms), key: "value1"}]);
+        queue.add([{time: t0.add(durations._120ms), key: "value2"}]);
+    });
+
+    it('drops the oldest point when over limit', function(done) {
+        var queue = new LivePointsQueue(scheduler, {
+            every: durations._25ms,
+            delay: durations._100ms,
+            heap_size_limit: 2
+        });
+
+        queue.on('drop', function(point) {
+            queue.stop();
+            expect(point.time.unixms()).to.equal(5);
+            done();
+        });
+
+        queue.start();
+        queue.add([{time: t0.add(durations._5ms), key: "value1"}]);
+        queue.add([{time: t0.add(durations._10ms), key: "value2"}]);
+        queue.add([{time: t0.add(durations._15ms), key: "value3"}]);
+    });
+});


### PR DESCRIPTION
A live emitter is responsible for batching points, then emitting them sorted, while allowing for 'late arrivals' within a given time window.

Internally, it is represented by a time-based priority queue with configurable maximum size and time window. Points arriving outside of it are dropped. When queue size limit is reached, emitter drops oldest points first. A periodic process is responsible for emitting points within the time window.

This is a common logic that will be used across adapters, so it makes sense to keep it in a separate class.