### PR TITLE
 source: add timeUnit option

### DIFF
--- a/docs/adapters/file.md
+++ b/docs/adapters/file.md
@@ -13,7 +13,7 @@ The `file` adapter allows reading points from, or writing points to, a file on t
 Supported file formats are JSON array, and JSON lines; see examples below.
 
 ```text
-read file -file <path> [-format <format>] [-timeField <fieldname>]
+read file -file <path> [-format <format>] [-timeField <fieldname>] [-timeUnit <unit>]
 ```
 
 Parameter         |             Description          | Required?
@@ -21,8 +21,11 @@ Parameter         |             Description          | Required?
 `-file`           | File path on the local filesystem, absolute or relative to the current working directory  | Yes
 `-format`         | Input file format: `csv` for [CSV](https://tools.ietf.org/html/rfc4180) data, `json` for [JSON](https://tools.ietf.org/html/rfc7159) data, or `jsonl` for [JSON lines](http://jsonlines.org/) data | No; defaults to `json`
 `-timeField`      | Name of the field in the data which contains a valid timestamp  | No; defaults to `time`
+`-timeUnit`       | Unit to use for any UNIX timestamps | No; defaults to `seconds`
 
-The data is assumed to contain valid timestamps in a field named `time` by default; a different name for the time field may be specified with `-timeField` option. If the data contains fields `time` and another named field specified with `-timeField`, the original contents of field `time` will be overwritten by the valid timestamp from `timeField`. 
+The data is assumed to contain valid timestamps in a field named `time` by default; a different name for the time field may be specified with `-timeField` option. If the data contains fields `time` and another named field specified with `-timeField`, the original contents of field `time` will be overwritten by the valid timestamp from `timeField`.
+
+For numeric [UNIX timestamps](https://en.wikipedia.org/wiki/Unix_time), specify a unit with the `-timeUnit` option.
 
 Timeless data, which contains no timestamps, is acceptable; however certain operations which expect time to be present in the points, such as `reduce -every :interval:`, will execute with warnings or error out. Timeless data can be joined in the Juttle flowgraph with other data which contains timestamps; a common use case for reading timeless data from a file or another backend is to join it with streaming data for enrichment.
 
@@ -92,8 +95,8 @@ If the file already exists and contains a valid JSON array, the write will appen
 _Example: writing data to a file_
 
 ```juttle
-emit -from :2015-01-01: -limit 2 
-| put name = 'write_me', value = count() 
+emit -from :2015-01-01: -limit 2
+| put name = 'write_me', value = count()
 | write file -file '/tmp/write_me.json'
 ```
 

--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -18,17 +18,19 @@ read http -url url
           -headers headers
           -body body
           -timeField timeField
+          -timeUnit timeUnit
           -rootPath rootPath
           -includeHeaders true/false
 ```
 
 Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
-`-url`            | URL to issue the HTTP request at | Yes 
+`-url`            | URL to issue the HTTP request at | Yes
 `-method`         | HTTP method to use               | No; default: `GET`
 `-headers`        | headers to attach to the HTTP request in the form `{ key1: "value1", ..., keyN: "valueN" }` | No; default: `{}`
 `-body`           | body to send with the HTTP requests | No; default: `{}`
 `-timeField`      | The name of the field to use as the time field <br><br>The specified field will be renamed to `time` in the body of the HTTP request. If the points already contain a field called `time`, that field is overwritten. This is useful when the source data contains a time field whose values are not valid time stamps.  | No; defaults to keeping the `time` field as is
+`-timeUnit`       | Unit to use for any UNIX timestamps | No; defaults to `seconds`
 `-rootPath`       | When the incoming data is JSON, use the specified path into the incoming object (expressed as `field1.field2`) to emit points | No
 `-includeHeaders` | When set to true the headers from the response are appended to each of the points in the response | No; default: `false`
 
@@ -36,7 +38,7 @@ Currently the `read http` adapter will automatically parse incoming data based o
 
     * `text/csv`: for [CSV](https://tools.ietf.org/html/rfc4180) data
     * `application/json` for [JSON](https://tools.ietf.org/html/rfc7159) data
-    * `application/json` for [JSON lines](http://jsonlines.org/) data 
+    * `application/json` for [JSON lines](http://jsonlines.org/) data
 
 _Example_
 
@@ -69,7 +71,7 @@ write http -url url
 
 Parameter    |             Description          | Required?
 ------------ | -------------------------------- | ---------:
-`-url`       | URL to issue the HTTP request at | Yes 
+`-url`       | URL to issue the HTTP request at | Yes
 `-method`    | HTTP method to use               | No; default: `POST`
 `-headers`   | headers to attach to the HTTP request in the form `{ key1: "value1", ..., keyN: "valueN" }` | No; default: `{}`
 `-maxLength` | maximum payload length per HTTP request, as number of data points (not bytes) <br><br>If the number of data points out of the flowgraph exceeds `maxLength` then multiple HTTP requests will be sent. | No, default: 1 (each data point out of the flowgraph becomes one HTTP request)

--- a/docs/adapters/stdio.md
+++ b/docs/adapters/stdio.md
@@ -13,15 +13,19 @@ The `stdio` adapter allows reading points from stdin and writing points to stdou
 Supported formats are JSON array, JSON lines and CSV; see examples below.
 
 ```text
-read stdio [-format <format>] [-timeField <fieldname>]
+read stdio [-format <format>] [-timeField <fieldname>] [-timeUnit <unit>]
 ```
 
 Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
 `-format`         | Input input format: `csv` for [CSV](https://tools.ietf.org/html/rfc4180) data, `json` for [JSON](https://tools.ietf.org/html/rfc7159) data, or `jsonl` for [JSON lines](http://jsonlines.org/) data | No; defaults to `json`
 `-timeField`      | Name of the field in the data which contains a valid timestamp  | No; defaults to `time`
+`-timeUnit`       | Unit to use for any UNIX timestamps | No; defaults to `seconds`
 
-The data is assumed to contain valid timestamps in a field named `time` by default; a different name for the time field may be specified with `-timeField` option. If the data contains fields `time` and another named field specified with `-timeField`, the original contents of field `time` will be overwritten by the valid timestamp from `timeField`. 
+The data is assumed to contain valid timestamps in a field named `time` by default; a different name for the time field may be specified with `-timeField` option. If the data contains fields `time` and another named field specified with `-timeField`, the original contents of field `time` will be overwritten by the valid timestamp from `timeField`.
+
+For numeric [UNIX timestamps](https://en.wikipedia.org/wiki/Unix_time), specify a unit with the `-timeUnit` option.
+
 Timeless data, which contains no timestamps, is acceptable; however certain operations which expect time to be present in the points, such as `reduce -every :interval:`, will execute with warnings or error out. Timeless data can be joined in the Juttle flowgraph with other data which contains timestamps; a common use case for reading timeless data from a file or another backend is to join it with streaming data for enrichment.
 
 The stdio adapter does not support any kind of filtering (neither filter expressions, nor full text search). In order to filter the data from the `read stdio`, pipe to the [filter](../processors/filter.md) proc.

--- a/lib/adapters/file/read.js
+++ b/lib/adapters/file/read.js
@@ -9,7 +9,7 @@ var Read = Juttle.proc.source.extend({
     procName: 'read-file',
 
     initialize: function(options, params, location, program) {
-        var allowed_options = ['from', 'to', 'file', 'timeField', 'format'];
+        var allowed_options = ['from', 'to', 'file', 'timeField', 'timeUnit', 'format'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -27,6 +27,7 @@ var Read = Juttle.proc.source.extend({
 
         this.filename = options.file;
         this.timeField = options.timeField;
+        this.timeUnit = options.timeUnit;
         this.format = options.format ? options.format : 'json'; // default to json
         this.parser = parsers.getParser(this.format);
 
@@ -63,7 +64,7 @@ var Read = Juttle.proc.source.extend({
 
         self.parser.parseStream(stream, function(points) {
             var validPoints = [];
-            self.parseTime(points, self.timeField);
+            self.parseTime(points, self.timeField, self.timeUnit);
             _.each(points, function(point) {
                 // timeless points just pass through at this point
                 if (point.time && point.time.moment) {

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -14,6 +14,7 @@ var Read = Juttle.proc.source.extend({
             'headers',
             'body',
             'timeField',
+            'timeUnit',
             'includeHeaders',
             'rootPath'
         ];
@@ -43,6 +44,7 @@ var Read = Juttle.proc.source.extend({
 
         this.body = options.body;
         this.timeField = options.timeField;
+        this.timeUnit = options.timeUnit;
         this.includeHeaders = options.includeHeaders;
         this.rootPath = options.rootPath;
 
@@ -108,7 +110,7 @@ var Read = Juttle.proc.source.extend({
                             points = [points];
                         }
 
-                        self.parseTime(points, self.timeField);
+                        self.parseTime(points, self.timeField, self.timeUnit);
                         self.emit(points);
                         self.emit_eof();
                     }).catch(function(err) {

--- a/lib/adapters/stdio/read.js
+++ b/lib/adapters/stdio/read.js
@@ -8,7 +8,7 @@ var Read = Juttle.proc.source.extend({
     procName: 'read stdio',
 
     initialize: function(options, params, location, program) {
-        var allowed_options = ['timeField', 'format', 'formatOptions'];
+        var allowed_options = ['timeField', 'timeUnit', 'format', 'formatOptions'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -18,6 +18,7 @@ var Read = Juttle.proc.source.extend({
         }
 
         this.timeField = options.timeField;
+        this.timeUnit = options.timeUnit;
 
         this.format = options.format ? options.format : 'json'; // default to json
         var formatOptions = options.formatOptions || {};
@@ -39,7 +40,7 @@ var Read = Juttle.proc.source.extend({
         var self = this;
 
         self.parser.parseStream(this.getStdin(), function(points) {
-            self.parseTime(points, self.timeField);
+            self.parseTime(points, self.timeField, self.timeUnit);
             self.emit(points);
         })
         .catch(function(err) {

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -3,7 +3,8 @@
 //
 
 var juttle_utils = require('../juttle-utils');
-var _ = require('underscore');
+var JuttleMoment = require('../../moment').JuttleMoment;
+var values = require('../values');
 
 var base = require('./base');
 
@@ -18,21 +19,23 @@ var source = base.extend({
     //
     // If not specified, timeField defaults to 'time'. If specified and point
     // is missing that field, emits a warning.
-    parseTime: function(points, timeField) {
+    parseTime: function(points, timeField, timeUnit) {
         var self = this;
 
-        _.each(points, function(pt) {
+        points.forEach(function(pt) {
             if (timeField && !pt[timeField]) {
                 self.trigger('warning', self.runtime_error('RT-POINT-MISSING-TIME', {field: timeField}));
             }
 
             var time = pt[timeField || 'time'];
-            if (time) { pt.time = time; }
+            if (values.isNumber(time)) {
+                time = JuttleMoment.duration(time, timeUnit).milliseconds();
+            }
+
+            if (time || time === 0) { pt.time = time; }
         });
 
-        juttle_utils.toNative(points);
-
-        return points;
+        return juttle_utils.toNative(points);
     }
 }, {
     info: INFO

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -158,6 +158,47 @@ describe('file adapter tests', function () {
 
             return expect_to_fail(failing_read, message);
         });
+
+        describe('time units', function() {
+            function time_test(unit, unit_size) {
+                var file = path.resolve(__dirname, 'input/unix-second-times.json');
+                var options = {timeField: 'timestamp'};
+                if (unit) { options.timeUnit = unit; }
+
+                return run_read_file_juttle(file, options)
+                    .then(function(result) {
+                        expect(result.errors).deep.equal([]);
+
+                        var expected = require(file).map(function(pt) {
+                            pt.time = new Date(pt.timestamp * unit_size).toISOString();
+
+                            return pt;
+                        });
+
+                        expect(result.sinks.table).deep.equal(expected);
+                    });
+            }
+
+            it('milliseconds', function() {
+                return time_test('milliseconds', 1);
+            });
+
+            it('seconds (default)', function() {
+                return time_test(null, 1000);
+            });
+
+            it('seconds (explicit)', function() {
+                return time_test('seconds', 1000);
+            });
+
+            it('minutes', function() {
+                return time_test('minutes', 60 * 1000);
+            });
+
+            it('hours', function() {
+                return time_test('hours', 60 * 60 * 1000);
+            });
+        });
     });
 
     describe('write file', function() {

--- a/test/adapters/file/input/unix-second-times.json
+++ b/test/adapters/file/input/unix-second-times.json
@@ -1,0 +1,4 @@
+[{
+    "timestamp": 1452727933.766,
+    "name": "unix-second-time"
+}]


### PR DESCRIPTION
if the times on points from a source are numeric, add a -timeUnit
option that tells what the numbers represent. Default to seconds.

fixes #166 

@demmer @dmajda @bkutil 