### PR TITLE
Scheduler support for periodic tasks

### DIFF
--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -1,11 +1,14 @@
 var Heap = require('heap');
 var Base = require('extendable-base');
+var errors = require('../errors');
 
 var Scheduler = Base.extend({
     initialize: function(options) {
         this.timer = null;
         this.queue = new Heap(function(a, b) { return a.ms - b.ms; });
+
         this.running = false;
+        this.stopped = false;
     },
 
     now: function() {
@@ -13,6 +16,10 @@ var Scheduler = Base.extend({
     },
 
     schedule: function(time, callback) {
+        if (this.stopped === true) {
+            throw errors.runtimeError('RT-CANNOT-SCHEDULE-AFTER-STOP');
+        }
+
         this.queue.push({ms:time, callback:callback});
 
         if (this.running === true) {
@@ -20,7 +27,6 @@ var Scheduler = Base.extend({
                 clearTimeout(this.timer);
                 this.timer = null;
             }
-
             this._run_after(0);
         }
     },
@@ -39,11 +45,14 @@ var Scheduler = Base.extend({
     },
 
     start: function() {
-        this._run_after(0);
-        this.running = true;
+        if (this.running === false) {
+            this._run_after(0);
+            this.running = true;
+        }
     },
 
     stop: function() {
+        this.stopped = true;
         this.running = false;
         if (this.timer !== null) {
             clearTimeout(this.timer);

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -13,7 +13,7 @@ var Scheduler = Base.extend({
 
     schedule: function(time, callback) {
         this.queue.push({ms:time, callback:callback});
-        if (this.timer) { clearTimeout(this.timer); }
+        if (this.timer) { clearTimeout(this.timer); this.timer = null; }
         this._run_after(0);
     },
 
@@ -22,7 +22,7 @@ var Scheduler = Base.extend({
     },
 
     stop: function() {
-        if (this.timer) { clearTimeout(this.timer); }
+        if (this.timer) { clearTimeout(this.timer); this.timer = null; }
     },
 
     _run: function() {

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -2,13 +2,18 @@ var Heap = require('heap');
 var Base = require('extendable-base');
 var errors = require('../errors');
 
+var State = {
+    INIT: 0,
+    RUNNING: 1,
+    STOPPED: 2
+};
+
 var Scheduler = Base.extend({
     initialize: function(options) {
         this.timer = null;
         this.queue = new Heap(function(a, b) { return a.ms - b.ms; });
 
-        this.running = false;
-        this.stopped = false;
+        this.state = State.INIT;
     },
 
     now: function() {
@@ -16,13 +21,13 @@ var Scheduler = Base.extend({
     },
 
     schedule: function(time, callback) {
-        if (this.stopped === true) {
+        if (this.state === State.STOPPED) {
             throw errors.runtimeError('RT-CANNOT-SCHEDULE-AFTER-STOP');
         }
 
         this.queue.push({ms:time, callback:callback});
 
-        if (this.running === true) {
+        if (this.state === State.RUNNING) {
             if (this.timer !== null) {
                 clearTimeout(this.timer);
                 this.timer = null;
@@ -34,14 +39,16 @@ var Scheduler = Base.extend({
     schedule_every: function(every, callback) {
         var self = this;
 
-        if (this.stopped === true) {
+        if (this.state === State.STOPPED) {
             throw errors.runtimeError('RT-CANNOT-SCHEDULE-AFTER-STOP');
         }
 
         var job = function() {
-            if (self.running === true) {
+            if (self.state === State.RUNNING) {
                 callback();
-                self.schedule(Date.now() + every, job);
+                if (self.state === State.RUNNING) {
+                    self.schedule(Date.now() + every, job);
+                }
             }
         };
 
@@ -49,15 +56,14 @@ var Scheduler = Base.extend({
     },
 
     start: function() {
-        if (this.running === false) {
+        if (this.state !== State.RUNNING) {
+            this.state = State.RUNNING;
             this._run_after(0);
-            this.running = true;
         }
     },
 
     stop: function() {
-        this.stopped = true;
-        this.running = false;
+        this.state = State.STOPPED;
         if (this.timer !== null) {
             clearTimeout(this.timer);
             this.timer = null;
@@ -69,7 +75,7 @@ var Scheduler = Base.extend({
         var peek;
 
         // Scheduler was stopped after previous tick and before this one
-        if (this.running === false) { return; }
+        if (this.state !== State.RUNNING) { return; }
 
         while ((peek = this.queue.peek()) && peek.ms <= now) {
             this.queue.pop().callback();

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -5,6 +5,7 @@ var Scheduler = Base.extend({
     initialize: function(options) {
         this.timer = null;
         this.queue = new Heap(function(a, b) { return a.ms - b.ms; });
+        this.running = false;
     },
 
     now: function() {
@@ -13,15 +14,22 @@ var Scheduler = Base.extend({
 
     schedule: function(time, callback) {
         this.queue.push({ms:time, callback:callback});
-        if (this.timer) { clearTimeout(this.timer); this.timer = null; }
-        this._run_after(0);
+
+        if (this.running === true) {
+            if (this.timer !== null) {
+                clearTimeout(this.timer);
+                this.timer = null;
+            }
+
+            this._run_after(0);
+        }
     },
 
     schedule_every: function(every, callback) {
         var self = this;
 
         var job = function() {
-            if (self.timer !== null) {
+            if (self.running === true) {
                 callback();
                 self.schedule(Date.now() + every, job);
             }
@@ -32,18 +40,28 @@ var Scheduler = Base.extend({
 
     start: function() {
         this._run_after(0);
+        this.running = true;
     },
 
     stop: function() {
-        if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+        this.running = false;
+        if (this.timer !== null) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
     },
 
     _run: function() {
         var now = this.now();
         var peek;
+
+        // Scheduler was stopped after previous tick and before this one
+        if (this.running === false) { return; }
+
         while ((peek = this.queue.peek()) && peek.ms <= now) {
             this.queue.pop().callback();
         }
+
         if (peek) {
             this._run_after(Math.max(peek.ms - now, 0));
         }
@@ -51,7 +69,7 @@ var Scheduler = Base.extend({
 
     _run_after: function(delay) {
         var self = this;
-        this.timer = setTimeout(function() { self._run(); }, delay);
+        this.timer = setTimeout(this._run.bind(this), delay);
     },
 });
 

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -17,6 +17,19 @@ var Scheduler = Base.extend({
         this._run_after(0);
     },
 
+    schedule_every: function(every, callback) {
+        var self = this;
+
+        var job = function() {
+            if (self.timer !== null) {
+                callback();
+                self.schedule(Date.now() + every, job);
+            }
+        };
+
+        this.schedule(Date.now() + every, job);
+    },
+
     start: function() {
         this._run_after(0);
     },

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -68,7 +68,6 @@ var Scheduler = Base.extend({
     },
 
     _run_after: function(delay) {
-        var self = this;
         this.timer = setTimeout(this._run.bind(this), delay);
     },
 });

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -34,6 +34,10 @@ var Scheduler = Base.extend({
     schedule_every: function(every, callback) {
         var self = this;
 
+        if (this.stopped === true) {
+            throw errors.runtimeError('RT-CANNOT-SCHEDULE-AFTER-STOP');
+        }
+
         var job = function() {
             if (self.running === true) {
                 callback();

--- a/lib/strings/juttle-error-strings-en-US.json
+++ b/lib/strings/juttle-error-strings-en-US.json
@@ -14,6 +14,7 @@
     "RT-POINT-MISSING-TIME": "Warning: point is missing a time in {{info.field}}",
     "RT-TIMELESS-POINTS": "Warning: encountered point(s) without the time field",
     "RT-TYPE-ERROR": "Error: {{info.message}}",
+    "RT-CANNOT-SCHEDULE-AFTER-STOP": "Cannot schedule callbacks after scheduler has been stopped",
     "RT-NO-FREE-TEXT": "Error: Free text search is not implemented in this context.",
     "RT-ADAPTER-UNSUPPORTED-FILTER": "Error: {{info.filter}} is not supported by {{info.proc}}.",
     "RT-FREE-TEXT-STOCHASTIC": "Error: Free text search is not implemented for stochastic adapter.",

--- a/test/runtime/scheduler.spec.js
+++ b/test/runtime/scheduler.spec.js
@@ -38,4 +38,16 @@ describe('Scheduler', function() {
             done();
         }, 70);
     });
+
+    it('schedule throws after scheduler stopped', function() {
+        scheduler.stop();
+        expect(scheduler.schedule.bind(scheduler, Date.now(), function() {})).to.throw(/Cannot schedule callbacks/);
+        scheduler.start();
+    });
+
+    it('schedule every throws after scheduler stopped', function() {
+        scheduler.stop();
+        expect(scheduler.schedule_every.bind(scheduler, 1000, function() {})).to.throw(/Cannot schedule callbacks/);
+        scheduler.start();
+    });
 });

--- a/test/runtime/scheduler.spec.js
+++ b/test/runtime/scheduler.spec.js
@@ -26,4 +26,16 @@ describe('Scheduler', function() {
             }
         }, 100);
     });
+
+    it('runs periodic jobs', function(done) {
+        var ticks  = 0;
+
+        scheduler.schedule_every(10, function() { ticks += 1; });
+
+        var check = setTimeout(function() {
+            clearTimeout(check);
+            expect(ticks).to.gte(5);
+            done();
+        }, 70);
+    });
 });


### PR DESCRIPTION
Most of our backends need to repeatedly execute a periodic fetch for the pseudo-live mode. Update the scheduler to support periodic task execution.