### PR TITLE
don't interleave output from multiple client views

### DIFF
--- a/lib/sinks/client-sink-mgr.js
+++ b/lib/sinks/client-sink-mgr.js
@@ -33,7 +33,8 @@ var ClientSinkManager = Base.extend({
     setup: function(program) {
         var self = this;
 
-        self.program.get_client_sinks(program).forEach(function(sink) {
+        var sinks = self.program.get_client_sinks(program);
+        sinks.forEach(function(sink) {
 
             var sink_class;
             if (_.has(self.sink_classes, sink.name)) {
@@ -41,6 +42,17 @@ var ClientSinkManager = Base.extend({
             } else {
                 throw JuttleErrors.syntaxError('RT-INVALID-VIEW', {sink: sink.name,
                                                                    location: sink.location});
+            }
+
+            // Progressive output only makes sense if there is exactly one view
+            // in the program, otherwise the output from the various views gets
+            // interleaved.
+            //
+            // So, unless the user has explicitly set the progressive option,
+            // make it default to true iff there is exactly one view in the
+            // program.
+            if (sink.options.progressive === undefined) {
+                sink.options.progressive = (sinks.length === 1);
             }
 
             self.sinks[sink.channel] = new sink_class(sink.options, self.env);

--- a/lib/sinks/table.js
+++ b/lib/sinks/table.js
@@ -8,7 +8,6 @@ var TableSink = ClientSink.extend({
     initialize: function(options) {
 
         this.options = _.defaults({}, options, {
-            progressive: true,
             columnOrder: ['time', 'name', 'value']
         });
 
@@ -193,7 +192,7 @@ var TableSink = ClientSink.extend({
         var self = this;
         var table;
 
-        if (self.options.progressive === false) {
+        if (! self.options.progressive) {
 
             // Get all the keys from all the points and sort them to
             // get the column names.

--- a/lib/sinks/text.js
+++ b/lib/sinks/text.js
@@ -28,6 +28,15 @@ var TextSink = ClientSink.extend({
         this.initial_keys = [];
         this.latest_keys = [];
         this.items_written = 0;
+        this.buffer = '';
+    },
+
+    write: function(data) {
+        if (this.options.progressive) {
+            this.fstream.write(data);
+        } else {
+            this.buffer += data;
+        }
     },
 
     write_item: function(item, skip_newline) {
@@ -40,20 +49,18 @@ var TextSink = ClientSink.extend({
 
         self.items_written++;
 
-        self.fstream.write(item);
+        this.write(item);
 
         if (!skip_newline) {
-            self.fstream.write("\n");
+            this.write("\n");
         }
     },
 
     always_write_item: function(item, skip_newline) {
-        var self = this;
-
-        self.fstream.write(item);
+        this.write(item);
 
         if (!skip_newline) {
-            self.fstream.write("\n");
+            this.write("\n");
         }
     },
 
@@ -172,9 +179,10 @@ var TextSink = ClientSink.extend({
             self.always_write_item("\n]");
         }
 
-        // Do an empty write here and wait for it (and any prior
+        // Flush the buffer and wait for it (and any prior
         // writes) to flush before emitting the end event.
-        self.fstream.write('', function() {
+        // In progressive mode, the buffer is empty.
+        self.fstream.write(self.buffer, function() {
             self.events.trigger('end');
         });
     }

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -233,6 +233,52 @@ describe('Juttle CLI Tests', function() {
                 });
         });
 
+        it('does not interleave output from multiple table views', function() {
+            return runJuttle(['-e', 'emit -from :2015-01-01: -limit 2 | (put sink = 1 | view table; put sink = 2 | view table)'])
+                .then(function(result) {
+                    expect(result.stdout).equals(
+'┌──────────────────────────┬──────┐\n' +
+'│ time                     │ sink │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:00.000Z │ 1    │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:01.000Z │ 1    │\n' +
+'└──────────────────────────┴──────┘\n' +
+'┌──────────────────────────┬──────┐\n' +
+'│ time                     │ sink │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:00.000Z │ 2    │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:01.000Z │ 2    │\n' +
+'└──────────────────────────┴──────┘\n');
+                    expect(result.code).to.equal(0);
+                    expect(result.stderr).to.equal('');
+                });
+        });
+
+        it('interleaves output from multiple table views in progressive mode', function() {
+            return runJuttle(['-e', 'emit -from :2015-01-01: -limit 2 | (put sink = 1 | view table -progressive true; put sink = 2 | view table -progressive true)'])
+                .then(function(result) {
+                    expect(result.stdout).equals(
+'┌────────────────────────────────────┬──────────┐\n' +
+'│ time                               │ sink     │\n' +
+'├────────────────────────────────────┼──────────┤\n' +
+'│ 2015-01-01T00:00:00.000Z           │ 1        │\n' +
+'┌────────────────────────────────────┬──────────┐\n' +
+'│ time                               │ sink     │\n' +
+'├────────────────────────────────────┼──────────┤\n' +
+'│ 2015-01-01T00:00:00.000Z           │ 2        │\n' +
+'├────────────────────────────────────┼──────────┤\n' +
+'│ 2015-01-01T00:00:01.000Z           │ 1        │\n' +
+'├────────────────────────────────────┼──────────┤\n' +
+'│ 2015-01-01T00:00:01.000Z           │ 2        │\n' +
+'└────────────────────────────────────┴──────────┘\n' +
+'└────────────────────────────────────┴──────────┘\n');
+                    expect(result.code).to.equal(0);
+                    expect(result.stderr).to.equal('');
+                });
+        });
+
         it('can execute juttle with text inputs', function() {
             return runJuttle([
                 '--input',


### PR DESCRIPTION
Currently the following juttle program:

```
emit -from :2015-01-01: -limit 2
| (put sink=1 | view table;
   put sink=2 | view table)
```

Would result in the following output:

```
┌────────────────────────────────────┬──────────┐
│ time                               │ sink     │
├────────────────────────────────────┼──────────┤
│ 2015-01-01T00:00:00.000Z           │ 1        │
┌────────────────────────────────────┬──────────┐
│ time                               │ sink     │
├────────────────────────────────────┼──────────┤
│ 2015-01-01T00:00:00.000Z           │ 2        │
├────────────────────────────────────┼──────────┤
│ 2015-01-01T00:00:01.000Z           │ 1        │
├────────────────────────────────────┼──────────┤
│ 2015-01-01T00:00:01.000Z           │ 2        │
└────────────────────────────────────┴──────────┘
└────────────────────────────────────┴──────────┘
```

This is because progressive mode defaults to true, so the two views interleave their output.

Change the initialization API so that the client-sink-mgr sets the default progressive mode option to true only if there is exactly one view in the program.

Also add a progressive option to the text view to address the same problem.
