### PR TITLE
Update emacs make cmd to use outrigger-client.

### DIFF
--- a/misc/emacs/juttle-derived-mode.el
+++ b/misc/emacs/juttle-derived-mode.el
@@ -14,7 +14,7 @@
 ;; (setq juttle-run-dir "/home/<user>/src/juttle/bin")
 
 (defvar juttle-run-dir "")
-(defvar juttle-run-prog "demo")
+(defvar juttle-run-prog "outrigger-client push --topic mydev --path")
 
 (defvar juttle-derived-mode-hook nil "hooks")
 


### PR DESCRIPTION
Now that we have rendezvous, update the emacs "build" command to use
outrigger-client push, which is our preferred way of pushing programs
into juttled.

This fixes #198.

@mnibecker 