### PR TITLE
Consolidate Juttle runtime: Pass Juttle runtime as a dependency

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -73,7 +73,7 @@ var Build = CodeGenerator.extend({
         // this should be the only object reference into the entire
         // compiled world and associated runtime.
         //
-        code = '(function(builder) {\n';
+        code = '(function(builder, juttle) {\n';
         code += body;
         code += 'builder.record_stats(' + JSON.stringify(ast.stats) + ');';
         code += ast.uname + '();\n';

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -71,7 +71,7 @@ var GraphCompiler = CodeGenerator.extend({
         // this should be the only object reference into the entire
         // compiled world and associated runtime.
         //
-        code = '(function() {\n';
+        code = '(function(juttle) {\n';
         code += 'var views=[];\n';
         code += 'var program = {};\n';
         code += body;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -77,7 +77,7 @@ var GraphCompiler = CodeGenerator.extend({
         code += body;
         code += 'return { program: program, now: program.now, views: views,';
         code += 'graph: ' + entry + ' };\n';
-        code += '})();\n';
+        code += '})';
         return code;
     },
     emit: function(s) {

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -13,7 +13,7 @@ var Build = require('./build');
 
 var _ = require('underscore'); // jshint ignore:line
 var JuttleMoment = require('../moment').JuttleMoment; // jshint ignore:line
-var juttle = require('../runtime').runtime; // jshint ignore:line
+var juttle = require('../runtime').runtime;
 
 var Juttle = require('../runtime').Juttle;
 
@@ -31,7 +31,7 @@ var stages = {
     flowgraph: function(code, options) {
         var fn = eval(code);
         var gb = new GraphBuilder(options);
-        fn(gb);
+        fn(gb, juttle);
         var graph = gb.graph();
         var program = new Graph();
         program.built_graph = graph;

--- a/lib/program.js
+++ b/lib/program.js
@@ -8,7 +8,7 @@ var Promise = require('bluebird');
 // and complains about unused variables.
 var JuttleMoment = require('./moment').JuttleMoment; // jshint ignore:line
 var Filter = require('./runtime/filter'); // jshint ignore:line
-var juttle = require('./runtime').runtime; // jshint ignore:line
+var juttle = require('./runtime').runtime;
 
 var Juttle = require('./runtime').Juttle;
 var errors = require('./errors');
@@ -29,7 +29,7 @@ var Program = Base.extend({
         }
     },
     _eval: function() {
-        var o = eval(this.code)();
+        var o = eval(this.code)(juttle);
         this.set_env({now: o.now});
         this.graph = o.graph;
         o.program.scheduler = this.scheduler;

--- a/lib/program.js
+++ b/lib/program.js
@@ -29,7 +29,7 @@ var Program = Base.extend({
         }
     },
     _eval: function() {
-        var o = eval(this.code);
+        var o = eval(this.code)();
         this.set_env({now: o.now});
         this.graph = o.graph;
         o.program.scheduler = this.scheduler;


### PR DESCRIPTION
Pass Juttle runtime as an explicit dependency to code evaluated in the `flowgraph` and `eval` stages of the compiler. This means this code does not depend on the `juttle` variable being present in the evaluation context. The change will allow making other dependencies such as `JuttleMoment` explicit too in the future.

Part of work on #97.