### PR TITLE
stochastic adapter: fix infinite loop when run with -from :beginning:

### DIFF
--- a/lib/adapters/stochastic-adapter.js
+++ b/lib/adapters/stochastic-adapter.js
@@ -45,6 +45,9 @@ var Read = Juttle.proc.source.extend({
                 value: values.inspect(this.from)
             });
         }
+        if (this.from.isBeginning()) {
+            this.from = new JuttleMoment(0);
+        }
         this.historic = this.from.lt(NOW);
 
         this.to = options.to || FOREVER;
@@ -154,6 +157,9 @@ var Read = Juttle.proc.source.extend({
                 break ; // don't step into the future
             }
             var by = step_to.subtract(this.next_t);
+            this.logger.debug('run step', i, 'stepping from',
+                this.next_t.valueOf(), 'to', step_to.valueOf(), 'by', by.valueOf());
+
             try {
                 this.step(this.next_t, step_to, by, out, errors);
             } catch (error) {

--- a/test/adapters/stochastic.spec.js
+++ b/test/adapters/stochastic.spec.js
@@ -23,6 +23,17 @@ describe('stochastic adapter options', function() {
         });
     });
 
+    it('supports starting at :beginning:', function() {
+        return check_juttle({
+            program: 'read stochastic -from :beginning: '+
+                     '-to :1970-01-01T00:00:10.000Z: ' +
+                     '| reduce count() | view text'
+        })
+        .then(function(res) {
+            expect(res.sinks.text[0]).deep.equal({count: 238});
+        });
+    });
+
     // a series of source cdn tests with various ways of specifying
     // the options will all produce these same results
     var hosts = [


### PR DESCRIPTION
Since :beginning: is actually an infinite moment, stepping forward ended up
causing an infinite loop.

Add a fix for this by explicitly checking for `-from :beginning:` and
implicitly converting it to start at the epoch instead.

Partially addresses #31.
