### PR TITLE
Bringing usage examples into juttle docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,16 @@
 
 Welcome to the documentation for [Juttle](https://github.com/juttle/juttle/), a dataflow programming language!
 
+## Project Info
+
+See the [GitHub project README](http://github.com/juttle/juttle) for installation and setup instructions, and if you wish to contribute.
+
+If you discover a bug in Juttle or these docs, please [open a GitHub issue](https://github.com/juttle/juttle/issues/new) or talk to us on [Gitter](https://gitter.im/juttle/juttle).
+
+Our public [Waffle board](https://waffle.io/juttle/juttle) tracks GitHub issues and PRs in a single place.
+
+This documentation was produced with [mkdocs](http://mkdocs.org), see details in [README](README.md).
+
 ## About Juttle
 
 Juttle is an analytics system and language for developers built upon
@@ -66,6 +76,7 @@ Here are some ideas of what you can do with Juttle:
   your data before implementing them in detail and in production using other
   stream-processing systems like Spark or Storm.
 
+Refer to the [Usage Examples](use_cases.md) section for more specific examples with Juttle programs and demos.
 
 ## Stream-processing Systems
 
@@ -87,20 +98,3 @@ the Juttle compiler and runtime to generate scala in addition to
 javascript as a target output langauge and leverage the Spark infrastructure
 for Juttle programs.
 
-## How To Navigate
-
-Use the left sidebar menu for navigating the sections. Getting started with the [Juttle Overview](concepts/overview.md) should orient you reasonably well; the rest of the Concepts section has background information on the language design.
-
-The search feature (powered by lunr.js in mkdocs) can be helpful too, see the search box in upper left corner.
-
-Juttle examples are provided as code snippets; copy them to run in your own environment.
-
-:construction: Embedded Juttle examples are coming soon.
-
-## Maintaining Docs
-
-:baby_symbol: These docs are just coming together.
-
-If you find a problem in the documentation, members of juttle GitHub project can edit the articles inline by following "Edit on GitHub" link. Small obvious fixes may be committed directly to master. If discussion is needed, please put up a PR on a branch.
-
-:information_source: This documentation was produced with [mkdocs](http://mkdocs.org), see details in [README](README.md).

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,0 +1,100 @@
+# Using Juttle
+
+This section provides examples of what you can do with Juttle. 
+
+Most of these use case examples utilize Juttle in conjunction with external systems
+using [adapters](adapters/index.md), and/or depend on visualizations from an environment
+like [outrigger](https://github.com/juttle/outrigger). Eventually each will link to a runnable demo (docker container based); meanwhile, these examples are meant to be illustrative.
+
+[TOC]
+
+## Hello world
+
+Hello world in Juttle:
+
+```juttle
+emit -every :1 second: -limit 10 | put message='hello world' | view table
+```
+
+## Error events on a timeseries graph
+
+This example prompts a user to input a time range to query, pulls a timeseries
+metric of counts of user signups from graphite, searches for 100 logs from
+Elasticsearch in which the app field is 'login' and the string 'error' occurs,
+and then plots the metric along with overlaid events on the same timechart along
+with a table showing the errors themselves.
+
+To run this program, you need [outrigger](https://github.com/juttle/outrigger), [elastic-adapter](https://github.com/juttle/juttle-elastic-adapter/), [graphite-adapter](https://github.com/juttle/juttle-graphite-adapter/).
+
+```outrigger
+input time_period: duration -label 'Time period to query' -default :5 minutes:;
+
+read graphite -last time_period name~'app.login.*.signup.count'
+| view timechart -title 'User Signups' -id 'signup_chart';
+
+read elastic -last time_period app='login' 'errors'
+| head 100
+| (
+    view table -title 'Errors';
+    view events -on 'signup_chart'
+  )
+```
+
+## Real-time slack alerting from twitter events
+
+This example taps into the stream of real-time twitter events searching for 'apple' and printing them to a table. If more than 10 posts occur in a five second window, it posts a message to a slack webhook.
+
+```juttle
+read twitter -stream true 'apple'
+| (
+    view table -title 'Tweets about apple';
+
+    reduce -every :5 seconds: value=count()
+    | filter value > 10
+    | put message='apple is trending'
+    | write http -maxLength 1 -url 'https://hooks.slack.com/services/ABCDEF12345/BB8739872984/BADF00DFEEDDAB'
+  )
+```
+
+## Sine wave chart
+
+This example uses Juttle math primitives to draw a sine wave on a timechart, with configurable period and amplitude, provided by the user via input controls.
+
+To run this program, you need [outrigger](https://github.com/juttle/outrigger).
+
+```outrigger
+input period: number -default 50 -label 'Sine Wave period';
+input amplitude: number -default 10 -label 'Sine Wave amplitude';
+
+emit -from :-5m: -limit 10000
+| put value =  amplitude * Math.sin(Math.PI * count() / period)
+| @timechart -title "Sine Wave";
+
+emit -from :-5m: -limit 10000
+| put value=count()
+| put value = value * value
+| @timechart -title "Geometric Growth";
+```
+
+## Coming Soon
+
+More examples with pointers to docker containers with demo data, to allow easy execution. 
+
+### Kitchen duty alerting to slack
+
+### Stock quote data from Yahoo! Finance
+
+### Twitter popularity race
+
+### Accessing memes data in ElasticSearch
+
+### Disk bandwidth data from a SQL database
+
+### Monitoring Docker containers via cAdvisor and InfluxDB
+
+### Plotting GitHub activity
+
+### Apache access logs in ElasticSearch
+
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ pages:
 
 - Introduction:
    - 'About': 'index.md'
+   - 'Usage Examples': 'use_cases.md'
    - '____ Docs README': 'README.md'
    - '____ Doc Template': 'doc_templates/template.md'
    - '____ Juttle Doc Template': 'doc_templates/juttle_TEMPLATE.md'


### PR DESCRIPTION
Another attempt to resolve #27. This creates a new docs section "Usage Examples" which currently has a copy of 3 examples from the project readme, plus the sine wave one from the still-private demo. The "Coming soon" list is where this is headed. 

The problem I'm struggling with is where to put the actual juttle code (and dockerfiles, once we're setting these up as self contained demos). The juttle repo doesn't seem like the right place, since we won't be able to syntax check the examples code. Should they live in outrigger? If we do that, inlining the juttle code in the docs will no longer be possible, unless we set up separate docs for outrigger (at the moment it only has a README). Maybe that's the way to go. Then juttle's "Usage Examples" will only include short description for each one, and link out to the right page of outrigger demo docs.

@rlgomes @demmer @dmajda @bkutil thoughts? 