### PR TITLE
Adding back example of import via URL

### DIFF
--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -204,13 +204,29 @@ _Example: import by filename_
 This example assumes that the program with exports is saved at path
 `docs/examples/concepts/export_module.juttle`.
 
-```
+```juttle-no-syntax-check
 // This program is runnable from CLI from the juttle repo root,
-// node ./bin/juttle docs/examples/concepts/import_module.juttle
+// juttle docs/examples/concepts/import_module.juttle
 
 import 'docs/examples/concepts/export_module.juttle' as my_module;
 emit
 | my_module.stamper -mark 'test'
+```
+
+_Example: import by URL_
+
+This example assumes that the exported module is saved as a
+[github gist](https://gist.githubusercontent.com/jut-test/273396ac4efcc838687b/)
+containing `main.juttle` file.
+
+```juttle-no-syntax-check
+// This program is runnable from CLI from the juttle repo root,
+// juttle docs/examples/concepts/import_module_from_url.juttle
+
+import 'https://gist.githubusercontent.com/jut-test/273396ac4efcc838687b/raw/dde7c96c7560c38a29881d0345fc2d5727ee082e/main.juttle'
+  as this_module;
+emit
+| this_module.stamper -mark "test"
 ```
 
 Subgraphs

--- a/docs/examples/concepts/import_module_from_url.juttle
+++ b/docs/examples/concepts/import_module_from_url.juttle
@@ -1,0 +1,4 @@
+import 'https://gist.githubusercontent.com/jut-test/273396ac4efcc838687b/raw/dde7c96c7560c38a29881d0345fc2d5727ee082e/main.juttle'
+  as this_module;
+emit
+| this_module.stamper -mark "test"


### PR DESCRIPTION
There was a misconception that URL import wasn't implemented on the CLI and so the example was removed; the actual problem was with obsolete syntax of the gist that exports the module. I fixed the gist in jut-test account, now import works fine. 

I had to leave the import examples (both inlined in the docs, and the examples file) not covered by the syntax check, as our `gulp examples-check` task is unable to parse the module dependency:

```
Error: checking /Users/dmehra/git/juttle/docs/examples/concepts/import_module_from_url.juttle: CompileError: Error: could not find module "https://gist.githubusercontent.com/jut-test/273396ac4efcc838687b/raw/dde7c96c7560c38a29881d0345fc2d5727ee082e/main.juttle"
    at /Users/dmehra/git/juttle/gulpfile.js:226:26
    at tryCatcher (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/dmehra/git/juttle/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

But running the example works properly:

```
$ juttle docs/examples/concepts/import_module_from_url.juttle 
┌────────────────────────────────────┬──────────┬──────────┐
│ time                               │ stamp    │ stamp2   │
├────────────────────────────────────┼──────────┼──────────┤
│ 2015-12-23T17:14:48.205Z           │ test     │ test     │
└────────────────────────────────────┴──────────┴──────────┘
```