### PR TITLE
Parser cleanups: Tidy up `parser.parse`

### DIFF
--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -167,7 +167,7 @@ function parseValue(source) {
  modules if `moduleResolver` is specified when `JuttleParser` is
  instantiated.
  */
-function parse(mainSource, options) {
+function parse(juttle, options) {
     function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return Promise.resolve({
@@ -192,14 +192,14 @@ function parse(mainSource, options) {
     options = processOptions(options, defaultResolver);
 
     var asts = {};
-    function parseModule(source, name) {
+    function parseModule(juttle, name) {
         var ast, imports;
         if (_.has(asts, name)) {
             // avoid infinite recursion on cyclic imports
             return Promise.resolve();
         }
         try {
-            ast = doParse(source, _.extend(options, { filename: name }));
+            ast = doParse(juttle, _.extend(options, { filename: name }));
         } catch(e) {
             return Promise.reject(e);
         }
@@ -215,7 +215,7 @@ function parse(mainSource, options) {
                 });
         });
     }
-    return parseModule(mainSource, 'main')
+    return parseModule(juttle, 'main')
         .then(function() {
             asts.main.modules = buildModuleDefs(asts);
             return asts.main;

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -179,6 +179,16 @@ function parse(mainSource, options) {
         }
     }
 
+    function resolveImport(import_) {
+        return options.moduleResolver(import_.modulename.value, import_.localname)
+            .catch(function(err) {
+                throw errors.compileError('RT-MODULE-NOT-FOUND', {
+                    module: import_.modulename.value,
+                    location: import_.location
+                });
+            });
+    }
+
     options = processOptions(options, defaultResolver);
 
     var asts = {};
@@ -199,13 +209,7 @@ function parse(mainSource, options) {
         _.each(imports, checkImportNode);
 
         return Promise.map(imports, function(imp) {
-            return options.moduleResolver(imp.modulename.value, imp.localname)
-                .catch(function(err) {
-                    throw errors.compileError('RT-MODULE-NOT-FOUND', {
-                        module: imp.modulename.value,
-                        location: imp.location
-                    });
-                })
+            return resolveImport(imp)
                 .then(function(res) {
                     return parse_(res.source, res.name);
                 });

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -192,30 +192,30 @@ function parse(juttle, options) {
     options = processOptions(options, defaultResolver);
 
     var asts = {};
-    function parseModule(juttle, name) {
+    function parseModule(module) {
         var ast, imports;
-        if (_.has(asts, name)) {
+        if (_.has(asts, module.name)) {
             // avoid infinite recursion on cyclic imports
             return Promise.resolve();
         }
         try {
-            ast = doParse(juttle, _.extend(options, { filename: name }));
+            ast = doParse(module.source, _.extend(options, { filename: module.name }));
         } catch(e) {
             return Promise.reject(e);
         }
 
-        asts[name] = ast;
+        asts[module.name] = ast;
         imports = extractImports(ast);
         _.each(imports, checkImportNode);
 
         return Promise.map(imports, function(imp) {
             return resolveImport(imp)
                 .then(function(res) {
-                    return parseModule(res.source, res.name);
+                    return parseModule(res);
                 });
         });
     }
-    return parseModule(juttle, 'main')
+    return parseModule({ source: juttle, name: 'main' })
         .then(function() {
             asts.main.modules = buildModuleDefs(asts);
             return asts.main;

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -193,27 +193,23 @@ function parse(juttle, options) {
 
     var asts = {};
     function parseModule(module) {
-        var ast, imports;
         if (_.has(asts, module.name)) {
             // avoid infinite recursion on cyclic imports
             return Promise.resolve();
         }
-        try {
-            ast = doParse(module.source, _.extend(options, { filename: module.name }));
-        } catch(e) {
-            return Promise.reject(e);
-        }
+        return Promise.resolve(module.source)
+            .then(function(juttle) {
+                return doParse(juttle, _.extend(options, { filename: module.name }));
+            })
+            .then(function(ast) {
+                asts[module.name] = ast;
 
-        asts[module.name] = ast;
-        imports = extractImports(ast);
-        _.each(imports, checkImportNode);
-
-        return Promise.map(imports, function(imp) {
-            return resolveImport(imp)
-                .then(function(res) {
-                    return parseModule(res);
-                });
-        });
+                return ast;
+            })
+            .then(extractImports)
+            .each(checkImportNode)
+            .map(resolveImport)
+            .each(parseModule);
     }
     return parseModule({ source: juttle, name: 'main' })
         .then(function() {

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -192,7 +192,7 @@ function parse(mainSource, options) {
     options = processOptions(options, defaultResolver);
 
     var asts = {};
-    function parse_(source, name) {
+    function parseModule(source, name) {
         var ast, imports;
         if (_.has(asts, name)) {
             // avoid infinite recursion on cyclic imports
@@ -211,11 +211,11 @@ function parse(mainSource, options) {
         return Promise.map(imports, function(imp) {
             return resolveImport(imp)
                 .then(function(res) {
-                    return parse_(res.source, res.name);
+                    return parseModule(res.source, res.name);
                 });
         });
     }
-    return parse_(mainSource, 'main')
+    return parseModule(mainSource, 'main')
         .then(function() {
             asts.main.modules = buildModuleDefs(asts);
             return asts.main;

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -168,6 +168,8 @@ function parseValue(source) {
  instantiated.
  */
 function parse(juttle, options) {
+    var asts = {};
+
     function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return Promise.resolve({
@@ -189,14 +191,12 @@ function parse(juttle, options) {
             });
     }
 
-    options = processOptions(options, defaultResolver);
-
-    var asts = {};
     function parseModule(module) {
         if (_.has(asts, module.name)) {
             // avoid infinite recursion on cyclic imports
             return Promise.resolve();
         }
+
         return Promise.resolve(module.source)
             .then(function(juttle) {
                 return doParse(juttle, _.extend(options, { filename: module.name }));
@@ -211,9 +211,13 @@ function parse(juttle, options) {
             .map(resolveImport)
             .each(parseModule);
     }
+
+    options = processOptions(options, defaultResolver);
+
     return parseModule({ source: juttle, name: 'main' })
         .then(function() {
             asts.main.modules = buildModuleDefs(asts);
+
             return asts.main;
         });
 }

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -192,8 +192,9 @@ function parse(juttle, options) {
     }
 
     function parseModule(module) {
+        // Don't break on cyclic imports and continue. There is a more proper
+        // check in the semantic pass.
         if (_.has(asts, module.name)) {
-            // avoid infinite recursion on cyclic imports
             return Promise.resolve();
         }
 


### PR DESCRIPTION
Small set of refactoring I started before Christmas already. The idea is to make `parser.parse` more understandable.

Once this PR gets in, I’ll follow with a similar set of changes for `parser.parseSync`.

Part of work on #140.