### PR TITLE
Drop sourcetype

### DIFF
--- a/lib/adapters/file/read.js
+++ b/lib/adapters/file/read.js
@@ -6,7 +6,6 @@ var parsers = require('../parsers');
 var values = require('../../runtime/values');
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'batch',
     procName: 'read-file',
 
     initialize: function(options, params, pname, location, program, juttle) {

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -5,7 +5,6 @@ var parsers = require('../parsers');
 var request = require('request');
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'batch',
     procName: 'read-http',
 
     initialize: function(options, params, pname, location, program, juttle) {

--- a/lib/adapters/stochastic-adapter.js
+++ b/lib/adapters/stochastic-adapter.js
@@ -5,7 +5,6 @@ var JuttleMoment = require('../moment').JuttleMoment;
 var Juttle = require('../runtime/index').Juttle;
 
 var Read = Juttle.proc.source.extend({
-    sourceType: 'any',
     procName:  'read-stochastic',
 
     //

--- a/lib/program.js
+++ b/lib/program.js
@@ -77,7 +77,7 @@ var Program = Base.extend({
 
         // Check that all heads are sources.
         for (var i = 0; i < this.graph.head.length; i++) {
-            if (!this.graph.head[i].sourceType) {
+            if (!(this.graph.head[i] instanceof Juttle.proc.source)) {
                 throw errors.compileError('RT-PROC-CANNOT-START-FLOWGRAPH', {
                     proc: this.graph.head[i].procName,
                     location: this.graph.head[i].location

--- a/lib/program.js
+++ b/lib/program.js
@@ -72,7 +72,7 @@ var Program = Base.extend({
         sub.connect(sink);
         this.graph.head[0].combine(sub);
     },
-    _validate_sources: function(type) {
+    _validate_sources: function() {
         var sources = this.get_sources();
 
         // Check that all heads are sources.
@@ -93,21 +93,6 @@ var Program = Base.extend({
                 proc: invalidSources[0].procName,
                 location: invalidSources[0].location
             });
-        }
-
-        // If type is set, ensure that all sources are the specified type.
-        if (type) {
-            for (var j = 0; j < sources.length; j++) {
-                var sourceType = sources[j].sourceType;
-
-                if (sourceType !== 'any' && sourceType !== type) {
-                    throw errors.compileError('RT-WRONG-PROC-TYPE', {
-                        proc: sources[j].procName,
-                        type: type,
-                        location: sources[j].location
-                    });
-                }
-            }
         }
     },
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -123,7 +123,7 @@ var Program = Base.extend({
 
     get_sources: function() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
-            return (proc.sourceType);
+            return (proc instanceof Juttle.proc.source);
         });
     },
 

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -20,7 +20,6 @@ var INFO = {
 
 var emit = source.extend({
     initialize: function(options) {
-        this.sourceType = 'batch';
         var NOW = this.program.now;
         var unknown = _.difference(_.keys(options),
                                    _.union(_.keys(INFO.options), _.keys(INFO._options)));

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -141,8 +141,6 @@ Juttle.proc.subscribe = Juttle.proc.source.extend({
     // by connect(), but pub will be calling its consume().
     // stick with the old gods here.
     initialize: function(options) {
-        this.sourceType = 'any';
-
         this.channel = this.channelName(options);
         var targets = Juttle.hub[this.channel];
         if (targets === undefined) {

--- a/test/runtime/test-adapter.js
+++ b/test/runtime/test-adapter.js
@@ -11,7 +11,6 @@ var store = {};
 
 function TestAdapter(config, Juttle) {
     var Read = Juttle.proc.source.extend({
-        sourceType: 'batch',
         procName: 'read-test',
 
         initialize: function(options, params) {


### PR DESCRIPTION
Remove `sourceType` property on procs and instead rely on `Juttle.proc.source` being in the inheritance chain.

Refs: https://github.com/juttle/juttle/issues/54

Corresponding PRs for adapters will reference this one.