### PR TITLE
Implement field-to-field comparisons in `filter`

### DIFF
--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -47,10 +47,24 @@ var FilterChecker = ASTVisitor.extend({
     },
 
     visitExpressionFilterTerm: function(node) {
-        var nodes = this._getFieldAndValueNodes(node.expression);
+        var expression = node.expression;
 
-        this._checkFieldNode(nodes.field, node.expression.location);
-        this._checkValueNode(nodes.value, node.expression.operator, node.expression.location);
+        if (this._isSimpleFieldReference(expression.left) && this._isSimpleFieldReference(expression.right)) {
+            if (this.options.allowFieldComparisons) {
+                this._checkFieldNode(expression.left, expression.location);
+                this._checkFieldNode(expression.right, expression.location);
+            } else {
+                throw new Error('At least one operand must not be a field reference.');
+            }
+        } else if (this._isSimpleFieldReference(expression.left)) {
+            this._checkFieldNode(expression.left, expression.location);
+            this._checkValueNode(expression.right, expression.operator, expression.location);
+        } else if (this._isSimpleFieldReference(expression.right)) {
+            this._checkValueNode(expression.left, expression.operator, expression.location);
+            this._checkFieldNode(expression.right, expression.location);
+        } else {
+            throw new Error('At least one operand must be a field reference.');
+        }
     },
 
     visitSimpleFilterTerm: function(node) {
@@ -67,16 +81,6 @@ var FilterChecker = ASTVisitor.extend({
                     type: this._nodeTypeDisplayName(node.expression.type),
                     location: node.location
                 });
-        }
-    },
-
-    _getFieldAndValueNodes: function(node) {
-        if (this._isSimpleFieldReference(node.left)) {
-            return { field: node.left, value: node.right };
-        } else if (this._isSimpleFieldReference(node.right)) {
-            return { field: node.right, value: node.left };
-        } else {
-            throw new Error('At least one operand must be a field reference.');
         }
     },
 

