### PR TITLE
http adapter -rootPath option

### DIFF
--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -18,6 +18,7 @@ read http -url url
           -headers headers
           -body body
           -timeField timeField
+          -rootPath rootPath
           -includeHeaders true/false
 ```
 
@@ -28,6 +29,7 @@ Parameter         |             Description          | Required?
 `-headers`        | headers to attach to the HTTP request in the form `{ key1: "value1", ..., keyN: "valueN" }` | No; default: `{}`
 `-body`           | body to send with the HTTP requests | No; default: `{}`
 `-timeField`      | The name of the field to use as the time field <br><br>The specified field will be renamed to `time` in the body of the HTTP request. If the points already contain a field called `time`, that field is overwritten. This is useful when the source data contains a time field whose values are not valid time stamps.  | No; defaults to keeping the `time` field as is
+`-rootPath`       | When the incoming data is JSON, use the specified path into the incoming object (expressed as `field1.field2`) to emit points | No
 `-includeHeaders` | When set to true the headers from the response are appended to each of the points in the response | No; default: `false`
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
@@ -40,6 +42,15 @@ _Example_
 
 Example of how to hit the Github Issues API and retrieve all issues from the
 beginning of time on a specific repository in the correct chronological order:
+
+```
+{!docs/examples/adapters/http_github_open_issues.juttle!}
+```
+
+_Example_
+
+Example of how to hit the NPM download counts API and retrieve daily download
+counts for a given package. This uses the rootPath and timeField options:
 
 ```
 {!docs/examples/adapters/http_github_open_issues.juttle!}
@@ -72,4 +83,3 @@ Simple example of using the `http` adapter to create gists in GitHub:
 ```
 {!docs/examples/adapters/http_post_to_a_gist.juttle!}
 ```
-

