### PR TITLE
finish renaming sink to view

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -84,8 +84,8 @@ var NODE_CHILDREN = {
     ByList:                   ['elements'],
     SortByList:               ['elements'],
     SortField:                ['expr'],
-    Sink:                     ['options'],
-    SinkOption:               ['expr'],
+    View:                     ['options'],
+    ViewOption:               ['expr'],
     InputOption:              ['expr'],
 
     /* Statements */

--- a/lib/compiler/autocompleter.js
+++ b/lib/compiler/autocompleter.js
@@ -38,8 +38,8 @@ var Autocompleter = Base.extend({
     initialize: function(options) {
         options = options || {};
 
-        var sinks = options.sinks || {};
-        this._procs = _.extend(_.clone(PROCS), sinks);
+        var views = options.views || {};
+        this._procs = _.extend(_.clone(PROCS), views);
     },
 
     getCompletions: function(juttle, pos) {

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -369,7 +369,7 @@ var Build = CodeGenerator.extend({
             PutProc: this.gen_PutProc,
             ReadProc: this.gen_ReadProc,
             ReduceProc: this.gen_ReduceProc,
-            Sink: this.gen_Sink,
+            View: this.gen_View,
             SortProc: this.gen_SortProc,
             WriteProc: this.gen_WriteProc
         };
@@ -486,7 +486,7 @@ var Build = CodeGenerator.extend({
     gen_SortProc: function(ast) {
         return this.gen_proc(ast);
     },
-    gen_Sink: function(ast) {
+    gen_View: function(ast) {
         return this.gen_proc(ast);
     },
     gen_CalendarExpression: function(ast) {

--- a/lib/compiler/flowgraph/implicit_views.js
+++ b/lib/compiler/flowgraph/implicit_views.js
@@ -11,7 +11,7 @@ function implicit_views(default_sink) {
         var table;
         _.each(leaves, function(node) {
             if (!is_sink(node)) {
-                table = g.add_node('Sink', default_sink);
+                table = g.add_node('View', default_sink);
                 g.add_edge(node, table);
             }
         });

--- a/lib/compiler/flowgraph/implicit_views.js
+++ b/lib/compiler/flowgraph/implicit_views.js
@@ -3,15 +3,15 @@ var is_sink = require('../graph-builder').is_sink;
 
 // Generate a graph builder that adds an implicit sink of the given type
 // to any branches of the graph that don't already end in a sink.
-function implicit_views(default_sink) {
-    default_sink = default_sink || "table";
+function implicit_views(default_view) {
+    default_view = default_view || "table";
 
     return function implicit_views(g) {
         var leaves = g.get_leaves();
         var table;
         _.each(leaves, function(node) {
             if (!is_sink(node)) {
-                table = g.add_node('View', default_sink);
+                table = g.add_node('View', default_view);
                 g.add_edge(node, table);
             }
         });

--- a/lib/compiler/flowgraph/program_stats.js
+++ b/lib/compiler/flowgraph/program_stats.js
@@ -109,7 +109,7 @@ function proc_stats(g) {
     return stats;
 }
 
-function sink_stats(g) {
+function view_stats(g) {
     var stats = {};
     var nodes = g.get_nodes();
     _.each(nodes, function (node) {
@@ -171,8 +171,8 @@ function extract_program_stats(prog) {
     stats.functions = function_stats(prog);
     stats.procs = proc_stats(prog);
     stats.proc_total = count_procs(stats.procs);
-    stats.sinks = sink_stats(prog);
-    stats.sink_total = count_procs(stats.sinks);
+    stats.views = view_stats(prog);
+    stats.view_total = count_procs(stats.views);
     stats.subs = sub_stats(prog);
     stats.imports = import_stats(prog);
     return stats;

--- a/lib/compiler/flowgraph/program_stats.js
+++ b/lib/compiler/flowgraph/program_stats.js
@@ -96,7 +96,7 @@ function proc_stats(g) {
     var stats = {};
     var nodes = g.get_nodes();
     _.each(nodes, function (node) {
-        if (node.type === 'Sink') {
+        if (node.type === 'View') {
             return;
         }
         var name = proc_name(node);
@@ -113,7 +113,7 @@ function sink_stats(g) {
     var stats = {};
     var nodes = g.get_nodes();
     _.each(nodes, function (node) {
-        if (node.type !== 'Sink') {
+        if (node.type !== 'View') {
             return;
         }
         if (!_.has(stats, node.name)) {

--- a/lib/compiler/flowgraph/views_sourceinfo.js
+++ b/lib/compiler/flowgraph/views_sourceinfo.js
@@ -15,7 +15,7 @@ function upstream_reads(g, node) {
 
 
 function views_sourceinfo(g) {
-    var views = _.where(g.get_leaves(), {type: 'Sink'});
+    var views = _.where(g.get_leaves(), {type: 'View'});
     _.each(views, function(view) {
         var reads = upstream_reads(g, view);
         var time_bounds = _.map(reads, function(read) {

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -11,11 +11,11 @@ function proc_name(node) {
 }
 
 function is_source(node) {
-    return node.type !== 'Sink' && Juttle.proc[proc_name(node)].info.type === 'source';
+    return node.type !== 'View' && Juttle.proc[proc_name(node)].info.type === 'source';
 }
 
 function is_sink(node) {
-    return node.type === 'Sink' || Juttle.proc[proc_name(node)].info.type === 'sink';
+    return node.type === 'View' || Juttle.proc[proc_name(node)].info.type === 'sink';
 }
 
 function value_ast(result) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -72,10 +72,10 @@ var GraphCompiler = CodeGenerator.extend({
         // compiled world and associated runtime.
         //
         code = '(function() {\n';
-        code += 'var sinks=[];\n';
+        code += 'var views=[];\n';
         code += 'var program = {};\n';
         code += body;
-        code += 'return { program: program, now: program.now, sinks: sinks,';
+        code += 'return { program: program, now: program.now, views: views,';
         code += 'graph: ' + entry + ' };\n';
         code += '})();\n';
         return code;
@@ -464,7 +464,7 @@ var GraphCompiler = CodeGenerator.extend({
         // and AST.
         var proc = this.gen_proc(ast, 'view', '{name: "'+ast.name+'"}');
 
-        this.emit('sinks.push({name: "' + ast.name + '",' +
+        this.emit('views.push({name: "' + ast.name + '",' +
                   'channel: ' + proc + '.channel,' +
                   'location: ' + JSON.stringify(ast.location) + '});\n');
 

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -462,7 +462,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_View: function(ast) {
         // silly special case for ast.name due to sink's special-case parsing
         // and AST.
-        var proc = this.gen_proc(ast, 'clientview', '{name: "'+ast.name+'"}');
+        var proc = this.gen_proc(ast, 'view', '{name: "'+ast.name+'"}');
 
         this.emit('sinks.push({name: "' + ast.name + '",' +
                   'channel: ' + proc + '.channel,' +

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -327,7 +327,7 @@ var GraphCompiler = CodeGenerator.extend({
             PutProc: this.gen_PutProc,
             ReadProc: this.gen_ReadProc,
             ReduceProc: this.gen_ReduceProc,
-            Sink: this.gen_Sink,
+            View: this.gen_View,
             SortProc: this.gen_SortProc,
             WriteProc: this.gen_WriteProc
         };
@@ -459,7 +459,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_SortProc: function(ast) {
         return this.gen_proc(ast, 'sort');
     },
-    gen_Sink: function(ast) {
+    gen_View: function(ast) {
         // silly special case for ast.name due to sink's special-case parsing
         // and AST.
         var proc = this.gen_proc(ast, 'clientview', '{name: "'+ast.name+'"}');

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -611,7 +611,7 @@ var SemanticPass = Base.extend({
             ReadProc: this.sa_ReadProc,
             ReduceProc: this.sa_ReduceProc,
             SingleArgProc: this.sa_SingleArgProc,
-            Sink: this.sa_Sink,
+            View: this.sa_View,
             SortProc: this.sa_SortProc,
             WriteProc: this.sa_WriteProc
         };
@@ -894,7 +894,7 @@ var SemanticPass = Base.extend({
     sa_SortProc: function(ast) {
         return this.sa_option_proc(ast, ['groupby', 'columns']);
     },
-    sa_Sink: function(ast) {
+    sa_View: function(ast) {
         // The "coerce_var" option needs to be set explicitly so that sa_ByList
         // doesn't override.
         var opts = {

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1720,7 +1720,7 @@ ProcStatement
     / OptionOnlyProc
     / SingleArgProc
     / SingleArgByProc
-    / Sink
+    / View
     / FunctionProc
     / '(' __ graph:ParallelGraph (__ ';')? __ ')' { return graph; }
 
@@ -1818,16 +1818,16 @@ ReduceItem
           });
       }
 
-Sink
-    = ACProcStart ViewToken ACProcEnd __ name:Identifier options:SinkOption* {
-          return createNode('Sink', location(), {
+View
+    = ACProcStart ViewToken ACProcEnd __ name:Identifier options:ViewOption* {
+          return createNode('View', location(), {
               name: name,
               options: options
           });
       }
 
-SinkOption
-    = ___ name:SinkOptionName ACOptionValueStart ___ ACOptionValueEnd value:ByList {
+ViewOption
+    = ___ name:ViewOptionName ACOptionValueStart ___ ACOptionValueEnd value:ByList {
         if (value.elements.length === 1) {
             // If the list has only 1 element, pass the element itself.
             value = value.elements[0];
@@ -1838,13 +1838,13 @@ SinkOption
           currentProcOptions[currentProcOptions.length - 1].value = value;
         }
 
-        return createNode('SinkOption', location(), {
+        return createNode('ViewOption', location(), {
             id: name,
             expr: value
         });
     }
 
-SinkOptionName 'option'
+ViewOptionName 'option'
     = ACOptionNameStart '-' start:Identifier parts:('.' Identifier)* ACOptionNameEnd {
           var result = start;
           for (var i=0; i<parts.length; i++) {

--- a/lib/program.js
+++ b/lib/program.js
@@ -146,7 +146,7 @@ var Program = Base.extend({
     get_views: function() {
         var allSinks = this.get_sinks();
         return _.filter(allSinks, function(sink) {
-            return sink.procName === 'clientview';
+            return sink.procName === 'view';
         })
         .map(function(view) {
             return {name: view.name, channel: view.channel, options: view.options, location: view.location};

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -70,7 +70,7 @@ Juttle.proc = {
     fanin: fanin
 };
 
-// base class for all sinks (both client-side and adapters)
+// base class for all sinks (both client-side views and adapter write procs)
 Juttle.proc.sink = fanin.extend({
     initialize: function(options, params) {
         // To indicate when the sink is finished, stash a completion trigger in

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -241,7 +241,7 @@ var SINK_INFO = {
 
 // XXX/demmer this should not inherit from publish but until we convert the
 // clients
-Juttle.proc.clientview = Juttle.proc.publish.extend({
+Juttle.proc.view = Juttle.proc.publish.extend({
     initialize: function(options, params) {
         this.name = params.name;
         this.options = convert_options(options);
@@ -249,7 +249,7 @@ Juttle.proc.clientview = Juttle.proc.publish.extend({
         this.channel = chan;
     },
 
-    procName: 'clientview',
+    procName: 'view',
 
     // When views get points/marks/ticks, they emit events on
     // the related program object. Program users will subscribe for

--- a/test/compiler/autocompleter.spec.js
+++ b/test/compiler/autocompleter.spec.js
@@ -10,7 +10,7 @@ describe('Autocompleter', function() {
             autocompleter = new Autocompleter({
                 // Deliberately in reverse-alphabetical order (to exercise
                 // sorting code in the autocompleter).
-                sinks: {
+                views: {
                     '@timechart': {
                         type: 'sink',
                         options: {}

--- a/test/compiler/program_stats.spec.js
+++ b/test/compiler/program_stats.spec.js
@@ -33,10 +33,10 @@ describe('Program instrumentation', function() {
             read: 1
         },
         proc_total: 1,
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         reducers: {},
         reducer_total: 0,
         functions: {'user-defined': 0},
@@ -54,10 +54,10 @@ describe('Program instrumentation', function() {
             read: 1
         },
         proc_total: 2,
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         reducers: {},
         reducer_total: 0,
         functions: {'user-defined': 0},
@@ -70,10 +70,10 @@ describe('Program instrumentation', function() {
         input_total: 0,
         source_total: 1,
         sources: [{type: 'read', from: from, to: null, last: null}],
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         procs: {
             read: 1
         },
@@ -89,10 +89,10 @@ describe('Program instrumentation', function() {
         input_total: 0,
         source_total: 1,
         sources: [{type: 'read', from: from, to: to, last: null}],
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         procs: {
             read: 1
         },
@@ -112,10 +112,10 @@ describe('Program instrumentation', function() {
             read: 1
         },
         proc_total: 1,
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         reducer_total: 0,
         reducers: {},
         functions: {'user-defined': 0},
@@ -130,10 +130,10 @@ describe('Program instrumentation', function() {
             {type: 'read', from: from, to: null, last: null},
             {type: 'read', from: null, to: null, last: last}
         ],
-        sinks: {
+        views: {
             view: 2
         },
-        sink_total: 2,
+        view_total: 2,
         procs: {
             read: 2
         },
@@ -152,10 +152,10 @@ describe('Program instrumentation', function() {
             {type: 'read', from: from, to: null, last: null},
             {type: 'read', from: null, to: null, last: last}
         ],
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         procs: {
             read: 2
         },
@@ -172,10 +172,10 @@ describe('Program instrumentation', function() {
              input_total: 0,
              source_total: 1,
              sources: [{type: 'read', from: null, to: null, last: null}],
-             sinks: {
+             views: {
                  view: 1
              },
-             sink_total: 1,
+             view_total: 1,
              procs: {
                  read: 1,
                  reduce: 1
@@ -201,11 +201,11 @@ describe('Program instrumentation', function() {
              input_total: 0,
              source_total: 1,
              sources: [{type: 'read', from: null, to: null, last: null}],
-             sinks: {
+             views: {
                  table: 1,
                  view: 1
              },
-             sink_total: 2,
+             view_total: 2,
              procs: {
                  read: 1,
                  reduce: 2
@@ -227,10 +227,10 @@ describe('Program instrumentation', function() {
              input_total: 0,
              source_total: 1,
              sources: [{type: 'emit'}],
-             sinks: {
+             views: {
                  view: 1
              },
-             sink_total: 1,
+             view_total: 1,
              procs: {
                  emit: 1,
                  put: 1
@@ -248,10 +248,10 @@ describe('Program instrumentation', function() {
         input_total: 0,
         source_total: 1,
         sources: [{type: 'emit'}],
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         procs: {
             emit: 1
         },
@@ -271,10 +271,10 @@ describe('Program instrumentation', function() {
         input_total: 2,
         source_total: 1,
         sources: [{type: 'emit'}],
-        sinks: {
+        views: {
             view: 1
         },
-        sink_total: 1,
+        view_total: 1,
         procs: {
             emit: 1
         },

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -95,7 +95,7 @@ describe('adapter API tests', function () {
             expect(first_node.procName).equal('read-test');
 
             var second_node = first_node.out_.default[0].proc;
-            expect(second_node.procName).equal('clientview');
+            expect(second_node.procName).equal('view');
             expect(result.sinks.table).deep.equal([{count: 1}]);
             expect(result.prog.graph.count).equal(true);
         });
@@ -122,7 +122,7 @@ describe('adapter API tests', function () {
             expect(first_node.procName).equal('read-test');
 
             var second_node = first_node.out_.default[0].proc;
-            expect(second_node.procName).equal('clientview');
+            expect(second_node.procName).equal('view');
 
             expect(result.sinks.table).deep.equal([{count: 1}]);
             expect(result.prog.graph.limit).equal(1);

--- a/test/runtime/deactivate.spec.js
+++ b/test/runtime/deactivate.spec.js
@@ -24,14 +24,14 @@ describe('Program deactivation', function() {
         var prog = "emit -limit 1 -from :-1m: | view result";
         return check_juttle({program: prog}).then(function(res) {
             res.prog.deactivate();
-            expect(teardowns.sort()).to.deep.equal(["clientview", "emit"]);
+            expect(teardowns.sort()).to.deep.equal(["emit", "view"]);
         });
     });
     it('teardown() is called on all procs (complicated program)', function() {
         var prog = "(emit -limit 1 -from :-1m: ; emit -limit 1 -from :-1m:)  | (put a = 1; put b = 1)| (view result1; view result2)";
         return check_juttle({program: prog}).then(function(res) {
             res.prog.deactivate();
-            expect(teardowns.sort()).to.deep.equal(["clientview", "clientview", "emit", "emit", "put", "put"]);
+            expect(teardowns.sort()).to.deep.equal(["emit", "emit", "put", "put", "view", "view"]);
         });
     });
 });

--- a/test/runtime/graph-api.spec.js
+++ b/test/runtime/graph-api.spec.js
@@ -179,7 +179,7 @@ describe('Graph API', function() {
         it('A | B; C | D, add edge D-B to build (A; C|D)|B', function() {
             var program = compile('emit -from Date.new(0) -limit 1 | view result; emit -from :0: -limit 1 | put a = 1;', function(graph) {
                 var put = _.findWhere(graph.get_leaves(), {type: 'PutProc'});
-                var sink = _.findWhere(graph.get_leaves(), {type: 'Sink'});
+                var sink = _.findWhere(graph.get_leaves(), {type: 'View'});
                 graph.add_edge(put, sink);
             });
             return run_juttle(program).then(function(res) {
@@ -194,10 +194,10 @@ describe('Graph API', function() {
         it('(A;B)|C, remove edge B-C to build A | C ; B ', function() {
             var program = compile('(emit -from Date.new(0) -limit 1 ; emit -from Date.new(0) -limit 1 | put a = 1)| view result ', function(graph) {
                 var put = _.findWhere(graph.get_nodes(), {type: 'PutProc'});
-                var sink = _.findWhere(graph.get_leaves(), {type: 'Sink'});
+                var sink = _.findWhere(graph.get_leaves(), {type: 'View'});
                 graph.remove_edge(put, sink);
                 // add a new sink just so that it doesn't complain about
-                graph.add_edge(put, graph.add_node("Sink", "newSink"));
+                graph.add_edge(put, graph.add_node("View", "newView"));
             });
             return run_juttle(program).then(function(res) {
                 expect(res.sinks.result.sort()).deep.equal([

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -197,7 +197,7 @@ function run_juttle(prog, options) {
 
             // non-visual sinks don't implement pub/sub channel but instead have
             // a done() promise to indicate when they are at eof.
-            if (sink.procName !== 'clientview') {
+            if (sink.procName !== 'view') {
                 return sink.isDone
                 .then(function() {
                     return sink;

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -66,7 +66,7 @@ function get_times(pts) {
 })();
 
 
-var TestSink = Juttle.proc.subscribe.extend({
+var TestView = Juttle.proc.subscribe.extend({
     initialize: function(options) {
         this.sink = options.sink;
         this.eofs = options.eofs || 1;
@@ -205,7 +205,7 @@ function run_juttle(prog, options) {
             }
 
             var cur_options = _.extend({ sink: sink }, sink_options[sink.name]);
-            var sink_handler = new TestSink(cur_options, {}, null, null, prog);
+            var sink_handler = new TestView(cur_options, {}, null, null, prog);
 
             sink_handlers.push(sink_handler);
 


### PR DESCRIPTION
Another pass through the compiler to replace instances of 'sink' with 'view' as appropriate.
Details in the specific commits.

Closes #24 

Note that outrigger will need to be updated once this merges.
