### PR TITLE
fix timing bug in serializer tests

### DIFF
--- a/test/adapters/serializers/csv.spec.js
+++ b/test/adapters/serializers/csv.spec.js
@@ -16,14 +16,17 @@ describe('serializers/csv', function() {
     it('can write no points to a provided stream', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('csv', stream);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
-            expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
-            done();
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('csv', stream);
+            serializer.done();
+
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+                expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
+                done();
+            });
         });
     });
 
@@ -44,33 +47,36 @@ describe('serializers/csv', function() {
     it('can write out a few points correctly', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('csv', stream);
-        var data = [
-            { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
-            { time: '2014-02-01T00:00:00.000Z', foo: 'buzz' },
-            { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
-        ];
-        serializer.write(data);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('csv', stream);
+            var data = [
+                { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
+                { time: '2014-02-01T00:00:00.000Z', foo: 'buzz' },
+                { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
+            ];
+            serializer.write(data);
+            serializer.done();
 
-            var parser = parsers.getParser('csv');
-            var results = [];
-            parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
-                results.push(result);
-            })
-            .then(function() {
-                expect(results).to.deep.equal([data]);
-                done();
-            })
-            .catch(function(err) {
-                done(err);
-            })
-            .finally(function() {
-                fs.unlinkSync(tmpFilename);
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+
+                var parser = parsers.getParser('csv');
+                var results = [];
+                parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
+                    results.push(result);
+                })
+                .then(function() {
+                    expect(results).to.deep.equal([data]);
+                    done();
+                })
+                .catch(function(err) {
+                    done(err);
+                })
+                .finally(function() {
+                    fs.unlinkSync(tmpFilename);
+                });
             });
         });
     });

--- a/test/adapters/serializers/json.spec.js
+++ b/test/adapters/serializers/json.spec.js
@@ -16,46 +16,50 @@ describe('serializers/json', function() {
     it('can write no points to a provided stream', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('json', stream);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
-            expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
-            done();
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('json', stream);
+            serializer.done();
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+                expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
+                done();
+            });
         });
     });
 
     it('can write out a few points correctly', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('json', stream);
-        var data = [
-            { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
-            { time: '2014-02-01T00:00:00.000Z', foo: 'buzz' },
-            { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
-        ];
-        serializer.write(data);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
-            var results = [];
-            var parser = parsers.getParser('json');
-            parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
-                results.push(result);
-            })
-            .then(function() {
-                expect(results).to.deep.equal([data]);
-                done();
-            })
-            .catch(function(err) {
-                done(err);
-            })
-            .finally(function() {
-                fs.unlinkSync(tmpFilename);
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('json', stream);
+            var data = [
+                { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
+                { time: '2014-02-01T00:00:00.000Z', foo: 'buzz' },
+                { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
+            ];
+            serializer.write(data);
+            serializer.done();
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+                var results = [];
+                var parser = parsers.getParser('json');
+                parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
+                    results.push(result);
+                })
+                .then(function() {
+                    expect(results).to.deep.equal([data]);
+                    done();
+                })
+                .catch(function(err) {
+                    done(err);
+                })
+                .finally(function() {
+                    fs.unlinkSync(tmpFilename);
+                });
             });
         });
     });

--- a/test/adapters/serializers/jsonl.spec.js
+++ b/test/adapters/serializers/jsonl.spec.js
@@ -16,47 +16,52 @@ describe('serializers/jsonl', function() {
     it('can write no points to a provided stream', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('jsonl', stream);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
-            expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
-            done();
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('jsonl', stream);
+            serializer.done();
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+                expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
+                done();
+            });
         });
     });
 
     it('can write out a few points correctly', function(done) {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
-        var serializer = serializers.getSerializer('jsonl', stream);
-        var data = [
-            { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
-            { time: '2014-02-01T00:00:00.000Z', fizz: 'buzz' },
-            { time: '2014-03-01T00:00:00.000Z', fuzz: 'bizz' }
-        ];
-        serializer.write(data);
-        serializer.done();
-        stream.end(function(err) {
-            if (err) {
-                done(err);
-            }
+        stream.on('open', function() {
+            var serializer = serializers.getSerializer('jsonl', stream);
+            var data = [
+                { time: '2014-01-01T00:00:00.000Z', foo: 'bar' },
+                { time: '2014-02-01T00:00:00.000Z', fizz: 'buzz' },
+                { time: '2014-03-01T00:00:00.000Z', fuzz: 'bizz' }
+            ];
+            serializer.write(data);
+            serializer.done();
 
-            var parser = parsers.getParser('jsonl');
-            var results = [];
-            return parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
-                results.push(result);
-            })
-            .then(function() {
-                expect(results).to.deep.equal([data]);
-                done();
-            })
-            .catch(function(err) {
-                done(err);
-            })
-            .finally(function() {
-                fs.unlinkSync(tmpFilename);
+            stream.end(function(err) {
+                if (err) {
+                    done(err);
+                }
+
+                var parser = parsers.getParser('jsonl');
+                var results = [];
+                return parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
+                    results.push(result);
+                })
+                .then(function() {
+                    expect(results).to.deep.equal([data]);
+                    done();
+                })
+                .catch(function(err) {
+                    done(err);
+                })
+                .finally(function() {
+                    fs.unlinkSync(tmpFilename);
+                });
             });
         });
     });


### PR DESCRIPTION
Fixes issue #152

The issue was not waiting for the `open` event on the new writable
stream before attempting to verify the file was there and contained
anything that was recently written to it.