### PR TITLE
Replace checks for isSink with inheritance test

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -102,7 +102,7 @@ var Program = Base.extend({
 
         // Check that all terminal nodes are valid sinks.
         for (var i = 0; i < terminalNodes.length; i++) {
-            if (!terminalNodes[i].isSink) {
+            if (!(terminalNodes[i] instanceof Juttle.proc.sink)) {
                 throw errors.compileError('RT-PROC-CANNOT-END-FLOWGRAPH', {
                     proc: terminalNodes[i].procName,
                     location: terminalNodes[i].location
@@ -140,7 +140,7 @@ var Program = Base.extend({
 
     get_sinks: function() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
-            return (proc.isSink);
+            return (proc instanceof Juttle.proc.sink);
         });
     },
 

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -4,6 +4,7 @@ var Base = require('extendable-base');
 var errors = require('../../errors');
 
 var DEFAULT_OUT_NAME = 'default';
+var Juttle = require('./procs');
 
 var base = Base.extend({
     //
@@ -76,7 +77,7 @@ var base = Base.extend({
     //XXX need a disconnect method
     connect: function(proc) {
         var out;
-        if (this.isSink) {
+        if (this instanceof Juttle.proc.sink) {
             throw new Error ("connecting an output to a sink shouldn't happen!");
         }
         out = this.out();
@@ -91,7 +92,7 @@ var base = Base.extend({
     // shortcut should appear to come from (for eof/mark fanin accounting purposes).
     shortcut: function(target, logical_from, name) {
         var out;
-        if (this.isSink) {
+        if (this instanceof Juttle.proc.sink) {
             throw new Error ("connecting an output to a sink shouldn't happen!");
         }
         out = this.out(name);

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -6,7 +6,10 @@ var errors = require('../../errors');
 var reducers = require('../reducers').reducers;
 var adapters = require('../adapters');
 
-// juttle namespace
+// Juttle namespace
+//
+// Assign Juttle to module.exports early to satisfy/break a circular dependency
+// from base.js
 var Juttle = module.exports = {
     hub: {},
     droppedChanName: function(program_id) {

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -7,7 +7,7 @@ var reducers = require('../reducers').reducers;
 var adapters = require('../adapters');
 
 // juttle namespace
-var Juttle = {
+var Juttle = module.exports = {
     hub: {},
     droppedChanName: function(program_id) {
         return 'drops-' + program_id;
@@ -83,8 +83,6 @@ Juttle.proc.sink = fanin.extend({
             self.done = resolve;
         });
     },
-
-    isSink: true
 });
 
 var PUBLISH_INFO = {
@@ -95,7 +93,6 @@ var PUBLISH_INFO = {
 //XXX make sure mark works right between flowgraphs
 Juttle.proc.publish = Juttle.proc.sink.extend({
     initialize: function(options) {
-        this.isSink = true;
         this.channel = options.channel || '__DEFAULT';
     },
     procName: 'publish',
@@ -336,5 +333,3 @@ Juttle.extend_options = function(opts, location) {
 
     return options;
 };
-
-module.exports = Juttle;


### PR DESCRIPTION
All adapters and sinks descend from the Juttle.procs.sink class,
so tests whether a certain proc can rely on that, instead of explicitly
testing an `isSink` boolean flag.

Also fix circular dependency problem between base.js using Juttle.procs
and procs.js requiring base by assigning Juttle to module.exports early.