### PR TITLE
Update views to handle nested points

### DIFF
--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var Table = require('cli-table');
 var View = require('./view.js');
 var utils = require('../runtime').utils;
+var values = require('../runtime/values');
 
 var TableView = View.extend({
     name: 'table',
@@ -129,7 +130,7 @@ var TableView = View.extend({
             if (self.initial_keys.length === 0) {
                 var columns = _.reduce(data, function(memo, pt) {
                     _.each(pt, function(val, key) {
-                        var val_len = String(val).length;
+                        var val_len = values.toString(val).length;
                         var key_len = String(key).length;
                         var new_len = Math.max(Math.ceil(1.5 * Math.max(key_len, val_len)), 10);
                         if (! memo[key]) {
@@ -180,7 +181,7 @@ var TableView = View.extend({
                     self.latest_keys = self.latest_keys.concat(new_keys).sort(self.sort_keys.bind(self));
                 }
                 var values = _.map(self.initial_keys, function(key) {
-                    return (_.has(point, key) ? point[key] : '');
+                    return point[key];
                 });
                 table.push(values.map(self._valueFormatter.bind(self)));
             });
@@ -225,7 +226,7 @@ var TableView = View.extend({
                 }
                 self.items_written++;
                 var values = _.map(keys, function(key) {
-                    return (_.has(point, key) ? point[key] : '');
+                    return point[key];
                 });
                 table.push(values.map(self._valueFormatter.bind(self)));
             });
@@ -249,7 +250,11 @@ var TableView = View.extend({
     },
 
     _valueFormatter: function(value) {
-        return value === null ? '' : value;
+        if (typeof(value) === 'undefined') {
+            return '';
+        } else {
+            return values.toString(value);
+        }
     },
 });
 

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var babyparse = require('babyparse');
 var View = require('./view.js');
 var utils = require('../runtime').utils;
+var values = require('../runtime/values');
 
 var TextView = View.extend({
     name: 'text',
@@ -66,12 +67,15 @@ var TextView = View.extend({
         }
     },
 
-    format_values: function(values) {
-        var val2 = _.map(values, function(value) {
-            if (_.isDate(value)) {
-                value = value.toISOString();
+    format_values: function(values_) {
+        var val2 = _.map(values_, function(value) {
+            if (typeof(value) === 'undefined') {
+                return '';
+            } else if (values.isArray(value) || values.isObject(value)) {
+                return values.inspect(value);
+            } else {
+                return values.toString(value);
             }
-            return value;
         });
         return babyparse.unparse([val2], {quotes: true});
     },
@@ -98,10 +102,10 @@ var TextView = View.extend({
                 self.warn("Ignoring new point key(s) \"" + new_keys.join(",") + "\"");
                 self.latest_keys = self.latest_keys.concat(new_keys).sort();
             }
-            var values = _.map(self.initial_keys, function(key) {
-                return (_.has(point, key) ? point[key] : '');
+            var values_ = _.map(self.initial_keys, function(key) {
+                return point[key];
             });
-            self.write_item(self.format_values(values));
+            self.write_item(self.format_values(values_));
             break;
 
         case 'json':


### PR DESCRIPTION
To output nested points, use `toString` serialization defined in `values.js`.

For csv text view, output arrays and objects in 'inspect' format, as the
brackets give a little bit more context while parsing the output
visually.