### PR TITLE
increase the test timeout and also tweak the slow value

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,7 +122,8 @@ function gulp_test() {
     return gulp.src('test/**/*.spec.js')
         .pipe(mocha({
             log: true,
-            timeout: 5000,
+            timeout: 10000,
+            slow: 3000,
             reporter: 'spec',
             ui: 'bdd',
             ignoreLeaks: true,


### PR DESCRIPTION
with these settings we'll have better settings for running tests in
general in travis

fixes #18 by simply tweaking the timeouts to better match the expectations of running tests in travis