### PR TITLE
Uniq on nested fields

### DIFF
--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -13,7 +13,7 @@ var INFO = {
    that came before it. Swallows other points. */
 var uniq = fanin.extend({
     initialize: function(options) {
-        this.columns = options.arg || [];
+        this.fields = options.arg || [];
         this.groups = new Groups(this, options);
     },
     procName:  'uniq',
@@ -24,7 +24,7 @@ var uniq = fanin.extend({
             var pt = points[i];
 
             var row = this.groups.lookup(pt);
-            var cols = (this.columns.length) ? this.columns : _.keys(_.omit(pt, 'time'));
+            var fields = (this.fields.length) ? this.fields : _.keys(_.omit(pt, 'time'));
 
             if (!row.stored) {
                 row.stored = pt;
@@ -32,10 +32,17 @@ var uniq = fanin.extend({
                 continue;
             }
 
-            for (var j = 0; j < cols.length; j++) {
-                var col = cols[j];
+            for (var j = 0; j < fields.length; j++) {
+                var field = fields[j];
 
-                if (!values.equal(row.stored[col], pt[col])) {
+                var inStored = _.has(row.stored, field);
+                var inPoint = _.has(pt, field);
+
+                // Nothing to compare
+                if (!inStored && !inPoint) { continue; }
+
+                // Emit also if the field doesn't exist in either of the points.
+                if (inStored !== inPoint || !values.equal(row.stored[field], pt[field])) {
                     row.stored = pt;
                     toEmit.push(pt);
                     break;

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -39,9 +39,7 @@ var uniq = fanin.extend({
                         toEmit.push(pt);
                         break;
                     }
-                } else if (row.stored[fld] !== pt[fld]
-                    || (!this.columns && _.keys(row.stored).length !== _.keys(pt).length)) {
-
+                } else if (row.stored[fld] !== pt[fld]) {
                     row.stored = pt;
                     toEmit.push(pt);
                     break;

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var JuttleMoment = require('../../moment').JuttleMoment;
 var fanin = require('./fanin');
 var values = require('../values');
 var Groups = require('../groups');

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -19,28 +19,31 @@ var uniq = fanin.extend({
     },
     procName:  'uniq',
     process: function(points) {
-        var k, m, fld, cols, row, pt;
         var toEmit = [];
-        for (k = 0; k < points.length; ++k) {
-            pt = points[k];
-            row = this.groups.lookup(pt);
+
+        for (var i = 0; i < points.length; i++) {
+            var pt = points[i];
+
+            var row = this.groups.lookup(pt);
+            var cols = (this.columns.length) ? this.columns : _.keys(_.omit(pt, 'time'));
+
             if (!row.stored) {
                 row.stored = pt;
                 toEmit.push(pt);
                 continue;
             }
 
-            cols = (this.columns.length) ? this.columns : _.keys(_.omit(pt, 'time'));
-            for (m = 0; m < cols.length; ++m) {
-                fld = cols[m];
+            for (var j = 0; j < cols.length; j++) {
+                var col = cols[j];
 
-                if (!values.equal(row.stored[fld], pt[fld])) {
+                if (!values.equal(row.stored[col], pt[col])) {
                     row.stored = pt;
                     toEmit.push(pt);
                     break;
                 }
             }
         }
+
         if (toEmit.length > 0) {
             this.emit(toEmit);
         }

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var JuttleMoment = require('../../moment').JuttleMoment;
 var fanin = require('./fanin');
+var values = require('../values');
 var Groups = require('../groups');
 
 var INFO = {
@@ -33,13 +34,7 @@ var uniq = fanin.extend({
             for (m = 0; m < cols.length; ++m) {
                 fld = cols[m];
 
-                if (row.stored[fld] instanceof JuttleMoment && pt[fld] instanceof JuttleMoment) {
-                    if (JuttleMoment.compare('!=', row.stored[fld], pt[fld])) {
-                        row.stored = pt;
-                        toEmit.push(pt);
-                        break;
-                    }
-                } else if (row.stored[fld] !== pt[fld]) {
+                if (!values.equal(row.stored[fld], pt[fld])) {
                     row.stored = pt;
                     toEmit.push(pt);
                     break;

--- a/test/runtime/specs/juttle-spec/juttle-procs-uniq.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-uniq.spec.md
@@ -36,6 +36,21 @@ uniq on a duration
     {time: "1970-01-01T00:00:01.000Z", foo: "00:00:01.000", rate: "00:00:02.000"}
     {time: "1970-01-01T00:00:03.000Z", foo: "00:00:03.000", rate: "00:00:04.000"}
 
+uniq on a non-scalar field
+----------------------------
+
+### Juttle
+    emit -from Date.new(0) -limit 5
+    | put foo=count()-1
+    | put obj={ i: foo + foo % 2 }
+    | uniq obj
+    | view result
+
+### Output
+
+    {time: "1970-01-01T00:00:00.000Z", foo: 0, obj: { i: 0 }}
+    {time: "1970-01-01T00:00:01.000Z", foo: 1, obj: { i: 2 }}
+    {time: "1970-01-01T00:00:03.000Z", foo: 3, obj: { i: 4 }}
 
 uniq on multiple fields
 ------------------------
@@ -54,7 +69,6 @@ uniq on multiple fields
     {time: "1970-01-01T00:00:01.000Z", foo: "00:00:01.000", rate: "00:00:02.000", test: "00:00:00.000"}
     {time: "1970-01-01T00:00:03.000Z", foo: "00:00:03.000", rate: "00:00:04.000", test: "00:00:01.000"}
     {time: "1970-01-01T00:00:04.000Z", foo: "00:00:04.000", rate: "00:00:04.000", test: "00:00:00.000"}
-
 
 uniq by
 --------
@@ -119,6 +133,26 @@ uniq by on all fields
     { x:3, y:2, n:7 }
     { x:3, y:2, n:8 }
     { x:4, y:2, n:9 }
+
+uniq by a non-scalar field
+----------------------------
+
+### Juttle
+    emit -from Date.new(0) -limit 9
+    | put n=count(), x={ i: Math.floor((count()-1)/2) }, y=Math.floor((count()-1)/3)
+    | uniq y by x
+    | remove time
+    | view result
+
+### Output
+
+    { x:{ i:0 }, y:0, n:1 }
+    { x:{ i:1 }, y:0, n:3 }
+    { x:{ i:1 }, y:1, n:4 }
+    { x:{ i:2 }, y:1, n:5 }
+    { x:{ i:3 }, y:2, n:7 }
+    { x:{ i:4 }, y:2, n:9 }
+
 
 uniq with batched input
 ------------------------


### PR DESCRIPTION
Add support for nested fields to `uniq` proc, by comparing values using `values.equal`.

refs: #55 