### PR TITLE
adapters: check for valid adapters in the build stage

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -57,12 +57,12 @@ var NODE_CHILDREN = {
     BuiltinProc:              ['options', 'arg'],
     OptionOnlyProc:           ['options'],
     PutProc:                  ['options', 'exprs', 'groupby'],
-    ReadProc:                 ['options', 'filter'],
+    ReadProc:                 ['options', 'filter', 'adapter'],
     ReduceProc:               ['options', 'exprs', 'groupby'],
     SingleArgProc:            ['options', 'arg', 'groupby'],
     SequenceProc:             ['filters'],
     SortProc:                 ['options', 'columns', 'groupby'],
-    WriteProc:                ['options'],
+    WriteProc:                ['options', 'adapter'],
 
     /* Graphs */
     ParallelGraph:            ['elements'],

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -409,7 +409,7 @@ var GraphCompiler = CodeGenerator.extend({
                                         ast.location,
                                         params);
         var code = 'var ' + pname + ' = ';
-        code += 'new (Juttle.adapters.get("' + ast.adapter + '").read)('
+        code += 'new (Juttle.adapters.get("' + ast.adapter.name + '", ' + JSON.stringify(ast.location) + ').read)('
             + soptions + ', '
             + JSON.stringify(ast.location) + ', '
             + 'program, juttle'
@@ -423,7 +423,7 @@ var GraphCompiler = CodeGenerator.extend({
                                         ast.location,
                                         {});
         var code = 'var ' + pname + ' = ';
-        code += 'new (Juttle.adapters.get("' + ast.adapter + '").write)('
+        code += 'new (Juttle.adapters.get("' + ast.adapter.name + '", ' + JSON.stringify(ast.location) + ').write)('
             + soptions + ', '
             + JSON.stringify(ast.location) + ', '
             + 'program, juttle'

--- a/lib/compiler/optimize/optimize.js
+++ b/lib/compiler/optimize/optimize.js
@@ -32,7 +32,7 @@ function optimize_read(source_node, graph, Juttle) {
 
     var optimization_info = {};
 
-    var adapter = Juttle.adapters.get(source_node.adapter);
+    var adapter = Juttle.adapters.get(source_node.adapter.name, source_node.adapter.location);
     if (!adapter) {
         throw new Error('unknown adapter');
     }

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1589,7 +1589,7 @@ PutProc
       }
 
 ReadProc
-    = ACProcStart ReadToken ACProcEnd __ adapter:Identifier options:ProcOptions __ filter:FilterExpressionToplevel? {
+    = ACProcStart ReadToken ACProcEnd __ adapter:IdentifierNameWithPos options:ProcOptions __ filter:FilterExpressionToplevel? {
           return createNode('ReadProc', location(), {
               name: 'read',
               adapter: adapter,
@@ -1651,7 +1651,7 @@ UniqProc
       }
 
 WriteProc
-  = ACProcStart WriteToken ACProcEnd __ adapter:Identifier options:ProcOptions {
+  = ACProcStart WriteToken ACProcEnd __ adapter:IdentifierNameWithPos options:ProcOptions {
         return createNode('WriteProc', location(), {
             name: 'write',
             adapter: adapter,

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -20,7 +20,7 @@ function register(type, module) {
     adapters[type] = module;
 }
 
-function get(type) {
+function get(type, location) {
     if (adapters[type]) {
         return adapters[type];
     }
@@ -30,8 +30,14 @@ function get(type) {
         return adapter;
     }
 
-    // XXX this should include location info
-    throw errors.compileError('RT-INVALID-ADAPTER', {type: type});
+    throw errors.compileError('JUTTLE-INVALID-ADAPTER', {
+        location: location,
+        type: type
+    });
+}
+
+function isValid(type) {
+    return (adapters[type] || adapterConfig[type]) ? true : false;
 }
 
 // Because adapters pull in the Juttle runtime via require('juttle/lib/xyz'),
@@ -146,5 +152,6 @@ function configure(config) {
 module.exports = {
     register: register,
     get: get,
+    isValid: isValid,
     configure: configure
 };

--- a/lib/strings/juttle-error-strings-en-US.json
+++ b/lib/strings/juttle-error-strings-en-US.json
@@ -5,7 +5,7 @@
     "JUTTLE-SYNTAX-ERROR-WITH-EXPECTED": "Expected {{info.expectedDescription}} but {{info.foundDescription}} found.",
     "JUTTLE-SYNTAX-ERROR-WITHOUT-EXPECTED": "{{info.message}}",
 
-    "RT-INVALID-ADAPTER": "Error: instantiating {{info.type}} -- module not registered",
+    "JUTTLE-INVALID-ADAPTER": "Error: adapter {{info.type}} not registered",
     "RT-GROUP-BY-UNDEFINED": "Warning: group by undefined field \"{{info.field}}\"",
     "RT-SORT-LIMIT-EXCEEDED": "Warning: sort limit exceeded, dropping points",
     "RT-BATCH-OUT-OF-ORDER": "Warning: batch dropped out-of-order point(s)",

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -152,4 +152,36 @@ describe('adapter API tests', function () {
             expect(result.sinks.table.length).equal(0);
         });
     });
+
+    it('errors if a bogus adapter is used in read', function() {
+        return check_juttle({
+            program: 'read bogus'
+        })
+        .then(function() {
+            throw new Error('unexpected success');
+        })
+        .catch(function(err) {
+            expect(err.code).equal('JUTTLE-INVALID-ADAPTER');
+            expect(err.message).equal('Error: adapter bogus not registered');
+            expect(err.info.location.filename).is.a.string;
+            expect(err.info.location.start.offset).is.a.number;
+            expect(err.info.location.end.offset).is.a.number;
+        });
+    });
+
+    it('errors if a bogus adapter is used in write', function() {
+        return check_juttle({
+            program: 'emit | write bogus'
+        })
+        .then(function() {
+            throw new Error('unexpected success');
+        })
+        .catch(function(err) {
+            expect(err.code).equal('JUTTLE-INVALID-ADAPTER');
+            expect(err.message).equal('Error: adapter bogus not registered');
+            expect(err.info.location.filename).is.a.string;
+            expect(err.info.location.start.offset).is.a.number;
+            expect(err.info.location.end.offset).is.a.number;
+        });
+    });
 });


### PR DESCRIPTION
Add a check to the flowgraph build stage that makes sure an adapter with the
specified name is either registered or configured to be dynamically loaded.

As part of this change, modify the ast for read and write in order to preserve
the location information for the adapter name.

Relates to #83