### PR TITLE
Build: Do not return anything from generated build function

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -74,11 +74,9 @@ var Build = CodeGenerator.extend({
         // compiled world and associated runtime.
         //
         code = '(function(builder) {\n';
-        code += 'var sinks=[];\n';
         code += body;
         code += 'builder.record_stats(' + JSON.stringify(ast.stats) + ');';
-        code += 'return { sinks: sinks,';
-        code += 'graph: ' + ast.uname + '() };\n';
+        code += ast.uname + '();\n';
         code += '});\n';
         return code;
     },


### PR DESCRIPTION
The result was unused. Everything important is collected in `GraphBuilder`.

Discovered during review of #115.