### PR TITLE
cli: fix 'undefined' in view warning output

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -175,7 +175,7 @@ function perform_run(options) {
         });
 
         program.events.on('warning', function(msg, warn) {
-            console.warn(warn, msg);
+            console.warn(msg);
         });
 
         view_mgr.events.on('error', function(msg, err) {
@@ -183,7 +183,7 @@ function perform_run(options) {
         });
 
         view_mgr.events.on('warning', function(msg, warn) {
-            console.warn(warn, msg);
+            console.warn(msg);
         });
 
         // Start the program.

--- a/lib/views/file.js
+++ b/lib/views/file.js
@@ -4,6 +4,8 @@ var fs = require('fs');
 // A file view is a text view with no arguments other than
 // format 'json' and writing to a file.
 var FileView = TextView.extend({
+    name: 'file',
+
     initialize: function(options) {
         this.options.format = 'json';
         this.filename = options.filename;

--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -5,6 +5,8 @@ var View = require('./view.js');
 var utils = require('../runtime').utils;
 
 var TableView = View.extend({
+    name: 'table',
+
     initialize: function(options) {
 
         this.options = _.defaults({}, options, {

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -5,6 +5,8 @@ var View = require('./view.js');
 var utils = require('../runtime').utils;
 
 var TextView = View.extend({
+    name: 'text',
+
     initialize: function(options) {
 
         this.options = _.clone(options);

--- a/lib/views/view.js
+++ b/lib/views/view.js
@@ -10,7 +10,6 @@ var events = require('backbone').Events;
 // class to handle streams of data from juttle programs.
 var View = Base.extend({
     initialize: function(options, env) {
-        this.name = options.name;
         this.events = _.extend({}, events);
         this.fstream = options.fstream ? options.fstream : process.stdout;
         this.env = env;
@@ -19,13 +18,13 @@ var View = Base.extend({
     warn: function(msg) {
         var self = this;
 
-        self.events.trigger('warning', "View " + self.name + ": " + msg);
+        self.events.trigger('warning', 'view ' + self.name + ': ' + msg);
     },
 
     error: function(msg) {
         var self = this;
 
-        self.events.trigger('error', "View " + self.name + ": " + msg);
+        self.events.trigger('error', 'view ' + self.name + ': ' + msg);
     },
 
     // The subclass should override one or more of these callbacks to

--- a/test/views/table.spec.js
+++ b/test/views/table.spec.js
@@ -139,4 +139,36 @@ describe('table view', function () {
             '└───────────────────────────────────┘',
             '' ]);
     });
+
+    it('warns if subsequent points arrive late with different keys', function() {
+        var stream = new streams.WritableStream();
+        var table = new TableView({
+            fstream: stream,
+            progressive: true
+        },{
+            color: false
+        });
+
+        var warnings = [];
+        table.events.on('warning', function(msg) {
+            warnings.push(msg);
+        });
+
+        table.consume([{key1: 'val1'}]);
+        table.consume([{key2: 'val2'}]);
+        table.eof();
+
+        var lines = stream.toString().split('\n');
+        expect(lines).to.deep.equal([
+            '┌──────────┐',
+            '│ key1     │',
+            '├──────────┤',
+            '│ val1     │',
+            '├──────────┤',
+            '│          │',
+            '└──────────┘',
+            ''
+        ]);
+        expect(warnings).to.deep.equal(['view table: Ignoring new point key(s) "key2"']);
+    });
 });


### PR DESCRIPTION
Previously if a warning was emitted by a view, the message would be
output as something like:

    undefined 'Sink undefined: Ignoring new point key(s) "key2"'

Fix the two `undefined` above by tiding the way the CLI prints out
warning events and by adding a static name property to each view
instead of expecting it to be passed into the options in the constructor.

Partially addresses #41 