### PR TITLE
Parser cleanups: Tidy up `parser.parseSync`

### DIFF
--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -249,7 +249,7 @@ function parseSync(mainSource, options) {
     options = processOptions(options, defaultResolver);
 
     var asts = {};
-    function rec(o) {
+    function parseModule(o) {
         var ast, imports, modules;
         if (_.has(asts, o.name)) {
             return [];
@@ -261,10 +261,10 @@ function parseSync(mainSource, options) {
         _.each(imports, checkImportNode);
         modules = imports.map(resolveImport);
 
-        _.each(modules, rec);
+        _.each(modules, parseModule);
     }
 
-    rec({source: mainSource, name: 'main'});
+    parseModule({source: mainSource, name: 'main'});
     asts.main.modules = buildModuleDefs(asts);
     return asts.main;
 }

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -224,6 +224,8 @@ function parse(juttle, options) {
 }
 
 function parseSync(juttle, options) {
+    var asts = {};
+
     function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return {
@@ -246,9 +248,6 @@ function parseSync(juttle, options) {
         }
     }
 
-    options = processOptions(options, defaultResolver);
-
-    var asts = {};
     function parseModule(module) {
         if (_.has(asts, module.name)) {
             return;
@@ -264,8 +263,11 @@ function parseSync(juttle, options) {
             .each(parseModule);
     }
 
-    parseModule({source: juttle, name: 'main'});
+    options = processOptions(options, defaultResolver);
+
+    parseModule({ source: juttle, name: 'main' });
     asts.main.modules = buildModuleDefs(asts);
+
     return asts.main;
 }
 

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -250,18 +250,18 @@ function parseSync(juttle, options) {
 
     var asts = {};
     function parseModule(module) {
-        var ast, imports, modules;
         if (_.has(asts, module.name)) {
             return;
         }
 
-        ast = doParse(module.source, _.extend(options, { filename: module.name }));
+        var ast = doParse(module.source, _.extend(options, { filename: module.name }));
         asts[module.name] = ast;
-        imports = extractImports(ast);
-        _.each(imports, checkImportNode);
-        modules = imports.map(resolveImport);
 
-        _.each(modules, parseModule);
+        var imports = extractImports(ast);
+        _.chain(imports)
+            .each(checkImportNode)
+            .map(resolveImport)
+            .each(parseModule);
     }
 
     parseModule({source: juttle, name: 'main'});

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -235,6 +235,17 @@ function parseSync(mainSource, options) {
         }
     }
 
+    function resolveImport(import_) {
+        try {
+            return options.moduleResolver(import_.modulename.value, import_.localname);
+        } catch (e) {
+            throw errors.compileError('RT-MODULE-NOT-FOUND', {
+                module: import_.modulename.value,
+                location: import_.location
+            });
+        }
+    }
+
     options = processOptions(options, defaultResolver);
 
     var asts = {};
@@ -248,19 +259,7 @@ function parseSync(mainSource, options) {
         asts[o.name] = ast;
         imports = extractImports(ast);
         _.each(imports, checkImportNode);
-        modules = imports.map(function(import_) {
-            try {
-                return options.moduleResolver(
-                    import_.modulename.value,
-                    import_.localname
-                );
-            } catch (e) {
-                throw errors.compileError('RT-MODULE-NOT-FOUND', {
-                    module: import_.modulename.value,
-                    location: import_.location
-                });
-            }
-        });
+        modules = imports.map(resolveImport);
 
         _.each(modules, rec);
     }

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -249,14 +249,14 @@ function parseSync(juttle, options) {
     options = processOptions(options, defaultResolver);
 
     var asts = {};
-    function parseModule(o) {
+    function parseModule(module) {
         var ast, imports, modules;
-        if (_.has(asts, o.name)) {
+        if (_.has(asts, module.name)) {
             return [];
         }
 
-        ast = doParse(o.source, _.extend(options, { filename: o.name }));
-        asts[o.name] = ast;
+        ast = doParse(module.source, _.extend(options, { filename: module.name }));
+        asts[module.name] = ast;
         imports = extractImports(ast);
         _.each(imports, checkImportNode);
         modules = imports.map(resolveImport);

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -252,7 +252,7 @@ function parseSync(juttle, options) {
     function parseModule(module) {
         var ast, imports, modules;
         if (_.has(asts, module.name)) {
-            return [];
+            return;
         }
 
         ast = doParse(module.source, _.extend(options, { filename: module.name }));

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -223,7 +223,7 @@ function parse(juttle, options) {
         });
 }
 
-function parseSync(mainSource, options) {
+function parseSync(juttle, options) {
     function defaultResolver(path, name) {
         if (_.has(options.modules, path)) {
             return {
@@ -264,7 +264,7 @@ function parseSync(mainSource, options) {
         _.each(modules, parseModule);
     }
 
-    parseModule({source: mainSource, name: 'main'});
+    parseModule({source: juttle, name: 'main'});
     asts.main.modules = buildModuleDefs(asts);
     return asts.main;
 }

--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -249,6 +249,8 @@ function parseSync(juttle, options) {
     }
 
     function parseModule(module) {
+        // Don't break on cyclic imports and continue. There is a more proper
+        // check in the semantic pass.
         if (_.has(asts, module.name)) {
             return;
         }


### PR DESCRIPTION
This makes `parser.parseSync` a mirror image of `parser.parse`.

Part of work on #140.