### PR TITLE
parser: Avoid module recursion in parser.parse{Value,Filter}

### DIFF
--- a/lib/parser/juttle-parser.js
+++ b/lib/parser/juttle-parser.js
@@ -6,13 +6,21 @@ var parser = require('./parser');
 // Parses a Juttle filter expression synchronously. Returns the resulting AST on
 // success, throws `errors.SyntaxError` on failure.
 function parseFilter(source) {
-    return parseSync(source, { startRule: "startFilter" });
+    return doParse(source, {
+        filename: null,
+        startRule: 'startFilter',
+        autocompleteCallback: null
+    });
 }
 
 // Parses a Juttle value synchronously. Returns the resulting AST on success,
 // throws `errors.SyntaxError` on failure.
 function parseValue(source) {
-    return parseSync(source, { startRule: "startValue" });
+    return doParse(source, {
+        filename: null,
+        startRule: 'startValue',
+        autocompleteCallback: null
+    });
 }
 
 // Parses a Juttle program asynchronously. Returns a promise that is resolved


### PR DESCRIPTION
Fixes #163.