### PR TITLE
enable filter to operate on multiple fields

### DIFF
--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -62,7 +62,20 @@ var FilterChecker = ASTVisitor.extend({
             });
         }
 
-        if (!this._isAllowedValueNodeForOperator(nodes.value, node.expression.operator)) {
+        if (nodes.field2 && !this._isValidFieldNode(nodes.field)) {
+            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
+                operator: '*',
+                type: this._nodeTypeDisplayName(nodes.field.expression.type),
+                // This should really point to nodes.field.expression.location
+                // but nodes.field won't have the "location" property set
+                // because it is rebuilt from a JavaScript value created at the
+                // build phase. This is yet another place where our
+                // double-compilation architecture hurts us.
+                location: node.expression.location
+            });
+        }
+
+        if (nodes.value && !this._isAllowedValueNodeForOperator(nodes.value, node.expression.operator)) {
             throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
                 operator: node.expression.operator,
                 type: this._nodeTypeDisplayName(nodes.value.type),
@@ -94,7 +107,12 @@ var FilterChecker = ASTVisitor.extend({
     },
 
     _getFieldAndValueNodes: function(node) {
-        if (this._isSimpleFieldReference(node.left)) {
+        if (this.options.allowFieldComparisons &&
+            this._isSimpleFieldReference(node.left) &&
+            this._isSimpleFieldReference(node.right))
+        {
+            return { field: node.left, field2: node.right };
+        } else if (this._isSimpleFieldReference(node.left)) {
             return { field: node.left, value: node.right };
         } else if (this._isSimpleFieldReference(node.right)) {
             return { field: node.right, value: node.left };

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -436,7 +436,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_FilterProc: function(ast) {
         var checker = new FilterChecker();
-        checker.check(ast.filter, { now: this.now });
+        checker.check(ast.filter, { now: this.now, allowFieldComparisons: true });
 
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -791,48 +791,6 @@ var SemanticPass = Base.extend({
     sa_ExpressionFilterTerm: function(ast) {
         ast.expression = this.sa_expr(ast.expression, { context: 'filter', coerce_var: 'field' });
 
-        var left_is_field  = this.is_simple_field_ref(ast.expression.left);
-        var right_is_field = this.is_simple_field_ref(ast.expression.right);
-        if (ast.expression.operator === '=~' || ast.expression.operator === '!~') {
-            if (left_is_field) {
-                if (!ast.expression.right.d) {
-                    throw errors.compileError('RT-ET-BAD-OPERAND', {
-                        operator: ast.expression.operator,
-                        side: 'RHS',
-                        location: ast.location
-                    });
-                }
-            } else {
-                throw errors.compileError('RT-ET-BAD-FORMAT-1', {
-                    operator: ast.expression.operator,
-                    location: ast.location
-                });
-            }
-        } else {
-            if (left_is_field) {
-                if (!ast.expression.right.d) {
-                    throw errors.compileError('RT-ET-BAD-OPERAND', {
-                        operator: ast.expression.operator,
-                        side: 'RHS',
-                        location: ast.location
-                    });
-                }
-            } else if (right_is_field) {
-                if (!ast.expression.left.d) {
-                    throw errors.compileError('RT-ET-BAD-OPERAND', {
-                        operator: ast.expression.operator,
-                        side: 'LHS',
-                        location: ast.location
-                    });
-                }
-            } else {
-                throw errors.compileError('RT-ET-BAD-FORMAT-2', {
-                    operator: ast.expression.operator,
-                    location: ast.location
-                });
-            }
-        }
-
         // will be carried in AST form to the "read" proc implementation
         ast.d = false;
         return ast;


### PR DESCRIPTION
This just a work-in-progress to enable comparisons between fields
as requested by @mccanne.

Remove the semantic pass checks that ensure that filter expressions
only ever compare a field to a compile-time expression.

Add an option `allowFieldComparisons` to the filter-checker that
allows an expression of the form `field1 == field2`.

