### PR TITLE
add -from/-to to `read file`

### DIFF
--- a/lib/adapters/file-adapter.js
+++ b/lib/adapters/file-adapter.js
@@ -11,15 +11,17 @@
 
 var _ = require('underscore');
 var Juttle = require('../runtime/index').Juttle;
+var JuttleMoment = require('../moment').JuttleMoment;
 var parsers = require('./parsers');
 var fs = require('fs');
+var values = require('../runtime/values');
 
 var Read = Juttle.proc.source.extend({
     sourceType: 'batch',
     procName: 'read-file',
 
     initialize: function(options, params, pname, location, program, juttle) {
-        var allowed_options = ['file', 'timeField', 'format'];
+        var allowed_options = ['from', 'to', 'file', 'timeField', 'format'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -40,6 +42,20 @@ var Read = Juttle.proc.source.extend({
         this.format = options.format ? options.format : 'json'; // default to json
         this.parser = parsers.getParser(this.format);
 
+        this.from = options.from || new JuttleMoment(0);
+        if (!this.from.moment) {
+            throw this.compile_error('RT-FROM-TO-MOMENT-ERROR', {
+                value: values.inspect(this.from)
+            });
+        }
+
+        this.to = options.to || this.program.now;
+        if (!this.to.moment) {
+            throw this.compile_error('RT-FROM-TO-MOMENT-ERROR', {
+                value: values.inspect(this.to)
+            });
+        }
+
         if (params.filter_ast) {
             throw this.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER', {
                 proc: 'read file',
@@ -58,8 +74,20 @@ var Read = Juttle.proc.source.extend({
         var stream = this.fetch();
 
         self.parser.parseStream(stream, function(points) {
+            var validPoints = [];
             self.parseTime(points, self.timeField);
-            self.emit(points);
+            _.each(points, function(point) {
+                // timeless points just pass through at this point
+                if (point.time && point.time.moment) {
+                    if (point.time.gte(self.from) && point.time.lt(self.to)) {
+                        validPoints.push(point);
+                    }
+                } else {
+                    // timeless points are passed along
+                    validPoints.push(point);
+                }
+            });
+            self.emit(validPoints);
         })
         .catch(function(err) {
             self.trigger('error', self.runtime_error('RT-INTERNAL-ERROR', {

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -95,6 +95,51 @@ describe('file adapter tests', function () {
                 expect(err.message).equal('Error: filtering is not supported by read file.');
             });
         });
+
+        it('filters points correctly with -from', function() {
+            return check_juttle({
+                program: 'read file -file "' + file + '.json" -from :1970-01-01T00:00:03.000Z: | keep time, rate'
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                expect(result.warnings.length).equal(0);
+                expect(result.sinks.table).to.deep.equal([
+                    { "time": "1970-01-01T00:00:03.000Z", "rate": 2},
+                    { "time": "1970-01-01T00:00:04.000Z", "rate": 7},
+                    { "time": "1970-01-01T00:00:05.000Z", "rate": 1},
+                    { "time": "1970-01-01T00:00:06.000Z", "rate": 3}
+                ]);
+            });
+        });
+
+        it('filters points correctly with -to', function() {
+            return check_juttle({
+                program: 'read file -file "' + file + '.json" -to :1970-01-01T00:00:03.000Z: | keep time, rate'
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                expect(result.warnings.length).equal(0);
+                expect(result.sinks.table).to.deep.equal([
+                    { "time": "1970-01-01T00:00:01.000Z", "rate": 1},
+                    { "time": "1970-01-01T00:00:02.000Z", "rate": 5},
+                ]);
+            });
+        });
+
+        it('filters points correctly with -from and -to', function() {
+            return check_juttle({
+                program: 'read file -file "' + file + '.json" -from :1970-01-01T00:00:03.000Z: -to :1970-01-01T00:00:05.000Z: | keep time, rate'
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                expect(result.warnings.length).equal(0);
+                expect(result.sinks.table).to.deep.equal([
+                    { "time": "1970-01-01T00:00:03.000Z", "rate": 2},
+                    { "time": "1970-01-01T00:00:04.000Z", "rate": 7},
+                ]);
+            });
+        });
+
     });
 
     describe('write file', function() {


### PR DESCRIPTION
fixes #65

this includes the ability to specify the -from/-to options to `read
file` as well as the ability to detect out of order points and drop
them with a warning.