### PR TITLE
Reduce on nested

### DIFF
--- a/lib/runtime/groups.js
+++ b/lib/runtime/groups.js
@@ -144,7 +144,7 @@ var Groups = Base.extend({
         for (var colno = 0; colno < by.length - 1; ++colno) {
             var currentField = pt[by[colno]];
 
-            index = index[values.valueOf(currentField)];
+            index = index[values.inspect(currentField)];
 
             if (index === undefined) {
                 return undefined;
@@ -152,8 +152,9 @@ var Groups = Base.extend({
         }
 
         var lastField = pt[by[by.length - 1]];
-        return index[values.valueOf(lastField)];
+        return index[values.inspect(lastField)];
     },
+
     _insert_key: function(pt) {
         var index = this.index;
         var next_index;
@@ -163,16 +164,16 @@ var Groups = Base.extend({
         for (colno = 0; colno < n - 1; ++colno) {
             val = pt[by[colno]];
             vals[colno] = val;
-            next_index = index[values.valueOf(val)];
+            next_index = index[values.inspect(val)];
             if (next_index === undefined) {
-                index[val] = next_index = {};
+                index[values.inspect(val)] = next_index = {};
             }
             index = next_index;
         }
         keyID = this.nkeys++;
         val = pt[by[n - 1]];
         vals[n - 1] = val;
-        index[values.valueOf(val)] = keyID;
+        index[values.inspect(val)] = keyID;
         this.key_vals[keyID] = vals;
         return keyID;
     },

--- a/lib/runtime/reducers.js
+++ b/lib/runtime/reducers.js
@@ -418,7 +418,7 @@ reducers.count_unique = {
             },
             update: function(pt) {
                 if (pt[field] !== undefined) {
-                    uniques[values.valueOf(pt[field])] = true;
+                    uniques[values.inspect(pt[field])] = true;
                 }
             }
         };

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -68,10 +68,6 @@ var values = {
         throw new Error('Invalid Juttle value: ' + value + '.');
     },
 
-    valueOf: function(v) {
-        return (values.isDate(v) || values.isDuration(v)) ? v.valueOf() : v;
-    },
-
     // Returns a display name for a Juttle type name (for use in error messages,
     // etc.).
     typeDisplayName: function(name) {

--- a/test/runtime/procs.spec.js
+++ b/test/runtime/procs.spec.js
@@ -1179,6 +1179,43 @@ describe('Juttle procs tests', function() {
                 });
         });
 
+        it('reduce by non-scalar field', function() {
+            var program = 'emit -points ['
+                            + '{ "o": { "a": 1 }, "value": 5 },'
+                            + '{ "o": { "a": 2 }, "value": 3 },'
+                            + '{ "o": { "a": 1 }, "value": 2 }]'
+                            + ' | reduce sum(value) by o | view result';
+            return check_juttle({
+                program: program
+            })
+                .then(function (res) {
+                    var expected_value = [
+                        { o: { a: 1 }, sum: 7 },
+                        { o: { a: 2 }, sum: 3 },
+                    ];
+                    expect(res.sinks.result).to.deep.equal(expected_value);
+                });
+        });
+
+        it('reduce by non-scalar field and a scalar field', function() {
+            var program = 'emit -points ['
+                            + '{ "o": { "a": 1 }, "tag": 1, "value": 5 },'
+                            + '{ "o": { "a": 2 }, "tag": 2, "value": 3 },'
+                            + '{ "o": { "a": 1 }, "tag": 1, "value": 2 }]'
+                            + ' | reduce count() by o, tag | view result';
+            return check_juttle({
+                program: program
+            })
+                .then(function (res) {
+                    var expected_value = [
+                        { o: { a: 1 }, tag: 1, count: 2 },
+                        { o: { a: 2 }, tag: 2, count: 1 },
+                    ];
+                    expect(res.sinks.result).to.deep.equal(expected_value);
+                });
+        });
+
+
         it('reduce by time (from function returning array)', function() {
             var program = 'function getGroups() { return ["time"]; } emit  -hz 1000 -from Date.new(0)  -limit 6 | reduce by getGroups() | view result';
             return check_juttle({

--- a/test/runtime/specs/juttle-spec/reducers/count_unique-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/count_unique-reducer.spec.md
@@ -23,3 +23,13 @@ counts unique days
 
 ### Output
     { days: 5 }
+
+supports nested points
+---------------------------------------
+### Juttle
+    emit -points [ {"task":{"day":"Monday"}}, {"task":{"day":"Friday"}}, {"task":{"day":"Monday"}} ]
+    | reduce days = count_unique(task)
+    | view result
+
+### Output
+    { days: 2 }


### PR DESCRIPTION
Add support for grouping on and unique-counting of 'nested points', i.e. points whose fields can be objects or arrays.

This relies on serializing such fields using `values.inspect` into an unique string representation. This is not optimal from the memory consumption perspective, but should be OK as a first version.

Also, as the `values.valueOf` is now unused, remove it from the codebase.

refs: https://github.com/juttle/juttle/issues/55