### PR TITLE
Documentation fixes

### DIFF
--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -73,6 +73,23 @@ emit -limit 10
       points_3=pow(points, 3)
 ```
 
+Reducers
+========
+
+Reducers are a Juttle-specific construct that allows operating on values of a chosen field, as points stream through the flowgraph, to carry out a running computation.
+
+Reducers are used in [reduce](../processors/reduce.md) and [put](../processors/put.md) assignment expressions.
+
+Juttle comes with a number of [built-in reducers](../reducers/index.md), including [count()](../reducers/count.md), [sum()](../reducers/sum.md) and [max()](../reducers/max.md) used in this example:
+
+```juttle
+emit -from :0: -limit 10
+| put value = count()
+| reduce sum = sum(value), largest = max(value)
+```
+
+Users can define their own reducers using the `reducer` keyword. To understand how reducers function, see [User-defined reducers](../reducers/juttle_reducers_user-defined.md) section that gives an annotated example.
+
 Variables
 =========
 
@@ -259,7 +276,7 @@ emit -limit 2
 | my_viz; // invoke the subgraph here
 ```
 
-<img src="/images/diagrams/juttleOverviewDiagrams/overview5.png" alt="overview5" style="width: 400px;"/>
+<img src="../../images/diagrams/juttleOverviewDiagrams/overview5.png" alt="overview5" style="width: 400px;"/>
 
 With this approach, experienced coders can express complex business
 logic and rich visualizations, then make them available to other Juttle

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -76,7 +76,7 @@ emit -limit 10
 Reducers
 ========
 
-Reducers are a Juttle-specific construct that allows operating on values of a chosen field, as points stream through the flowgraph, to carry out a running computation.
+Reducers are a Juttle-specific construct that allows operating on field values of data points as they stream through the flowgraph, to carry out a running computation.
 
 Reducers are used in [reduce](../processors/reduce.md) and [put](../processors/put.md) assignment expressions.
 

--- a/docs/processors/join.md
+++ b/docs/processors/join.md
@@ -9,7 +9,7 @@ Create new points from the points of multiple input streams.
 
 ``` 
 join
-   [-nearest :duration: | -zip (true | :duration:) | -once true]
+   [-nearest :duration: | -zip <true|:duration:> | -once true]
    [-table inputNumber, inputNumber, ...]
    [-outer inputNumber]
    [fieldName1, fieldName2,...fieldNameN]
@@ -19,18 +19,62 @@ It should be placed after a merge point in a parallel Juttle expression,
 like this:
 
 ```
