### PR TITLE
FromNative handles nested time fields

### DIFF
--- a/lib/runtime/juttle-utils.js
+++ b/lib/runtime/juttle-utils.js
@@ -25,13 +25,17 @@ function toNative(records, epsilon) {
 }
 
 function fromNative(records) {
-    _.each(records, function(record) {
+    function convert(record) {
         _.each(record, function(value, key) {
-            if (value instanceof JuttleMoment) {
+            if (values.isDate(value) || values.isDuration(value)) {
                 record[key] = value.valueOf();
+            } else if (values.isObject(value) || values.isArray(value)) {
+                convert(value);
             }
         });
-    });
+    }
+
+    _.each(records, convert);
 
     return records;
 }

--- a/test/runtime/juttle-utils.spec.js
+++ b/test/runtime/juttle-utils.spec.js
@@ -1,0 +1,21 @@
+var expect = require('chai').expect;
+var utils = require('../../lib/runtime/juttle-utils');
+var JuttleMoment = require('../../lib/moment').JuttleMoment;
+
+describe('juttle utils tests', function() {
+    describe('fromNative', function() {
+        it('serializes juttle moments in points', function() {
+            var time = new JuttleMoment(0);
+
+            var points = [
+                { time: time, arr: [time], obj: {time: time}  }
+            ];
+
+            var converted = utils.fromNative(points)[0];
+
+            expect(converted.time).to.equal(time.valueOf());
+            expect(converted.arr[0]).to.equal(time.valueOf());
+            expect(converted.obj.time).to.equal(time.valueOf());
+        });
+    });
+});


### PR DESCRIPTION
Nested fields can contain juttle moments, which fromNative should
serialize to a string. Modify the conversion code to recursively
serialize object/array elements and add test.

Fixes: #172