### PR TITLE
Purge utils.fromNative from views

### DIFF
--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -2,7 +2,6 @@
 var _ = require('underscore');
 var Table = require('cli-table');
 var View = require('./view.js');
-var utils = require('../runtime').utils;
 var values = require('../runtime/values');
 
 var TableView = View.extend({
@@ -117,8 +116,6 @@ var TableView = View.extend({
         if (self.options.limit && self.items_written >= self.options.limit) {
             return;
         }
-
-        data = utils.fromNative(data.map(_.clone));
 
         // In progressive mode, look at the first batch of points to detect the
         // columns and determine their widths based on the length of the fields.

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -2,7 +2,6 @@
 var _ = require('underscore');
 var babyparse = require('babyparse');
 var View = require('./view.js');
-var utils = require('../runtime').utils;
 var values = require('../runtime/values');
 
 var TextView = View.extend({
@@ -132,7 +131,7 @@ var TextView = View.extend({
     consume: function(data) {
         var self = this;
 
-        utils.fromNative(data.map(_.clone)).forEach(function(point) {
+        data.forEach(function(point) {
             self.format_point(point);
         });
     },


### PR DESCRIPTION
Views should properly handle all Juttle data types by themselves, there is no need for the conversion.