-(... ; ...) | join ...
+(
+  stream-1;
+  stream-2;
+)
+| join [options]
+| ... // process joined stream
+```
+
+For example:
+
+```
+read source1
+             \
+               join | reduce ...
+             /
+read source2
 ```
 
 In its simplest form, join aligns its input streams by time stamp and
 produces new output points by unioning the fields of successive matching
 input points.
 
+To join only points with matching field values, use `join fieldNameN` where fieldNameN serves as a foreign key in SQL join terms.
+
+By default, an inner join is performed; use `-outer` option to do an outer join instead. Left or right outer join is achieved by specifying the input number of the "base" stream.
+
+The `-nearest` option causes a streaming many-to-one join, while `-zip` option causes a streaming one-to-one join.
+
+The time intervals between points are ignored by default when joining streams; set `:duration:` parameter in `-nearest` or `-zip` to join only points that are close in time.
+
+For a non-streaming join that runs over the entire set of inputs, use `-once` option.
+
+For a join that treats one or more inputs as a lookup table with timeless points, akin to a SQL relational join, use `-table` option.
+
+Join can be used on a single stream, see [Notes](#Notes).
+
+Parameter  |  Description  |  Required?
+---------- | ------------- | ---------:
+`-nearest :duration:`  |   Streaming many-to-one join of each input point or batch with the points or batches on the other inputs having the nearest time stamp. <br><br>If one stream has fewer points than the others, its points may be joined multiple times as needed so that all points or batches on the other inputs participate in a join. The duration is the maximum acceptable difference in time stamps between matched groups of points, and will cause points to be dropped rather than joined if the gap in time is too large. |  No; defaults to unbounded duration; mutually exclusive with -zip and -once.
+`-zip <true | :duration:>`  |   Streaming one-to-one join of each input point or batch with the points or batched on the other inputs having the nearest time stamp. <br><br>If one stream has more points than the others, extra points are dropped, such that any point is joined at most once. <br><br>If specified, the `duration` is the maximum acceptable difference in time stamps between matched groups of points. If instead `-zip true` is specified, there is no limit to the difference in time stamps.  |  No; mutually exclusive with -nearest and -once.
+`-once true`  |  Non-streaming join over the entire set of input points, after all points have been received. <br><br>The time field may be specified as a join field if desired, giving results similar to a streaming one-to-one join with exactly matching time stamps. There is no analogue to the duration parameter of -zip and -nearest for non-streaming joins. |  No; mutually exclusive with -nearest and -zip.
+`-table inputNumber1 [, 2, ...]`   |  Treat the specified input streams as timeless, i.e. as passive tables with no associated time stamp; input streams are numbered top to bottom (or left to right) from 1 in the program.  |  No
+`-outer inputNumber`  |  Perform an outer join preserving the specified input stream. Input streams are numbered top to bottom (or left to right) from 1 in the program (that is, `-outer 1` specifies an outer left join where the first series in the flowgraph is preserved). When a point on the outer input does not have a matching join key on the other inputs, `-outer` forwards it unchanged, or partially joined against any matching inputs. Without `-outer`, an inner join is performed, which only produces points when all inputs match. |  No; defaults to inner join.
+`fieldnameN`  |   The fields to match when joining points.  |  No; by default, points will be unioned without matching on fields.
+
+##### Notes
+
+###### Single Stream Join
+
 If used on a single stream, its points are grouped by their time stamp
 or batch, and all points in a group are unioned to create an output
 point. If optional joinFields are specified for the single stream, they
 act like group-by fields, and there is an output point for each distinct
 value of the joinFields among the points.
+
+###### Multiple Stream Join
 
 Options to `join` can cause it to
 operate like an SQL relational join across multiple input streams, where
@@ -41,12 +85,16 @@ batches. When points with matching key values appear on each input, new
 points are produced containing the union of these matching points'
 fields.
 
+###### Batched vs Unbatched Join
+
 Streaming joins are computed continually as points or batches of points
 arrive at the inputs. When a stream is batched, all points in a batch
 are treated as a group for joining (as if they all had the batch's
 ending time stamp). For an unbatched stream, all points having the same
 time stamp are treated as a batch. It is okay to join a batched stream
 with an unbatched stream.
+
+###### Time Matching in Many-to-One and One-to-One Join
 
 To require exact time stamp matching for batches to be joined, specify
 time as a join key along with any other join keys. If time is not listed
@@ -59,6 +107,7 @@ successive input batch with one on its other inputs, matching by nearest
 time stamp, and drops any extra input batches that do not have matches.
 A many-to-one join performs a similar matching, but will re-use an input
 batch if it remains the best match. 
+
 Both `-zip` and `-nearest` accept a duration limiting the
 difference in time stamps allowed between matched batches, with :0:
 behaving as if time had been specified as a join key. When time stamps
@@ -66,18 +115,24 @@ do not match exactly, an output point will be given the maximum time
 stamp of its input points. A join without `-zip` or `-nearest` or time as a join key is
 implicitly a `-nearest` join with no limiting duration.
 
+###### Join with Table Input
+
 A streaming join can treat some of its input batches as passive tables
 with no associated time stamp. For example, this is useful for joining a
 stream of event points having user IDs against a table of user names,
 annotating the event point with its particular user name. 
 The `-table` option lists which inputs are to be
-treated in this way. A batch on a table input remains there until
+treated in this way. The "table" input can be timeless (i.e. its data points do not contain a `time` field at all), or if it has timestamps, they will be ignored when joining.
+
+A batch on a table input remains there until
 updated by a later batch, and joins are always performed against the
 most recently received complete batch. Joins are only triggered by the
 arrival of new points on a timeful input. Because tables are timeless, a
 join is never triggered by an update to a table, and no guarantees can
 be made about precisely when (in stream time) an update will displace a
 current table batch.
+
+###### Non-streaming Join
 
 A non-streaming join over all points at once (at the end of the run) can
 be specified by the `-once` flag. 
@@ -87,14 +142,9 @@ Time stamps will be ignored unless the time field is specified as a join
 field, which forces time stamps to be matched exactly between the input
 sets.
 
-Parameter  |  Description  |  Required?
----------- | ------------- | ---------:
-`-nearest :duration:`  |   Streaming many-to-one join of each input point or batch with the points or batches on the other inputs having the nearest time stamp. <p>If one stream has fewer points than the others, its points may be joined multiple times as needed so that all points or batches on the other inputs participate in a join. The duration is the maximum acceptable difference in time stamps between matched groups of points, and will cause points to be dropped rather than joined if the gap in time is too large.</p><p>:information_source: `Note:` -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.</p> |  No
-`-zip true` \| `:duration:`  |   Streaming one-to-one join of each input point or batch with the points or batched on the other inputs having the nearest time stamp. <p>If one stream has more points than the others, extra points are dropped, such that any point is joined at most once. </p><p>If specified, the `duration` is the maximum acceptable difference in time stamps between matched groups of points. If instead `-zip true` is specified, there is no limit to the difference in time stamps. </p><p>:information_source: `Note:` -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.  |  No
-`-once true`  |  Non-streaming join over the entire set of input points, after all points have been received. <p>The time field may be specified as a join field if desired, giving results similar to a streaming one-to-one join with exactly matching time stamps. There is no analogue to the duration parameter of -zip and -nearest for non-streaming joins. </p><p>:information_source: `Note:`-nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.</p>  |  No
-`-table`   |  Treat the specified input streams as passive tables with no associated time stamp; input streams are numbered top to bottom (or left to right) from 1 in the program. <p>:baby_symbol: `experimental:`  We're still working on this feature. Try it and see what you think, then [chat with us](http://www.jut.io) to provide feedback. </p> |  No
-`-outer inputNumber`  |  Perform an outer join preserving the specified input stream. Input streams are numbered top to bottom (or left to right) from 1 in the program (that is, `-outer 1` specifies an outer left join where the first series in the flowgraph is preserved). When a point on the outer input does not have a matching join key on the other inputs, `-outer` forwards it unchanged, or partially joined against any matching inputs. Without `-outer`, an inner join is performed, which only produces a points when all inputs match.  |  No
-`fieldnameN`  |   The fields to match when joining points.  |  No
+Note: -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.
+
+##### Join Examples
 
 _Example: merging metric points_
 

--- a/docs/processors/reduce.md
+++ b/docs/processors/reduce.md
@@ -20,15 +20,17 @@ reduce [-every duration [-on duration-or-calendar-offset]]
 Parameter  |  Description  |  Required?
 ---------- | ------------- | ---------:
 `-every`   | The interval at which values will be computed, as a duration literal. A new result is produced each time this duration passes.  |  No; if not specified, the upstream batch interval is used. If there is no upstream batch, a single result is produced after the stream has ended.
-`over`     | The moving time window over which the value will be computed, as a [duration literal](../modules/juttle_time_moment_literals). This is typically some multiple of the `-every` interval (for example, `reduce -every :minute: -over :hour: value=avg(value)` updates a trailing hourly average every minute). <p>When `-over` is specified, results will only be produced for full windows of data. No results will be produced until `-over` has passed after the first point. No result will be produced for any final points that span interval less than `-over`. </p><p>If `-over` is :forever:, the reducer emits results cumulatively, over all points seen so far. </p><p>See [Moving time windows](../reducers/juttle_reducers_timewindows.md) for more information about moving time windows.  | No
-`-reset`  |  Set this to 'false' to emit results cumulatively, over all points seen so far.  |  No
-`-forget`  |  When grouping reducer results with 'by', set this to 'false' to cause results to be emitted for every value of 'by' that has been seen in previous batches. Values that do not appear in the current batch will report their 'empty' value (for example, count() will produce 0, avg() will produce null)  |  No
+`-over`     | The moving time window over which the value will be computed, as a [duration literal](../modules/juttle_time_moment_literals). This is typically some multiple of the `-every` interval (for example, `reduce -every :minute: -over :hour: value=avg(value)` updates a trailing hourly average every minute). <br><br>When `-over` is specified, results will only be produced for full windows of data. No results will be produced until `-over` has passed after the first point. No result will be produced for any final points that span interval less than `-over`. <br><br>If `-over` is :forever:, the reducer emits results cumulatively, over all points seen so far. <br><br>See [Moving time windows](../reducers/juttle_reducers_timewindows.md) for more information about moving time windows.  | No; defaults to not using a moving window.
+`-reset`  |  Set this to 'false' to emit results cumulatively, over all points seen so far.  |  No; defaults to resetting every interval.
+`-forget`  |  When grouping reducer results with 'by', set this to 'false' to cause results to be emitted for every value of 'by' that has been seen in previous batches. Values that do not appear in the current batch will report their 'empty' value (for example, count() will produce 0, avg() will produce null)  |  No; defaults to forgetting.
 `-from`    | When used with `-over`, the start time of the earliest full window of data.  |  No; if not specified, the earliest window begins with the earliest point or batch received.
 `-to`      | When used with `-over`, the end time of the last full window of data.  |  No; if not specified, the last point or batch time stamp received is assumed.
 `-on`      | A time alignment for `-every`. It may be a duration or a calendar offset less than `-every`. For example, `-every :hour: -on :00:30:00:` runs every hour on the half-hour, while `-every :month: -on :day 10:` runs a monthly computation on day 10 of the month.  |  No; if `-on` is not specified, output batches are aligned with the UNIX epoch, as if from a batch node.
-`fieldname=expr`  |  An assignment expression, where expr can be a [reducer](../reducers/index.md). Each assignment expression results in an output field that has the left-hand side of the expression as its name and the computed right-hand side as its value.   |  At least one
-`by`  |  One or more fields for which the assignment expression is computed separately. <p>If grouping fields are present, then the assignment expression is computed independently for each unique combination of values present in the grouping fields. See [Processors](../processors/index.md) for more about grouping with by.  </p>  |  No; if no grouping fields are present, then the assignment expression is computed over all points in the batch.
-    
+`fieldname=expr`  |  An assignment expression, where `expr` can be a [reducer](../reducers/index.md) or a constant value. See [Note 2](#note-2). |  At least one
+`by`  |  One or more fields for which the assignment expression is computed separately. <br><br>If grouping fields are present, then the assignment expression is computed independently for each unique combination of values present in the grouping fields. See [Processors](../processors/index.md) for more about grouping with by.  <br><br> |  No; if no grouping fields are present, then the assignment expression is computed over all points in the batch.
+
+###### Note 1
+
 The output points contain:
 
 -   All the fields specified as assignment expressions or grouping fields in the arguments
@@ -41,6 +43,44 @@ batch. When the points flowing into reduce are not batched, output
 points are generated for all points when the stream ends.
 
 See [Field referencing](../concepts/fields.md#referencing) for additional information relevant to this processor.
+
+###### Note 2
+
+In the assignment expression `fieldname=expr`, if `expr` is a reducer, the resulting point will have the return value of reducer's result() function as the value of field `fieldname`.
+
+If `expr` is a constant value (Juttle constant, string literal, number), the resulting point will have field 'fieldname' with that value. This is commonly used to place "naming" fields into the data point, such as:
+
+```
+... | reduce name = 'pct90', value = percentile (value, 0.9)
+```
+
+Assignments that try to dereference fields from the incoming data point are invalid; the field values of the point being processed by `reduce` are only accessible in the context of a reducer.
+
+For example, this is not valid Juttle, it would emit error "a is not defined" because it would try looking for a constant named 'a':
+
+```text
+// INVALID JUTTLE
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce c = a + b
+```
+
+This is also not valid Juttle, it would error out when trying to add up two null values, because dereferencing of fields 'a' and 'b' would attempt to access such fields in the data point being _created_ by the `reduce`, not the data point being _processed_ by it, since the fields of incoming point are not in scope.
+
+```text
+// INVALID JUTTLE
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce c = *'a' + *'b'
+```
+
+The legitimate way to achieve the desired result (compute a cumulative sum of field values for 'a' and 'b' over all points) would be to use `reduce` to get sums of 'a' and 'b' separately, with the built-in reducer [sum()](../reducers/sum.md), and then add resulting field values in a `put` expression:
+
+```juttle
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce sum_a = sum(a), sum_b = sum(b)
+| put c = sum_a + sum_b
+```
+
+More examples of using `reduce`:
 
 _Example: Trailing ten-minute average_
 


### PR DESCRIPTION
fixes #79 
- [x] fixed "Programming Constructs" image link to "Overview5"
- [x] added "Reducers" section in "Programming Constructs"
- [x] clarified "field=expr" in `reduce` article
- [x] fixed formatting of `join` parameter table, and while I was in there, simplified explanation of what different options do (new sentences above param table). The doc update partially addresses https://github.com/juttle/juttle/issues/76