### PR TITLE
table: look at all points in the batch to determine column widths

### DIFF
--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -111,57 +111,64 @@ var TableView = View.extend({
     consume: function(data) {
         var self = this;
 
-        // If in progressive output, print a tablelet for the column
-        // headers and first point, or a tablelet for the points.
+        if (self.options.limit && self.items_written >= self.options.limit) {
+            return;
+        }
+
+        data = utils.fromNative(data.map(_.clone));
+
+        // In progressive mode, look at the first batch of points to detect the
+        // columns and determine their widths based on the length of the fields.
+        // Then print a tablelet for each batch of points, using the same widths
+        // to make things align properly.
         if (self.options.progressive) {
             var table;
 
-            this.data_points = utils.fromNative(data.map(_.clone)).forEach(function(point) {
+            if (self.initial_keys.length === 0) {
+                var columns = _.reduce(data, function(memo, pt) {
+                    _.each(pt, function(val, key) {
+                        var val_len = String(val).length;
+                        var key_len = String(key).length;
+                        var new_len = Math.max(Math.ceil(1.5 * Math.max(key_len, val_len)), 10);
+                        if (! memo[key]) {
+                            memo[key] = new_len;
+                        } else {
+                            memo[key] = Math.max(memo[key], new_len);
+                        }
+                    });
 
+                    return memo;
+                }, {});
+
+                self.initial_keys = _.keys(columns).sort(self.sort_keys.bind(self));
+                self.latest_keys = self.initial_keys;
+                self.column_widths = _.map(self.latest_keys, function(key) {
+                    return columns[key];
+                });
+
+                if (self.options.title) {
+                    self.fstream.write(self.options.title + "\n");
+                }
+                table = new Table({
+                    head: self.latest_keys,
+                    colWidths: self.column_widths,
+                    chars: self.first_table_chars,
+                    style: self.style
+                });
+            } else {
+                table = new Table({
+                    colWidths: self.column_widths,
+                    chars: self.mid_table_chars,
+                    style: self.style
+                });
+            }
+
+            data.forEach(function(point) {
                 if (self.options.limit && self.items_written >= self.options.limit) {
                     return;
                 }
 
                 self.items_written++;
-
-                if (self.initial_keys.length === 0) {
-
-                    // This is the first point ever. Save the keys in
-                    // this point as the columns, and use the greater
-                    // of the width of the keys or values for this
-                    // point as a hint on the width of each column.
-
-                    self.initial_keys = _.keys(point).sort(self.sort_keys.bind(self));
-                    self.latest_keys = self.initial_keys;
-                    self.column_widths = _.map(self.latest_keys, function(key) {
-                        var value_len = String(point[key]).length;
-                        var key_len = String(key).length;
-                        var new_len = Math.ceil(1.5 * Math.max(key_len, value_len));
-                        if (new_len < 10) {
-                            new_len = 10;
-                        }
-                        return new_len;
-                    });
-                    table = new Table({
-                        head: self.latest_keys,
-                        colWidths: self.column_widths,
-                        chars: self.first_table_chars,
-                        style: self.style
-                    });
-
-                    if (self.options.title) {
-                        self.fstream.write(self.options.title + "\n");
-                    }
-                } else if (table === undefined) {
-                    // This is not the first point ever, but the first
-                    // point for this batch. Create a table to hold
-                    // the points.
-                    table = new Table({
-                        colWidths: self.column_widths,
-                        chars: self.mid_table_chars,
-                        style: self.style
-                    });
-                }
 
                 // If this point has additional keys, emit a warning
                 // and ignore the additional keys.
@@ -175,6 +182,7 @@ var TableView = View.extend({
                 });
                 table.push(values.map(self._valueFormatter.bind(self)));
             });
+
             if (table !== undefined) {
                 // Print the table, if it exists. It won't exist only
                 // if we've hit limit.
@@ -183,7 +191,7 @@ var TableView = View.extend({
         } else {
             // We're not in progressive mode. Just save the points so
             // we can build the big table at the end.
-            this.data_points = this.data_points.concat(utils.fromNative(data.map(_.clone)));
+            this.data_points = this.data_points.concat(data);
         }
     },
 

--- a/test/views/table.spec.js
+++ b/test/views/table.spec.js
@@ -97,4 +97,46 @@ describe('table view', function () {
         expect(lines[5]).to.match(/│.*true.*│/);
         expect(lines[7]).to.match(/│.*false.*│/);
     });
+
+    it('progressive mode truncates columns in subsequent batches', function() {
+        var stream = new streams.WritableStream();
+        var table = new TableView({
+            fstream: stream,
+            progressive: true
+        },{
+            color: false
+        });
+
+        var batch1 = [
+            { key: 'short' },
+            { key: 'a bit longer' },
+            { key: 'very much longer by far' },
+            { key: 'shorter' }
+        ];
+
+        var batch2 = [
+            { key: 'very very very very very much longer by far' }
+        ];
+
+        table.consume(batch1);
+        table.consume(batch2);
+        table.eof();
+
+        var lines = stream.toString().split('\n');
+        expect(lines).to.deep.equal([
+            '┌───────────────────────────────────┐',
+            '│ key                               │',
+            '├───────────────────────────────────┤',
+            '│ short                             │',
+            '├───────────────────────────────────┤',
+            '│ a bit longer                      │',
+            '├───────────────────────────────────┤',
+            '│ very much longer by far           │',
+            '├───────────────────────────────────┤',
+            '│ shorter                           │',
+            '├───────────────────────────────────┤',
+            '│ very very very very very much lo… │',
+            '└───────────────────────────────────┘',
+            '' ]);
+    });
 });


### PR DESCRIPTION
In progressive mode, look at all the points in the first call to
consume when determining the set of columns and widths instead of
only looking at the first point.

Fixes #33.