### PR TITLE
HTTP adapter: Eliminate useless `emit_eof` calls in `Write`

### DIFF
--- a/lib/adapters/http/write.js
+++ b/lib/adapters/http/write.js
@@ -75,7 +75,6 @@ var Write = Juttle.proc.sink.extend({
                     error: err.toString()
                 });
                 self.trigger('warning', runtime_error);
-                self.emit_eof();
             })
             .on('response', function(res) {
                 if (!('' + res.statusCode).match(/2\d\d/)) {
@@ -89,7 +88,6 @@ var Write = Juttle.proc.sink.extend({
                             error: 'StatusCodeError: ' + res.statusCode + ' - ' + body.join('')
                         });
                         self.trigger('warning', runtime_error);
-                        self.emit_eof();
                     });
                 }
             })
@@ -102,7 +100,6 @@ var Write = Juttle.proc.sink.extend({
 
     _maybe_done: function() {
         if (this.eofs === this.ins.length && this.in_progress_writes === 0) {
-            this.emit_eof();
             this.done();
         }
     },


### PR DESCRIPTION
These calls are noops (because `Write` is a sink).

See #131.