### PR TITLE
Adding contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,178 @@
+# How To Contribute
+
+Thank you for taking the time to contribute to project Juttle!
+
+The aim of this document is to make the process easy. These guidelines apply to new contributors as well as the regular project maintainers.
+
+If you have questions, feel free to ask in our [Gitter chat room](https://gitter.im/juttle/juttle).
+
+[TOC]
+
+## Project Organization
+
+We use GitHub issues to track bugs and enhancement requests. All you need to submit an issue is a GitHub user login. 
+
+We accept GitHub Pull Requests (PRs) with code contributions.
+
+Our project workflow is organized as a public [Waffle dashboard](https://waffle.io/juttle/juttle) that displays both GitHub issues and PRs.
+
+Juttle is composed of multiple repositories. To submit bugs, enhancement requests, and code contributions in the right place, use this logical grouping:
+
+- juttle - core language and CLI
+- outrigger - dev environment with visualizations in the browser
+- juttle-viz - charting library
+- moment-parser - time handling library
+- backend adapters:
+  - juttle-elastic-adapter
+  - juttle-influx-adapter
+  - juttle-gmail-adapter
+  - juttle-mysql-adapter
+  - juttle-postgres-adapter
+  - juttle-sqlite-adapter
+  - juttle-twitter-adapter
+  - etc.
+
+If you are unclear on where to file an issue, ask us on [Gitter](https://gitter.im/juttle/juttle). Cross-repository issues can be filed in the main [juttle repo](https://github.com/juttle/juttle).
+
+## What's Happening
+
+We haven't started a project blog yet.
+
+To know what's going on with project Juttle, you can view our GitHub issues. The ones with "idea" label represent future directions of work, the ones with "ehnancement" labels are outstanding feature requests, and the ones with "bug" label are known defects.
+
+The roadmap will be published [soon](https://github.com/juttle/juttle/issues/63) as a GitHub Wiki.
+
+You can "star" our GitHub repositories to bookmark them and show your interest. You may separately elect to "watch" the repos to be notified of new issues and pull requests (this can get noisy due to all the activity).
+
+To see open issues for a given repository, look under "Issues" in the GitHub UI, for example [open issues in juttle repo](https://github.com/juttle/juttle/issues). To see all issues for project Juttle in a single place, use the [Waffle dashboard](https://waffle.io/juttle/juttle) and set the filter (in upper right corner) to "Issues Only". You can enter search terms in the filter to see issues of interest, for example, enter "time travel" to see if anyone already asked for Juttle to support it.
+
+The Waffle board also gives an idea of what's being worked on ("In Progress" column), what will be worked on imminently ("Assigned") and soon ("Ready"). The "Backlog" column is not in a perfectly sorted order.
+
+We use these GitHub labels for issue types:
+
+Label       | Meaning
+----------- | --------
+bug         | Code doesn't work as intended
+enhancement | Request to support a new feature or behavior
+question    | How do I do thing X in Juttle? Why doesn't thing Y work?
+idea        | Future work direction, bigger and fuzzier than "enhancement"
+test        | Testing task (add tests, fix tests)
+docs        | Documentation issue (add docs, fix docs)
+task        | Internal task (code cleanup, refactoring) with no user facing impact
+performance | Performance issue
+
+We use these GitHub labels for issue transitions:
+
+Label       | Meaning
+----------- | --------
+triaged     | Reviewed by project maintainers and added to backlog
+ready       | Short-listed to be worked on soon (next sprint)
+assigned    | Assigned to be worked on now (current sprint)
+in progress | Actively being worked on (has a branch, has open PR)
+
+There is no label for "done" issues, they get closed when done.
+
+When searching for issues in the GitHub UI, you can add `label:X` to find a subset of issues, for example "is:issue is:closed label:question" will find answered questions. The Waffle UI also allows searching by label as well as repository, assignee, and free text search on issue names. Note that Waffle only shows the last 7 days of "done" issues; use the GitHub UI to search across older closed issues.
+
+## Filing Bugs
+
+If you ran into a bug when using Juttle, let us know by filing a GitHub issue in the right repository (for example: if the problem is specific to `write elastic`, file it in the juttle-elastic-adapter repo). If you can't tell which component is responsible for the bug, file it in the main [juttle repo](https://github.com/juttle/juttle).
+
+Before filing the bug, please check if it's already known by searching the GitHub issues in the repository, or the [Waffle dashboard](https://waffle.io/juttle/juttle) which covers all repos. If the bug is already filed, please add a note to the issue so we know you also ran into it.
+
+When filing a new bug, use GitHub label "bug" to help us triage the issue.
+
+Include the following information:
+- expected behavior, based on documentation or your intuition
+- actual behavior, including error output
+- juttle program you ran (put it in a code block if the program is short, attach in a text file if long)
+- sample data (if your program reads from a storage backend, explain the data format)
+- steps to reproduce the problem, if it's more than just running your juttle program
+- screenshot of the browser output, if the problem is with juttle-viz or outrigger
+- version of the code you used (for example, 'juttle@0.1.0' as reported by `npm list`, or "master as of rev abcd")
+
+We like to attend to newly filed bugs within a business day or two. When we've looked at your submission, it will acquire a "triaged" label. If we have further questions, we will ask them on the GitHub issue, and you will get an email notification. If it's clearly a bug that should be fixed, we will get it assigned for work, and PR will be attached to the issue when work is underway. When the PR merges, the bug will be considered fixed, and the GitHub issue will be automatically closed. At that point, the master branch will have the fix for your bug; publishing the new release to npm will happen a bit later. 
+
+## Asking Questions
+
+If you want to run something by us that's not quite a bug, but not really a feature request either, more of a question (for example, "How to do a right outer join in Juttle?"), file us a GitHub issue with label "question".
+
+We do not currently have an FAQ, but do a search on GitHub issues to see if someone else has already asked your question (be sure to remove the default `is:open` from the search, to cover answered questions).
+
+For a quick response, try the [Gitter](https://gitter.im/juttle/juttle) chat room.
+
+## Updating Docs
+
+If you run into issues with our documentation (missing docs, incorrect docs, broken links), file us a GitHub issue with label "docs".
+
+When viewing our published docs for [juttle](http://juttle.github.io/juttle) and [juttle-viz](http://juttle.github.io/juttle-viz/), you will also have the option to "Edit on GitHub". This is great for fixing typos - no need to go through the trouble of filing a GitHub issue just to tell us to 's/aaa/aba', simply make a pull request to get it fixed. We will gratefully merge it.
+
+## Requesting Enhancements
+
+If you want Juttle to do something it doesn't yet do, let us know by filing a GitHub issue in the right repository (ie: the main juttle repo for core language enhancements, juttle-viz for charts, adapter repos for enhancements to reading and writing to various backends). To request support for new backends, which do not have an juttle-adapter-X repo, submit the issue in the [main juttle repo](https://github.com/juttle/juttle).
+
+Check if your request has already been filed by searching GitHub issues for the right repository, or [Waffle dashboard](https://waffle.io/juttle/juttle) which covers all repos. If there is already an issue for your request, add a note to it so we know you also want this feature. The note can be as simple as "+1" for "me too", or include the details of your use case, which we'd love to know about.
+
+When filing a new request, use GitHub label "enhancement" to help us triage the issue.
+
+Describe the desired new feature or enhancement, and the use case it will enable for you.
+
+We like to respond to enhancement requests within a few business days. We will comment on the issue and mark it with "triaged" label once we understand how to handle the request. We may need to ask you additional questions first, before we are able to triage it. If we are unable to honor the request, we will close the issue with an explanation. The "triaged" requests enter our backlog and eventually get scheduled for work. You can look at our public [Waffle dashboard](https://waffle.io/juttle/juttle) to get an idea of where in the queue your request stands (note that it's not a fully prioritized list).
+
+To get enhancements implemented faster, please help us by contributing code!
+
+## Contributing Code
+
+Pull Requests (PRs) can be opened for existing GitHub issues, or independently. We generally file issues for non-trivial bits of work, while small fixes can start life in a PR without an associated issue.
+
+### Maintainers
+
+Please follow these guidelines for sanity of work tracking in [Waffle](https://waffle.io/juttle/juttle).
+
+If your PR is for a GitHub issue, include the issue number in your branch name (for example, name your branch "add-flux-capacitor-#88" for GitHub issue #88). When you push code on this branch, the issue will move into "in progress" state automatically (done by our Waffle bot).
+
+Include one of [GitHub closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in your PR description (for example, "resolves #88"). If you do this, the Waffle dashboard will show this PR as attached to the issue #88, and not standalone. When the PR is merged, the issue will be automatically closed by the Waffle bot.
+
+If you want Waffle to show the PR attached to the issue, but don't want it to close the issue upon merge (because there are multiple PRs for the same issue), use a special Waffle keyword "connects to" in the PR description (for example, "connects to #88"). This only works if the keyword is in PR description, not in the later comments (you can always edit the description).
+
+If you don't do these things, you will need to manually transition the GitHub issue by adding label "in progress" and closing it when it's done. That's fine, just more work for you.
+
+We also use "ready" and "assigned" labels for issue state transitions. Those are normally auto-assigned by Waffle when issues are moved between columns in the Waffle UI. This should just work, see the [Waffle FAQ](https://github.com/waffleio/waffle.io/wiki/FAQs) for more info.
+
+### Contributors
+
+If you do not have commit privileges on the Juttle project repositories, you will need to fork the repo in order to put up a PR. Then create a topic branch from where you want to base your work (usually, master):
+
+```
+git checkout -b support-time-travel-#88 master
+```
+
+Work on this branch and make commits of logical units of work, with commit messages describing the work. Run tests and make documentation updates (see [next section](#everyone)). When ready, push the commits and create a Pull Request.
+
+If your PR is for an existing GitHub issue, use "resolves" keyword in the PR description to tie the PR to the issue (for example, "resolves #88"). If this is a standalone PR, not connected to any issue, you don't need to do anything special with keywords. We will add keywords and labels as needed, so you may see new ones showing up on your PR - don't worry about it.
+
+If you know who should review your contribution, @mention them by username on the PR; otherwise we will choose a reviewer from project maintainers.
+
+Once you have created a PR, we will be notified, review the code (along with tests and docs), comment on the PR if there are questions or additional requirements before we can accept it, and once it passes review, merge it from your fork into master.
+
+### Everyone
+
+Run tests on your branch to ensure no regression has occurred:
+
+```
+npm test
+```
+
+This command in any of the juttle project repositories will check code style and run unit tests.
+
+When you put up a PR, the same tests will be run by Travis, our CI infrastructure, and their pass/fail status will be reported in a badge on your PR. Naturally, tests must pass before the PR can merge. 
+
+When adding new functionality, you should add tests that cover it. Part of the checks run by Travis is to calculate code coverage by unit tests.
+
+When developing you may run into failures during linting where jscs complains about your coding style. An easy way to fix those files is to simply run `jscs --fix test` or `jscs --fix lib` from the root directory of the project. After jscs fixes things you should proceed to check that those changes are reasonable, as auto-fixing may not produce the nicest looking code.
+
+Be sure to update documentation when you make user-facing changes. Small repositories such as the adapters only have the README.md file, where updates should be made. For juttle and juttle-viz, we maintain doc articles in the `docs` directory, and publish them to GitHub Pages. You can preview these docs by running `mkdocs serve` command in the root directory. See the [docs README](docs/README.md) for more info on maintaining docs.
+
+When adding Juttle code, follow the [Juttle Style Guide](docs/references/style_guide.md). If you add *.juttle programs under docs/examples, or embedded anywhere in the docs markdown articles as a code block with `juttle` language marker, they will be automatically syntax-checked when tests are run.
+
+

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -73,6 +73,23 @@ emit -limit 10
       points_3=pow(points, 3)
 ```
 
+Reducers
+========
+
+Reducers are a Juttle-specific construct that allows operating on values of a chosen field, as points stream through the flowgraph, to carry out a running computation.
+
+Reducers are used in [reduce](../processors/reduce.md) and [put](../processors/put.md) assignment expressions.
+
+Juttle comes with a number of [built-in reducers](../reducers/index.md), including [count()](../reducers/count.md), [sum()](../reducers/sum.md) and [max()](../reducers/max.md) used in this example:
+
+```juttle
+emit -from :0: -limit 10
+| put value = count()
+| reduce sum = sum(value), largest = max(value)
+```
+
+Users can define their own reducers using the `reducer` keyword. To understand how reducers function, see [User-defined reducers](../reducers/juttle_reducers_user-defined.md) section that gives an annotated example.
+
 Variables
 =========
 
@@ -259,7 +276,7 @@ emit -limit 2
 | my_viz; // invoke the subgraph here
 ```
 
-<img src="/images/diagrams/juttleOverviewDiagrams/overview5.png" alt="overview5" style="width: 400px;"/>
+<img src="../../images/diagrams/juttleOverviewDiagrams/overview5.png" alt="overview5" style="width: 400px;"/>
 
 With this approach, experienced coders can express complex business
 logic and rich visualizations, then make them available to other Juttle

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -76,7 +76,7 @@ emit -limit 10
 Reducers
 ========
 
-Reducers are a Juttle-specific construct that allows operating on values of a chosen field, as points stream through the flowgraph, to carry out a running computation.
+Reducers are a Juttle-specific construct that allows operating on field values of data points as they stream through the flowgraph, to carry out a running computation.
 
 Reducers are used in [reduce](../processors/reduce.md) and [put](../processors/put.md) assignment expressions.
 

--- a/docs/processors/join.md
+++ b/docs/processors/join.md
@@ -9,7 +9,7 @@ Create new points from the points of multiple input streams.
 
 ``` 
 join
-   [-nearest :duration: | -zip (true | :duration:) | -once true]
+   [-nearest :duration: | -zip <true|:duration:> | -once true]
    [-table inputNumber, inputNumber, ...]
    [-outer inputNumber]
    [fieldName1, fieldName2,...fieldNameN]
@@ -19,18 +19,62 @@ It should be placed after a merge point in a parallel Juttle expression,
 like this:
 
 ```
-(... ; ...) | join ...
+(
+  stream-1;
+  stream-2;
+)
+| join [options]
+| ... // process joined stream
+```
+
+For example:
+
+```
+read source1
+             \
+               join | reduce ...
+             /
+read source2
 ```
 
 In its simplest form, join aligns its input streams by time stamp and
 produces new output points by unioning the fields of successive matching
 input points.
 
+To join only points with matching field values, use `join fieldNameN` where fieldNameN serves as a foreign key in SQL join terms.
+
+By default, an inner join is performed; use `-outer` option to do an outer join instead. Left or right outer join is achieved by specifying the input number of the "base" stream.
+
+The `-nearest` option causes a streaming many-to-one join, while `-zip` option causes a streaming one-to-one join.
+
+The time intervals between points are ignored by default when joining streams; set `:duration:` parameter in `-nearest` or `-zip` to join only points that are close in time.
+
+For a non-streaming join that runs over the entire set of inputs, use `-once` option.
+
+For a join that treats one or more inputs as a lookup table with timeless points, akin to a SQL relational join, use `-table` option.
+
+Join can be used on a single stream, see [Notes](#Notes).
+
+Parameter  |  Description  |  Required?
+---------- | ------------- | ---------:
+`-nearest :duration:`  |   Streaming many-to-one join of each input point or batch with the points or batches on the other inputs having the nearest time stamp. <br><br>If one stream has fewer points than the others, its points may be joined multiple times as needed so that all points or batches on the other inputs participate in a join. The duration is the maximum acceptable difference in time stamps between matched groups of points, and will cause points to be dropped rather than joined if the gap in time is too large. |  No; defaults to unbounded duration; mutually exclusive with -zip and -once.
+`-zip <true | :duration:>`  |   Streaming one-to-one join of each input point or batch with the points or batched on the other inputs having the nearest time stamp. <br><br>If one stream has more points than the others, extra points are dropped, such that any point is joined at most once. <br><br>If specified, the `duration` is the maximum acceptable difference in time stamps between matched groups of points. If instead `-zip true` is specified, there is no limit to the difference in time stamps.  |  No; mutually exclusive with -nearest and -once.
+`-once true`  |  Non-streaming join over the entire set of input points, after all points have been received. <br><br>The time field may be specified as a join field if desired, giving results similar to a streaming one-to-one join with exactly matching time stamps. There is no analogue to the duration parameter of -zip and -nearest for non-streaming joins. |  No; mutually exclusive with -nearest and -zip.
+`-table inputNumber1 [, 2, ...]`   |  Treat the specified input streams as timeless, i.e. as passive tables with no associated time stamp; input streams are numbered top to bottom (or left to right) from 1 in the program.  |  No
+`-outer inputNumber`  |  Perform an outer join preserving the specified input stream. Input streams are numbered top to bottom (or left to right) from 1 in the program (that is, `-outer 1` specifies an outer left join where the first series in the flowgraph is preserved). When a point on the outer input does not have a matching join key on the other inputs, `-outer` forwards it unchanged, or partially joined against any matching inputs. Without `-outer`, an inner join is performed, which only produces points when all inputs match. |  No; defaults to inner join.
+`fieldnameN`  |   The fields to match when joining points.  |  No; by default, points will be unioned without matching on fields.
+
+##### Notes
+
+###### Single Stream Join
+
 If used on a single stream, its points are grouped by their time stamp
 or batch, and all points in a group are unioned to create an output
 point. If optional joinFields are specified for the single stream, they
 act like group-by fields, and there is an output point for each distinct
 value of the joinFields among the points.
+
+###### Multiple Stream Join
 
 Options to `join` can cause it to
 operate like an SQL relational join across multiple input streams, where
@@ -41,12 +85,16 @@ batches. When points with matching key values appear on each input, new
 points are produced containing the union of these matching points'
 fields.
 
+###### Batched vs Unbatched Join
+
 Streaming joins are computed continually as points or batches of points
 arrive at the inputs. When a stream is batched, all points in a batch
 are treated as a group for joining (as if they all had the batch's
 ending time stamp). For an unbatched stream, all points having the same
 time stamp are treated as a batch. It is okay to join a batched stream
 with an unbatched stream.
+
+###### Time Matching in Many-to-One and One-to-One Join
 
 To require exact time stamp matching for batches to be joined, specify
 time as a join key along with any other join keys. If time is not listed
@@ -59,6 +107,7 @@ successive input batch with one on its other inputs, matching by nearest
 time stamp, and drops any extra input batches that do not have matches.
 A many-to-one join performs a similar matching, but will re-use an input
 batch if it remains the best match. 
+
 Both `-zip` and `-nearest` accept a duration limiting the
 difference in time stamps allowed between matched batches, with :0:
 behaving as if time had been specified as a join key. When time stamps
@@ -66,18 +115,24 @@ do not match exactly, an output point will be given the maximum time
 stamp of its input points. A join without `-zip` or `-nearest` or time as a join key is
 implicitly a `-nearest` join with no limiting duration.
 
+###### Join with Table Input
+
 A streaming join can treat some of its input batches as passive tables
 with no associated time stamp. For example, this is useful for joining a
 stream of event points having user IDs against a table of user names,
 annotating the event point with its particular user name. 
 The `-table` option lists which inputs are to be
-treated in this way. A batch on a table input remains there until
+treated in this way. The "table" input can be timeless (i.e. its data points do not contain a `time` field at all), or if it has timestamps, they will be ignored when joining.
+
+A batch on a table input remains there until
 updated by a later batch, and joins are always performed against the
 most recently received complete batch. Joins are only triggered by the
 arrival of new points on a timeful input. Because tables are timeless, a
 join is never triggered by an update to a table, and no guarantees can
 be made about precisely when (in stream time) an update will displace a
 current table batch.
+
+###### Non-streaming Join
 
 A non-streaming join over all points at once (at the end of the run) can
 be specified by the `-once` flag. 
@@ -87,14 +142,9 @@ Time stamps will be ignored unless the time field is specified as a join
 field, which forces time stamps to be matched exactly between the input
 sets.
 
-Parameter  |  Description  |  Required?
----------- | ------------- | ---------:
-`-nearest :duration:`  |   Streaming many-to-one join of each input point or batch with the points or batches on the other inputs having the nearest time stamp. <p>If one stream has fewer points than the others, its points may be joined multiple times as needed so that all points or batches on the other inputs participate in a join. The duration is the maximum acceptable difference in time stamps between matched groups of points, and will cause points to be dropped rather than joined if the gap in time is too large.</p><p>:information_source: `Note:` -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.</p> |  No
-`-zip true` \| `:duration:`  |   Streaming one-to-one join of each input point or batch with the points or batched on the other inputs having the nearest time stamp. <p>If one stream has more points than the others, extra points are dropped, such that any point is joined at most once. </p><p>If specified, the `duration` is the maximum acceptable difference in time stamps between matched groups of points. If instead `-zip true` is specified, there is no limit to the difference in time stamps. </p><p>:information_source: `Note:` -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.  |  No
-`-once true`  |  Non-streaming join over the entire set of input points, after all points have been received. <p>The time field may be specified as a join field if desired, giving results similar to a streaming one-to-one join with exactly matching time stamps. There is no analogue to the duration parameter of -zip and -nearest for non-streaming joins. </p><p>:information_source: `Note:`-nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.</p>  |  No
-`-table`   |  Treat the specified input streams as passive tables with no associated time stamp; input streams are numbered top to bottom (or left to right) from 1 in the program. <p>:baby_symbol: `experimental:`  We're still working on this feature. Try it and see what you think, then [chat with us](http://www.jut.io) to provide feedback. </p> |  No
-`-outer inputNumber`  |  Perform an outer join preserving the specified input stream. Input streams are numbered top to bottom (or left to right) from 1 in the program (that is, `-outer 1` specifies an outer left join where the first series in the flowgraph is preserved). When a point on the outer input does not have a matching join key on the other inputs, `-outer` forwards it unchanged, or partially joined against any matching inputs. Without `-outer`, an inner join is performed, which only produces a points when all inputs match.  |  No
-`fieldnameN`  |   The fields to match when joining points.  |  No
+Note: -nearest, -zip, and -once are mutually exclusive. If none are specified, the behavior is as if -nearest was specified with an unbounded duration.
+
+##### Join Examples
 
 _Example: merging metric points_
 

--- a/docs/processors/reduce.md
+++ b/docs/processors/reduce.md
@@ -20,15 +20,17 @@ reduce [-every duration [-on duration-or-calendar-offset]]
 Parameter  |  Description  |  Required?
 ---------- | ------------- | ---------:
 `-every`   | The interval at which values will be computed, as a duration literal. A new result is produced each time this duration passes.  |  No; if not specified, the upstream batch interval is used. If there is no upstream batch, a single result is produced after the stream has ended.
-`over`     | The moving time window over which the value will be computed, as a [duration literal](../modules/juttle_time_moment_literals). This is typically some multiple of the `-every` interval (for example, `reduce -every :minute: -over :hour: value=avg(value)` updates a trailing hourly average every minute). <p>When `-over` is specified, results will only be produced for full windows of data. No results will be produced until `-over` has passed after the first point. No result will be produced for any final points that span interval less than `-over`. </p><p>If `-over` is :forever:, the reducer emits results cumulatively, over all points seen so far. </p><p>See [Moving time windows](../reducers/juttle_reducers_timewindows.md) for more information about moving time windows.  | No
-`-reset`  |  Set this to 'false' to emit results cumulatively, over all points seen so far.  |  No
-`-forget`  |  When grouping reducer results with 'by', set this to 'false' to cause results to be emitted for every value of 'by' that has been seen in previous batches. Values that do not appear in the current batch will report their 'empty' value (for example, count() will produce 0, avg() will produce null)  |  No
+`-over`     | The moving time window over which the value will be computed, as a [duration literal](../modules/juttle_time_moment_literals). This is typically some multiple of the `-every` interval (for example, `reduce -every :minute: -over :hour: value=avg(value)` updates a trailing hourly average every minute). <br><br>When `-over` is specified, results will only be produced for full windows of data. No results will be produced until `-over` has passed after the first point. No result will be produced for any final points that span interval less than `-over`. <br><br>If `-over` is :forever:, the reducer emits results cumulatively, over all points seen so far. <br><br>See [Moving time windows](../reducers/juttle_reducers_timewindows.md) for more information about moving time windows.  | No; defaults to not using a moving window.
+`-reset`  |  Set this to 'false' to emit results cumulatively, over all points seen so far.  |  No; defaults to resetting every interval.
+`-forget`  |  When grouping reducer results with 'by', set this to 'false' to cause results to be emitted for every value of 'by' that has been seen in previous batches. Values that do not appear in the current batch will report their 'empty' value (for example, count() will produce 0, avg() will produce null)  |  No; defaults to forgetting.
 `-from`    | When used with `-over`, the start time of the earliest full window of data.  |  No; if not specified, the earliest window begins with the earliest point or batch received.
 `-to`      | When used with `-over`, the end time of the last full window of data.  |  No; if not specified, the last point or batch time stamp received is assumed.
 `-on`      | A time alignment for `-every`. It may be a duration or a calendar offset less than `-every`. For example, `-every :hour: -on :00:30:00:` runs every hour on the half-hour, while `-every :month: -on :day 10:` runs a monthly computation on day 10 of the month.  |  No; if `-on` is not specified, output batches are aligned with the UNIX epoch, as if from a batch node.
-`fieldname=expr`  |  An assignment expression, where expr can be a [reducer](../reducers/index.md). Each assignment expression results in an output field that has the left-hand side of the expression as its name and the computed right-hand side as its value.   |  At least one
-`by`  |  One or more fields for which the assignment expression is computed separately. <p>If grouping fields are present, then the assignment expression is computed independently for each unique combination of values present in the grouping fields. See [Processors](../processors/index.md) for more about grouping with by.  </p>  |  No; if no grouping fields are present, then the assignment expression is computed over all points in the batch.
-    
+`fieldname=expr`  |  An assignment expression, where `expr` can be a [reducer](../reducers/index.md) or a constant value. See [Note 2](#note-2). |  At least one
+`by`  |  One or more fields for which the assignment expression is computed separately. <br><br>If grouping fields are present, then the assignment expression is computed independently for each unique combination of values present in the grouping fields. See [Processors](../processors/index.md) for more about grouping with by.  <br><br> |  No; if no grouping fields are present, then the assignment expression is computed over all points in the batch.
+
+###### Note 1
+
 The output points contain:
 
 -   All the fields specified as assignment expressions or grouping fields in the arguments
@@ -41,6 +43,44 @@ batch. When the points flowing into reduce are not batched, output
 points are generated for all points when the stream ends.
 
 See [Field referencing](../concepts/fields.md#referencing) for additional information relevant to this processor.
+
+###### Note 2
+
+In the assignment expression `fieldname=expr`, if `expr` is a reducer, the resulting point will have the return value of reducer's result() function as the value of field `fieldname`.
+
+If `expr` is a constant value (Juttle constant, string literal, number), the resulting point will have field 'fieldname' with that value. This is commonly used to place "naming" fields into the data point, such as:
+
+```
+... | reduce name = 'pct90', value = percentile (value, 0.9)
+```
+
+Assignments that try to dereference fields from the incoming data point are invalid; the field values of the point being processed by `reduce` are only accessible in the context of a reducer.
+
+For example, this is not valid Juttle, it would emit error "a is not defined" because it would try looking for a constant named 'a':
+
+```text
+// INVALID JUTTLE
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce c = a + b
+```
+
+This is also not valid Juttle, it would error out when trying to add up two null values, because dereferencing of fields 'a' and 'b' would attempt to access such fields in the data point being _created_ by the `reduce`, not the data point being _processed_ by it, since the fields of incoming point are not in scope.
+
+```text
+// INVALID JUTTLE
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce c = *'a' + *'b'
+```
+
+The legitimate way to achieve the desired result (compute a cumulative sum of field values for 'a' and 'b' over all points) would be to use `reduce` to get sums of 'a' and 'b' separately, with the built-in reducer [sum()](../reducers/sum.md), and then add resulting field values in a `put` expression:
+
+```juttle
+emit -points [ { a: 5, b: 7 }, { a: 12, b: 88 } ]
+| reduce sum_a = sum(a), sum_b = sum(b)
+| put c = sum_a + sum_b
+```
+
+More examples of using `reduce`:
 
 _Example: Trailing ten-minute average_
 


### PR DESCRIPTION
resolves #99

I used [puppet](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md) and [atom](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) docs as examples. The filename CONTRIBUTING.md is [standard](https://github.com/blog/1184-contributing-guidelines). 

We are missing something like a [CLA](https://en.wikipedia.org/wiki/Contributor_License_Agreement) or Certificate of origin like [nodejs](https://nodejs.org/en/get-involved/development/#developers-certificate-of-origin-10). It's not clear to me how critical is to have one, and must it be explicitly signed (using a tool like [clahub](https://www.clahub.com/) perhaps?) or is it enough to mention that by contributing, you allow to abide by the CLA.

@mccanne @demmer @dmajda 
