### PR TITLE
rename options for write to match desired naming scheme

### DIFF
--- a/docs/adapters/file.md
+++ b/docs/adapters/file.md
@@ -83,9 +83,9 @@ write file -file <path>
 Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
 `-file`           | File path on the local filesystem, absolute or relative to the current working directory  | Yes
-`-bufferLimit`    | Maximum number of points to buffer in memory before each write to the specified file | No; defaults to 100000
+`-bufferLimit`    | Maximum number of points that will be written to the file. | No; defaults to 100
 `-maxFilesize`    | Maximum size of the file being written to, limited since the entire JSON needs to fit in memory | No; defaults to 200MB
-`-flushFrequency` | How often (in number of points) to flush the points in memory out to the specified file | No; defaults to every 100 points
+`-limit` | Maximum number of points in a file before we'd stop writing points to the file to avoid running out of memory | No; defaults to 100000
 
 If the file already exists and contains a valid JSON array, the write will append new data rather than overwrite.
 

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -6,7 +6,7 @@ var fs = Promise.promisifyAll(require('fs'));
 var Write = Juttle.proc.sink.extend({
     procName: 'write-file',
     initialize: function(options, params) {
-        var allowed_options = ['file', 'bufferLimit', 'maxFilesize', 'flushFrequency'];
+        var allowed_options = ['file', 'limit', 'maxFilesize', 'bufferLimit'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -22,14 +22,14 @@ var Write = Juttle.proc.sink.extend({
             });
         }
 
-        this.bufferLimit = options.bufferLimit || 100000;
-        if (!_.isNumber(this.bufferLimit) || this.bufferLimit < 0 ) {
+        this.limit = options.limit || 100000;
+        if (!_.isNumber(this.limit) || this.limit < 0 ) {
             throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: "bufferLimit"
+                option: "limit"
             });
         }
 
-        // 200MB bufferLimit on file
+        // 200MB limit on file
         this.maxFilesize = options.maxFilesize || 200*1024*1024;
         if (!_.isNumber(this.maxFilesize) || this.maxFilesize < 0 ) {
             throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
@@ -38,10 +38,10 @@ var Write = Juttle.proc.sink.extend({
         }
 
         // flush every 100 points
-        this.flushFrequency = options.flushFrequency ? options.flushFrequency : 100;
-        if (!_.isNumber(this.flushFrequency) || this.flushFrequency < 0 ) {
+        this.bufferLimit = options.bufferLimit ? options.bufferLimit : 100;
+        if (!_.isNumber(this.bufferLimit) || this.bufferLimit < 0 ) {
             throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: "flushFrequency"
+                option: "bufferLimit"
             });
         }
 
@@ -54,7 +54,7 @@ var Write = Juttle.proc.sink.extend({
         this.queue = this.queue.concat(points);
         // if we're due for a flush and don't have a flush in course then
         // fire off another flush
-        if (this.queue.length > this.flushFrequency && !this.flushPromise) {
+        if (this.queue.length > this.bufferLimit && !this.flushPromise) {
             this.flush();
         }
     },
@@ -87,23 +87,23 @@ var Write = Juttle.proc.sink.extend({
             }
         })
         .then(function() {
-            if (points.length > self.bufferLimit) {
+            if (points.length > self.limit) {
                 self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                    option: 'bufferLimit',
-                    value: self.bufferLimit,
-                    extra: ', droppping points.'
+                    option: 'limit',
+                    value: self.limit,
+                    extra: ', dropping points.'
                 }));
                 return Promise.resolve();
             } else {
-                var space_left = self.bufferLimit - points.length;
+                var space_left = self.limit - points.length;
                 if (space_left < self.queue.length) {
                     points = points.concat(self.queue.slice(0, space_left));
                     // error since we really can't take any more points after this and
                     // should stop the whole pipeline
                     self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                        option: 'bufferLimit',
-                        value: self.bufferLimit,
-                        extra: ', droppping points.'
+                        option: 'limit',
+                        value: self.limit,
+                        extra: ', dropping points.'
                     }));
                 } else {
                     // lets write out some more points

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -204,7 +204,7 @@ describe('file adapter tests', function () {
             });
         });
 
-        _.each(['bufferLimit', 'maxFilesize', 'flushFrequency'], function(option) {
+        _.each(['limit', 'maxFilesize', 'bufferLimit'], function(option) {
             it('fails when you provide an invalid ' + option, function() {
                 return check_juttle({
                     program: 'emit -limit 1 | write file -file "' + filename + '" -' + option + ' -1'
@@ -258,13 +258,13 @@ describe('file adapter tests', function () {
             });
         });
 
-        it('fails when you exceed the -bufferLimit value', function() {
+        it('fails when you exceed the -limit value', function() {
             return check_juttle({
-                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + filename + '" -bufferLimit 1'
+                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + filename + '" -limit 1'
             })
             .then(function(result) {
                 expect(result.errors.length).equal(1);
-                expect(result.errors[0]).to.equal('Error: option bufferLimit exceeded limit of 1, droppping points.');
+                expect(result.errors[0]).to.equal('Error: option limit exceeded limit of 1, dropping points.');
             })
             .then(function() {
                 return check_juttle({
@@ -299,9 +299,9 @@ describe('file adapter tests', function () {
             });
         });
 
-        it('can write all expected data with a high -flushFrequency', function() {
+        it('can write all expected data with a high -bufferLimit', function() {
             return check_juttle({
-                program: 'emit -limit 10 | write file -file "' + filename + '" -flushFrequency 1000'
+                program: 'emit -limit 10 | write file -file "' + filename + '" -bufferLimit 1000'
             })
             .then(function() {
                 // verify we didn't write out any additional points to the file
@@ -319,9 +319,9 @@ describe('file adapter tests', function () {
             });
         });
 
-        it('can write all expected data with a low -flushFrequency', function() {
+        it('can write all expected data with a low -bufferLimit', function() {
             return check_juttle({
-                program: 'emit -limit 10 | write file -file "' + filename + '" -flushFrequency 1'
+                program: 'emit -limit 10 | write file -file "' + filename + '" -bufferLimit 1'
             })
             .then(function() {
                 // verify we didn't write out any additional points to the file
@@ -340,19 +340,19 @@ describe('file adapter tests', function () {
         });
 
 
-        it('fails when you attempt to write to a file with more points than than -bufferLimit allows', function() {
+        it('fails when you attempt to write to a file with more points than than -limit allows', function() {
             return check_juttle({
                 program: 'emit -limit 3 -from :2014-01-01: | write file -file "' + filename + '"'
             })
             .then(function() {
                 return check_juttle({
-                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + filename + '" -bufferLimit 2'
+                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + filename + '" -limit 2'
                 });
             })
             .then(function(result) {
                 expect(result.errors.length).to.equal(1);
                 expect(result.warnings.length).to.equal(0);
-                expect(result.errors[0]).to.contain('Error: option bufferLimit exceeded limit of 2, droppping points.');
+                expect(result.errors[0]).to.contain('Error: option limit exceeded limit of 2, dropping points.');
             })
             .then(function() {
                 // verify we didn't write out any additional points to the file


### PR DESCRIPTION
fixes #100

In my hastiness to get pr #11 in I changed the wrong option to be
bufferLimit resulting in a messy set of options which should be cleared
up now with this PR.