### PR TITLE
README: add a link to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ See the [docs](./docs) to learn more about [why juttle exists](./docs/index.md),
 get an [overview](./docs/concepts/overview.md) of the language, learn about the
 [dataflow features](./docs/concepts/dataflow.md) and how to [program in juttle](./docs/concepts/programming_constructs.md), and more.
 
+All documentation is also available from the [juttle documentation site](https://juttle.github.io/juttle).
+
 ## Installation
 
 Juttle requires [node.js](https://nodejs.org/) version 4.2 or later.


### PR DESCRIPTION
Although the docs are available within the github repository itself,
it seems useful to have a link to the external docs site generated
with mkthedocs.