### PR TITLE
Fix multiline inputs and history.

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -335,7 +335,7 @@ function setupCline() {
         trim_history();
     });
 
-    cli.command('{juttle}', 'evaluate juttle program', {juttle: '(?!(help|clear|exit)|\\.).*'}, function(input, args) {
+    cli.command('{juttle}', 'evaluate juttle program', {juttle: '(?!(help|clear|exit)|\\.).*(?:\n.*)*'}, function(input, args) {
         if (in_multi_line) {
             multi_line_src += input + '\n';
         } else {
@@ -351,7 +351,14 @@ function setupCline() {
             cli.prompt(prompt);
         } else {
             in_multi_line = false;
-            add_history(multi_line_src);
+
+            // Remove the newlines from the command before adding it
+            // to history. This will make it easier to view and edit
+            // after scrolling back through history. When running the
+            // command, however, still keep the multi-line version so
+            // any initial errors are printed in context.
+
+            add_history(multi_line_src.replace(/\n/g, ' '));
             perform_mode({
                 action: mode,
                 juttle_src: multi_line_src

--- a/bin/juttle
+++ b/bin/juttle
@@ -332,6 +332,7 @@ function setupCline() {
         console.log('Starting multi-line input. End input with a line containing a single ".":');
         multi_line_src = '';
         in_multi_line = true;
+        cli.prompt('');
         trim_history();
     });
 


### PR DESCRIPTION
To fix #81, include 2 changes that both address the problem in different
ways. I think I'll keep both fixes just to allow for flexibility in
case we want to change the behavior later.

The first fix involves collapsing multi-line programs to a single line
when saving to history. That way, scrolling through history doesn't
result in an ugly multi-line item, and also allows for editing of the
item. When the multi-line program is run for the first time, however,
it's still run as a multi-line program. That allows any errors to be
shown in the context of the original multi-line program.

The second fix is to allow multiline inputs to work with history. The
problem was that the '.*' regex wasn't matching multiple lines
separated by newlines. Javascript regex apparently doesn't have a
multi-line option when compiling the regex, so just look for newlines
explicitly.

To fix #80, while in the middle of a multi-line input, set the prompt to an empty
string so it won't appear if you use editing keys.

This fixes #80 and #81.

@dmehra 