### PR TITLE
JuttleMoment compare returns -1, 0, 1

### DIFF
--- a/lib/moment/juttle-moment.js
+++ b/lib/moment/juttle-moment.js
@@ -173,27 +173,27 @@ var JuttleMoment = Base.extend({
     // Comparison convenience methods
 
     eq: function(operand) {
-        return JuttleMoment.compare('=', this, operand);
+        return JuttleMoment.compare(this, operand) === 0;
     },
 
     ne: function(operand) {
-        return JuttleMoment.compare('!=', this, operand);
+        return JuttleMoment.compare(this, operand) !== 0;
     },
 
     gt: function(operand) {
-        return JuttleMoment.compare('>', this, operand);
+        return JuttleMoment.compare(this, operand) > 0;
     },
 
     gte: function(operand) {
-        return JuttleMoment.compare('>=', this, operand);
+        return JuttleMoment.compare(this, operand) >= 0;
     },
 
     lt: function(operand) {
-        return JuttleMoment.compare('<', this, operand);
+        return JuttleMoment.compare(this, operand) < 0;
     },
 
     lte: function(operand) {
-        return JuttleMoment.compare('<=', this, operand);
+        return JuttleMoment.compare(this, operand) <= 0;
     },
 
     add: function(operand) {
@@ -324,7 +324,7 @@ var JuttleMoment = Base.extend({
 
     // Comparison
 
-    compare: function(operator, operand1, operand2) {
+    compare: function(operand1, operand2) {
         if (!(operand1 && operand1 instanceof JuttleMoment
             && operand2 && operand2 instanceof JuttleMoment)) {
             throw new Error("Can't compare a Date/Duration with other types.");
@@ -336,60 +336,45 @@ var JuttleMoment = Base.extend({
         var ms1 = operand1.milliseconds();
         var ms2 = operand2.milliseconds();
 
-        switch (operator) {
-            case '=':
-            case '==':
-            case '===':
-                return (ms1 === ms2 && operand1.epsilon === operand2.epsilon);
-
-            case '!=':
-                return (ms1 !== ms2 || operand1.epsilon !== operand2.epsilon);
-
-            case '<':
-                return (ms1 < ms2 || (ms1 === ms2 && operand1.epsilon && !operand2.epsilon));
-
-            case '<=':
-                return (ms1 < ms2
-                        || (ms1 === ms2 && (operand1.epsilon === operand2.epsilon
-                                            || operand1.epsilon && !operand2.epsilon)));
-
-            case '>':
-                return (ms1 > ms2 || (ms1 === ms2 && operand2.epsilon && !operand1.epsilon));
-
-            case '>=':
-                return (ms2 < ms1
-                        || (ms2 === ms1 && (operand2.epsilon === operand1.epsilon
-                                            || operand2.epsilon && !operand1.epsilon)));
-
-            default:
-                throw new Error('Invalid operator on JuttleMoments: '+ operator);
+        if (ms1 === ms2) {
+            if (operand1.epsilon === operand2.epsilon) {
+                return 0;
+            } else {
+                return (operand1.epsilon && !operand2.epsilon) ? -1 : 1;
+            }
+        } else {
+            if (ms1 > ms2) {
+                return 1;
+            } else {
+                return -1;
+            }
         }
     },
 
     // Comparison convenience methods
 
     eq: function(operand1, operand2) {
-        return JuttleMoment.compare('=', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) === 0;
     },
 
     ne: function(operand1, operand2) {
-        return JuttleMoment.compare('!=', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) !== 0;
     },
 
     gt: function(operand1, operand2) {
-        return JuttleMoment.compare('>', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) > 0;
     },
 
     gte: function(operand1, operand2) {
-        return JuttleMoment.compare('>=', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) >= 0;
     },
 
     lt: function(operand1, operand2) {
-        return JuttleMoment.compare('<', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) < 0;
     },
 
     lte: function(operand1, operand2) {
-        return JuttleMoment.compare('<=', operand1, operand2);
+        return JuttleMoment.compare(operand1, operand2) <= 0;
     },
 
     // Math

--- a/lib/moment/juttle-moment.js
+++ b/lib/moment/juttle-moment.js
@@ -322,28 +322,6 @@ var JuttleMoment = Base.extend({
         return m;
     },
 
-    evalExpression: function(operator, operand1, operand2) {
-        switch (operator) {
-            case '+':
-                return JuttleMoment.add(operand1, operand2);
-
-            case '-':
-                return JuttleMoment.subtract(operand1, operand2);
-
-            case '*':
-                return JuttleMoment.multiply(operand1, operand2);
-
-            case '/':
-                return JuttleMoment.divide(operand1, operand2);
-
-            case '%':
-                return JuttleMoment.remainder(operand1, operand2);
-
-            default:
-                return JuttleMoment.compare(operator, operand1, operand2);
-        }
-    },
-
     // Comparison
 
     compare: function(operator, operand1, operand2) {

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -200,7 +200,7 @@ var values = {
                 return a === b ? 0 : (a > b ? 1 : -1);
             case 'Date':
             case 'Duration':
-                return JuttleMoment.eq(a, b) ? 0 : JuttleMoment.gt(a, b) ? 1 : -1;
+                return JuttleMoment.compare(a, b);
             case 'Array':
                 return compareArrays(a, b);
             default:

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect;
 var _ = require('underscore');
 var values = require('../../lib/runtime/values');
+var JuttleMoment = require('../../lib/moment').JuttleMoment;
 
 describe('Values tests', function () {
     describe('compare', function() {
@@ -39,6 +40,95 @@ describe('Values tests', function () {
                 expect(values.compare(test.left, test.right)).to.equal(
                     test.result,
                     JSON.stringify(test.left) + ' <=> ' + JSON.stringify(test.right)
+                );
+            });
+        });
+
+        it('moment', function() {
+            var tests = [
+                {
+                    left: new JuttleMoment(1),
+                    right: new JuttleMoment(0),
+                    result: 1
+                },
+                {
+                    left: new JuttleMoment(0),
+                    right: new JuttleMoment(0),
+                    result: 0
+                },
+                {
+                    left: new JuttleMoment(0),
+                    right: new JuttleMoment(1),
+                    result: -1
+                },
+                {
+                    left: new JuttleMoment({ raw: 0, epsilon: true }),
+                    right: new JuttleMoment({ raw: 0, epsilon: true  }),
+                    result: 0
+                },
+                {
+                    left: new JuttleMoment({ raw: 0, epsilon: false }),
+                    right: new JuttleMoment({ raw: 0, epsilon: false }),
+                    result: 0
+                },
+                {
+                    left: new JuttleMoment({ raw: 0, epsilon: true }),
+                    right: new JuttleMoment({ raw: 0, epsilon: false }),
+                    result:  -1
+                },
+                {
+                    left: new JuttleMoment({ raw: 0, epsilon: false }),
+                    right: new JuttleMoment({ raw: 0, epsilon: true }),
+                    result: 1
+                },
+                {
+                    left: new JuttleMoment(Infinity),
+                    right: new JuttleMoment(Infinity),
+                    result: 0
+                },
+                {
+                    left: new JuttleMoment(-Infinity),
+                    right: new JuttleMoment(-Infinity),
+                    result: 0
+                },
+                {
+                    left: new JuttleMoment(Infinity),
+                    right: new JuttleMoment(-Infinity),
+                    result: 1
+                },
+                {
+                    left: new JuttleMoment(-Infinity),
+                    right: new JuttleMoment(Infinity),
+                    result: -1
+                },
+                {
+                    left: new JuttleMoment({ raw: Infinity, epsilon: true }),
+                    right: new JuttleMoment({ raw: Infinity, epsilon: false }),
+                    result: -1
+                },
+                {
+                    left: new JuttleMoment({ raw: Infinity, epsilon: false }),
+                    right: new JuttleMoment({ raw: Infinity, epsilon: true }),
+                    result: 1
+                },
+                {
+                    left: new JuttleMoment({ raw: -Infinity, epsilon: true }),
+                    right: new JuttleMoment({ raw: -Infinity, epsilon: false }),
+                    result: -1
+                },
+                {
+                    left: new JuttleMoment({ raw: -Infinity, epsilon: false }),
+                    right: new JuttleMoment({ raw: -Infinity, epsilon: true }),
+                    result: 1
+                },
+            ];
+
+            _.each(tests, function(test) {
+                expect(values.compare(test.left, test.right)).to.equal(
+                    test.result,
+                    test.left.valueOf() + ' (eps: ' + test.left.epsilon + ')'
+                    + ' <=> '
+                    + test.right.valueOf() + ' (eps: ' + test.right.epsilon + ')'
                 );
             });
         });


### PR DESCRIPTION
To be consistent with `values.js` compare and simplify the
implementation a bit, make `compare` for JuttleMoments return -1, 0, 1
for smaller, equal, or greater values.

Update the helper functions (`lt` / `gt`...) to handle new return values.