### PR TITLE
adapters: downgrade initialization logging and add timing info

### DIFF
--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -27,15 +27,25 @@ function get(type) {
 
 // Load and initialize the adapter modules specified in the given config.
 function load(config) {
+    logger.debug('loading adapters');
     _.each(config, function(options, module) {
         try {
             var module_path = options.path || module;
             if (module_path[0] === '.') {
                 module_path = path.resolve(process.cwd(), module_path);
             }
+
+            var start = new Date();
             var init = require(module_path);
+
+            var loaded = new Date();
             var adapter = init(options);
-            logger.info('loaded', adapter.name);
+
+            var initialized = new Date();
+
+            logger.debug(adapter.name, 'adapter loaded in', (loaded - start), 'ms,',
+                         'initialized in', (initialized - loaded), 'ms');
+
             register(adapter.name, adapter);
         } catch (err) {
             logger.error('error loading adapter ' + module + ': ' + err.message);


### PR DESCRIPTION
Downgrade the adapter init logging message from info to debug and
include some timing info to see how long it takes for the adapter to
load and to be initialized.