### PR TITLE
adapters: avoid loading multiple copies of juttle

### DIFF
--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -5,6 +5,7 @@
 var _ = require('underscore');
 var path = require('path');
 var errors = require('../errors');
+var Module = require('module');
 var logger = require('../logger').getLogger('juttle-adapter');
 
 var BUILTIN_ADAPTERS = ['file', 'http', 'stdio', 'stochastic'];
@@ -33,6 +34,59 @@ function get(type) {
     throw errors.compileError('RT-INVALID-ADAPTER', {type: type});
 }
 
+// Because adapters pull in the Juttle runtime via require('juttle/lib/xyz'),
+// there's a chance that loading an adapter may load another copy of the runtime
+// code, depending on the specifics of how the user installed the various node
+// modules.
+//
+// This causes problems if identical code is loaded from two different paths,
+// since `instanceof` will fail to match an object created from one copy to the
+// class definition in another copy.
+//
+// To avoid these issues, before loading the adapter, intercept the node.js module
+// loader and if there is a conflict for juttle, log a warning and rewrite any
+// require requests for `juttle/*` to be relative paths using the _current_ module
+// (i.e.  lib/runtime/adapters.js) as the context.
+//
+// This ensures that only one implementation will be loaded into memory.
+var moduleLoad = Module._load;
+var reportModuleConflict = _.once(function(origFilename, newFilename) {
+    var origPath = origFilename.replace(/juttle\/.*$/, 'juttle');
+    var newPath = newFilename.replace(/juttle\/.*$/, 'juttle');
+    var shouldLoad = process.env.JUTTLE_RESOLVE_ADAPTER_CONFLICT !== undefined;
+    if (shouldLoad) {
+        logger.warn('detected juttle module conflict:',
+                    'loading from', newPath, 'instead of', origPath);
+    } else {
+        logger.error('detected juttle module conflict:',
+                     'runtime in', newPath, 'but adapter resolved', origPath,
+                     '... exiting');
+        process.exit(1);
+    }
+});
+
+function startModuleLoadOverride() {
+    Module._load = function(request, parent, isMain) {
+        if (request.split('/')[0] === 'juttle') {
+            var origRequest = request;
+            var newRequest = request.replace(/^juttle/, '../..');
+            var origFilename = Module._resolveFilename(origRequest, parent);
+            var newFilename = Module._resolveFilename(newRequest, module);
+
+            if (origFilename !== newFilename) {
+                reportModuleConflict(origFilename, newFilename);
+                request = newRequest;
+                parent = module;
+            }
+        }
+        return moduleLoad(request, parent, isMain);
+    };
+}
+
+function stopModuleLoadOverride() {
+    Module._load = moduleLoad;
+}
+
 // Load the adapter of the given type.
 function loadAdapter(type) {
     var options = adapterConfig[type];
@@ -47,11 +101,15 @@ function loadAdapter(type) {
             module_path = path.resolve(process.cwd(), module_path);
         }
 
+        startModuleLoadOverride();
+
         var start = new Date();
         var init = require(module_path);
 
         var loaded = new Date();
         var adapter = init(options);
+
+        stopModuleLoadOverride();
 
         if (adapter.name !== type) {
             throw new Error('adapter name ', adapter.name, ' != type ', type);


### PR DESCRIPTION
Because adapters pull in the Juttle runtime via require('juttle/lib/xyz'),
there's a chance that loading an adapter may load another copy of the runtime
code, depending on the specifics of how the user installed the various node
modules.

This causes problems if identical code is loaded from two different paths,
since `instanceof` will fail to match an object created from one copy to the
class definition in another copy.

To avoid these issues, before loading the adapter, intercept the node.js
module loader and if there is a conflict for juttle, log an informative
error and exit the process.

If the environment variable JUTTLE_RESOLVE_ADAPTER_CONFLICT exists, then
log a warning and rewrite any require requests for `juttle/*` to be relative
paths using the _current_ module (i.e.  lib/runtime/adapters.js) as the
context.

This ensures that we don't have strange errors when multiple copies of the
runtime are loaded into the same process.

Fixes #130 