### PR TITLE
JuttleMoment: new constructor option: rawDurationString

### DIFF
--- a/lib/moment/juttle-moment.js
+++ b/lib/moment/juttle-moment.js
@@ -34,6 +34,15 @@ var JuttleMoment = Base.extend({
             this.epsilon = false;
             return;
         }
+
+        // A rawDurationString is the result of a moment.duration().toJSON()
+        // and can be used to construct a moment.duration directly
+        if (options.rawDurationString) {
+            this.duration = moment.duration(options.rawDurationString);
+            this.normalize();
+            return;
+        }
+
         // For cloning a JuttleMoment.
         if (options.duration || options.moment) {
             this.duration = options.duration;


### PR DESCRIPTION
This new option is used for creating a JuttleMoment duration from the native string representation of a momentjs moment.duration.

Will be used by outrigger for instantiating JuttleMoment durations from momentjs moment.duration.

@demmer 