### PR TITLE
Fix displaying of objects and arrays in the table view

### DIFF
--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -71,8 +71,6 @@ var TextView = View.extend({
         var val2 = _.map(values_, function(value) {
             if (typeof(value) === 'undefined') {
                 return '';
-            } else if (values.isArray(value) || values.isObject(value)) {
-                return values.inspect(value);
             } else {
                 return values.toString(value);
             }


### PR DESCRIPTION
With the #200 in, remove the previously used workaround and simply rely on `toString`.

Fixes: #185 