--- a/docs/examples/adapters/http_npm_download_counts.juttle
+++ b/docs/examples/adapters/http_npm_download_counts.juttle
@@ -1,0 +1,13 @@
+/*
+ * Query daily download counts from npm
+ *
+ * Input parameters:
+ *
+ *  package: package name (i.e. 'juttle')
+ */
+
+input package: text -default 'juttle';
+
+read http -url 'https://api.npmjs.org/downloads/range/last-month/${package}'
+     -rootPath 'downloads' -timeField 'day'
+| view table

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -14,7 +14,8 @@ var Read = Juttle.proc.source.extend({
             'headers',
             'body',
             'timeField',
-            'includeHeaders'
+            'includeHeaders',
+            'rootPath'
         ];
 
         var unknown = _.difference(_.keys(options), allowed_options);
@@ -43,6 +44,7 @@ var Read = Juttle.proc.source.extend({
         this.body = options.body;
         this.timeField = options.timeField;
         this.includeHeaders = options.includeHeaders;
+        this.rootPath = options.rootPath;
 
         if (params.filter_ast) {
             throw this.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER', {
@@ -92,7 +94,7 @@ var Read = Juttle.proc.source.extend({
                 }
 
                 try {
-                    var parser =  parsers.getParser(format);
+                    var parser =  parsers.getParser(format, {rootPath: self.rootPath});
                     parser.parseStream(req, function(points) {
                         if (self.includeHeaders) {
                             _.each(points, function(point) {

--- a/lib/adapters/parsers/json.js
+++ b/lib/adapters/parsers/json.js
@@ -5,9 +5,13 @@ var oboe = require('oboe');
 var Promise = require('bluebird');
 
 module.exports = base.extend({
+    initialize: function(options) {
+        this.options = options || {};
+    },
 
     parseStream: function(stream, emit) {
         var self = this;
+        var rootPath = self.options.rootPath || '';
 
         return new Promise(function(resolve, reject) {
             var buffer = [];
@@ -18,10 +22,16 @@ module.exports = base.extend({
                     return;
                 }
 
-                // we only care for points that are at the most 1 path element
-                // deep and that path element happens to be an number which
-                // means we're handling a point within a top level JSON Array
-                if (path.length > 1 || (path.length === 1 && !_.isNumber(path[0]))) {
+                // we only care for points that match the expected root path or
+                // an element of the array at the given root path.
+                //
+                // to that end, remove any trailing numbers from the path to
+                // handle the case where the field is an array, then compare the
+                // path with the configured root.
+                if (_.isNumber(path[path.length - 1])) {
+                    path = path.slice(0, path.length - 1);
+                }
+                if (path.join('.') !== rootPath) {
                     return;
                 }
 

--- a/test/adapters/parsers/input/json/point_with_nested_array.json
+++ b/test/adapters/parsers/input/json/point_with_nested_array.json
@@ -4,5 +4,13 @@
         {"fizz1": "buzz"},
         {"fizz2": "buzz"},
         {"fizz3": "buzz"}
-    ]
+    ],
+    "bar": {
+        "baz": [
+            {"fizz1": "buzz", "contents": [1,2,3]},
+            {"fizz2": "buzz", "contents": [1,2,3]},
+            {"fizz3": "buzz", "contents": [1,2,3]}
+        ],
+        "bing": {"bang": "object", "bong": {"type": "object"}}
+    }
 }

--- a/test/adapters/parsers/json.spec.js
+++ b/test/adapters/parsers/json.spec.js
@@ -58,7 +58,7 @@ describe('parsers/json', function() {
         });
     });
 
-    it('can parse a JSON object with nested arrrays correctly', function() {
+    it('can parse a JSON object with nested arrays correctly', function() {
         var json = parsers.getParser('json');
         var results = [];
         return json.parseStream(fs.createReadStream(pointWithArrayFile), function(result) {
@@ -73,13 +73,67 @@ describe('parsers/json', function() {
                         {'fizz1': 'buzz'},
                         {'fizz2': 'buzz'},
                         {'fizz3': 'buzz'}
-                    ]
+                    ],
+                    'bar': {
+                        'baz': [
+                            {'fizz1': 'buzz', 'contents': [1,2,3]},
+                            {'fizz2': 'buzz', 'contents': [1,2,3]},
+                            {'fizz3': 'buzz', 'contents': [1,2,3]}
+                        ],
+                        'bing': {'bang': 'object', 'bong': {'type': 'object'}}
+                    }
                 }
             ]]);
         });
     });
 
-    it('can parse a JSON array with nested arrrays correctly', function() {
+    it('can parse a nested array out of a JSON object using a rootPath path', function() {
+        var json = parsers.getParser('json', {rootPath: 'foo'});
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointWithArrayFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
+                {'fizz1': 'buzz'},
+                {'fizz2': 'buzz'},
+                {'fizz3': 'buzz'}
+            ]]);
+        });
+    });
+
+    it('can parse a nested array out of a JSON object using a multi-element rootPath path', function() {
+        var json = parsers.getParser('json', {rootPath: 'bar.baz'});
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointWithArrayFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
+                {'fizz1': 'buzz', 'contents': [1,2,3]},
+                {'fizz2': 'buzz', 'contents': [1,2,3]},
+                {'fizz3': 'buzz', 'contents': [1,2,3]}
+            ]]);
+        });
+    });
+
+    it('can parse a nested object out of a JSON object using a rootPath path', function() {
+        var json = parsers.getParser('json', {rootPath: 'bar.bing'});
+        var results = [];
+        return json.parseStream(fs.createReadStream(pointWithArrayFile), function(result) {
+            results.push(result);
+        })
+        .then(function() {
+            expect(results.length).equal(1);
+            expect(results).to.deep.equal([[
+                {'bang': 'object', 'bong': {'type': 'object'}}
+            ]]);
+        });
+    });
+
+    it('can parse a JSON array with nested arrays correctly', function() {
         var json = parsers.getParser('json');
         var results = [];
         return json.parseStream(fs.createReadStream(pointsWithArrayFile), function(result) {


### PR DESCRIPTION
Add a `-rootPath` option to `read http` that can specify a path into the retrieved object from which the points should be processed.

Fixes #146.
