### PR TITLE
values: Improve `values.inspect` comment

### DIFF
--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -284,8 +284,11 @@ var values = {
 
     // Returns string representation of a Juttle value. This representation is
     // intended to be used in places where exactness has precedence over
-    // readability (e.g. error messages, logs, dumps). In general, we aim to use
-    // the same representation of values as in Juttle source code.
+    // readability (e.g. error messages, logs, dumps).
+    //
+    // The function guarantees that the representation of each Juttle value is
+    // unique (typically the same as in Juttle source code). This means it can
+    // be used e.g. as a key in objects that map values to some associated data.
     //
     // See also values.toString.
     inspect: function(value) {


### PR DESCRIPTION
Explicitly state that the representation of each Juttle value is unique.