### PR TITLE
Grammar: Fix outdated comment

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1191,8 +1191,8 @@ BitwiseORExpression
       }
 
 // Restricts BitwiseORExpression to make sure that "|" followed by an identifier
-// or a sink name is recognized as a proc, not as part of BitwiseORExpression.
-// This means that e.g.
+// is recognized as a proc, not as part of BitwiseORExpression. This means that
+// e.g.
 //
 //     put a = 1 | unbatch
 //


### PR DESCRIPTION
There are no sink names as a separate concept in the grammar anymore.

Discovered during review of #115.