--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -49,31 +49,8 @@ var FilterChecker = ASTVisitor.extend({
     visitExpressionFilterTerm: function(node) {
         var nodes = this._getFieldAndValueNodes(node.expression);
 
-        if (!this._isValidFieldNode(nodes.field)) {
-            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
-                operator: '*',
-                type: this._nodeTypeDisplayName(nodes.field.expression.type),
-                // This should really point to nodes.field.expression.location
-                // but nodes.field won't have the "location" property set
-                // because it is rebuilt from a JavaScript value created at the
-                // build phase. This is yet another place where our
-                // double-compilation architecture hurts us.
-                location: node.expression.location
-            });
-        }
-
-        if (!this._isAllowedValueNodeForOperator(nodes.value, node.expression.operator)) {
-            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
-                operator: node.expression.operator,
-                type: this._nodeTypeDisplayName(nodes.value.type),
-                // This should really point to nodes.value.location but
-                // nodes.value won't have the "location" property set because it
-                // is rebuilt from a JavaScript value created at the build
-                // phase. This is yet another place where our double-compilation
-                // architecture hurts us.
-                location: node.expression.location
-            });
-        }
+        this._checkFieldNode(nodes.field, node.expression.location);
+        this._checkValueNode(nodes.value, node.expression.operator, node.expression.location);
     },
 
     visitSimpleFilterTerm: function(node) {
@@ -100,6 +77,36 @@ var FilterChecker = ASTVisitor.extend({
             return { field: node.right, value: node.left };
         } else {
             throw new Error('At least one operand must be a field reference.');
+        }
+    },
+
+    _checkFieldNode: function(node, location) {
+        if (!this._isValidFieldNode(node)) {
+            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
+                operator: '*',
+                type: this._nodeTypeDisplayName(node.expression.type),
+                // This should really point to node.expression.location but node
+                // won't have the "location" property set because it is rebuilt
+                // from a JavaScript value created at the build phase. This is
+                // yet another place where our double-compilation architecture
+                // hurts us.
+                location: location
+            });
+        }
+    },
+
+    _checkValueNode: function(node, operator, location) {
+        if (!this._isAllowedValueNodeForOperator(node, operator)) {
+            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
+                operator: operator,
+                type: this._nodeTypeDisplayName(node.type),
+                // This should really point to node.location but node won't have
+                // the "location" property set because it is rebuilt from a
+                // JavaScript value created at the build phase. This is yet
+                // another place where our double-compilation architecture hurts
+                // us.
+                location: location
+            });
         }
     },
 

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -397,7 +397,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_ReadProc: function(ast) {
         if (ast.filter) {
             var checker = new FilterChecker();
-            checker.check(ast.filter, { now: this.now });
+            checker.check(ast.filter, { now: this.now, allowFieldComparisons: false });
         }
 
         var params = {
@@ -436,7 +436,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_FilterProc: function(ast) {
         var checker = new FilterChecker();
-        checker.check(ast.filter, { now: this.now });
+        checker.check(ast.filter, { now: this.now, allowFieldComparisons: true });
 
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);
@@ -445,7 +445,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_SequenceProc: function(ast) {
         var checker = new FilterChecker();
-        _.each (ast.filters, function(filter) { checker.check(filter, { now: this.now });});
+        _.each (ast.filters, function(filter) { checker.check(filter, { now: this.now, allowFieldComparisons: true });});
 
 
         var filters = _.map(ast.filters, function(filter) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -788,7 +788,7 @@ var SemanticPass = Base.extend({
             && ast.operator === '*'
             && ast.expression.d;
     },
-    sa_ExpressionFilterTerm: function(ast) {
+    sa_ExpressionFilterTerm: function(ast, opts) {
         ast.expression = this.sa_expr(ast.expression, { context: 'filter', coerce_var: 'field' });
 
         var left_is_field  = this.is_simple_field_ref(ast.expression.left);
@@ -809,7 +809,9 @@ var SemanticPass = Base.extend({
                 });
             }
         } else {
-            if (left_is_field) {
+            if (left_is_field && right_is_field && opts.allow_field_comparisons) {
+                // OK, don't do anything.
+            } else if (left_is_field) {
                 if (!ast.expression.right.d) {
                     throw errors.compileError('RT-ET-BAD-OPERAND', {
                         operator: ast.expression.operator,
@@ -843,9 +845,9 @@ var SemanticPass = Base.extend({
         ast.d = false;
         return ast;
     },
-    sa_filter_proc: function(ast) {
+    sa_filter_proc: function(ast, opts) {
         if (ast.filter) {
-            ast.filter = this.sa_expr(ast.filter);
+            ast.filter = this.sa_expr(ast.filter, opts);
         }
         return this.sa_proc(ast);
     },
@@ -865,13 +867,13 @@ var SemanticPass = Base.extend({
         return this.sa_proc(ast);
     },
     sa_FilterProc: function(ast) {
-        return this.sa_filter_proc(ast);
+        return this.sa_filter_proc(ast, { allow_field_comparisons: true });
     },
     sa_SequenceProc: function(ast) {
         return this.sa_sequence_proc(ast);
     },
     sa_ReadProc: function(ast) {
-        return this.sa_filter_proc(ast);
+        return this.sa_filter_proc(ast, { allow_field_comparisons: false });
     },
     sa_option_proc: function(ast, options) {
         // Some procs have syntactical sugar for parameters (e.g. the limit in

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -128,6 +128,31 @@ Other operators: Produces an error for `stream-expression @ field`
 
   * The "<" operator: LHS operand must be computable at compile-time.
 
+Other operators: Allows `field @ field` in `filter`
+---------------------------------------------------
+
+### Juttle
+
+    emit -from :0: -limit 1
+    | put a = 5, b = 6
+    | filter a < b
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", a: 5, b: 6 }
+
+Other operators: Produces an error for `field @ field` in `read`
+----------------------------------------------------------------
+
+### Juttle
+
+    read test a < b
+
+### Errors
+
+  * The "<" operator: RHS operand must be computable at compile-time.
+
 The `=~` operator: Produces an error when RHS has an invalid type
 -----------------------------------------------------------------
 


### PR DESCRIPTION
Allow using equality operators (`=`, `==`, `!=`), comparison operators (`<`, `>`, `<=`, `>=`), and `in` to compare fields with other fields in `filter`.

Resolves #120.
