### PR TITLE
stochastic: bump up the syslog max limit

### DIFF
--- a/lib/runtime/procs/stoke/cdn.js
+++ b/lib/runtime/procs/stoke/cdn.js
@@ -74,7 +74,7 @@ var _config = {
     syslog_lpm: 0.1, // avg syslog error lines per minute per host
     syslog_thresh: 0.7, // demand at which message rate increases
     syslog_max_lpm: 20, // additional syslog error lines above thresh
-    syslog_max_lines: 1000, // max loglines produced before throttling
+    syslog_max_lines: 100000, // max loglines produced before throttling
     response_ms_normal_mean: 80,
     response_ms_heavy_mean: 2000,
     response_ms_thresh: 0.5,


### PR DESCRIPTION
A naive invocation of `read stochastic -source 'cdn' -last :1w:` would
trigger the limit of 1000 syslog messages.

Bump up the limit to 100000 to make this less likely to occur.

Fixes #39.