### PR TITLE
view options: emit moment.duration instead of seconds

### DIFF
--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -208,7 +208,7 @@ Juttle.alloc_channel = alloc_channel;
 function convert_options(o) {
     if (o instanceof JuttleMoment) {
         if (o.duration) {
-            return o.valueOf();
+            return o.duration;
         }
         else {
             return o.moment.toDate();

--- a/test/compiler/views_sourceinfo.spec.js
+++ b/test/compiler/views_sourceinfo.spec.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var compiler = require('../../lib/compiler');
 var views_sourceinfo = require('../../lib/compiler/flowgraph/views_sourceinfo.js');
 var juttle_test_utils = require('../runtime/specs/juttle-test-utils'); // jshint ignore: line
+var moment = require('moment');
 
 describe('Views get info on source time bounds', function() {
     function test(juttle, spec) {
@@ -16,19 +17,19 @@ describe('Views get info on source time bounds', function() {
                     actual = views[i].options._jut_time_bounds[j];
 
                     if (expected.from !== null) {
-                        expect(expected.from).to.equal(actual.from.toISOString());
+                        expect(expected.from.toISOString()).to.equal(actual.from.toISOString());
                     } else {
                         expect(expected.from).to.be.null;
                     }
 
                     if (expected.to !== null) {
-                        expect(expected.to).to.equal(actual.to.toISOString());
+                        expect(expected.to.toISOString()).to.equal(actual.to.toISOString());
                     } else {
                         expect(expected.to).to.be.null;
                     }
 
                     if (expected.last !== null) {
-                        expect(expected.last).to.equal(actual.last);
+                        expect(expected.last.as("seconds")).to.equal(actual.last.as("seconds"));
                     } else {
                         expect(expected.last).to.be.null;
                     }
@@ -37,19 +38,19 @@ describe('Views get info on source time bounds', function() {
         });
     }
 
-    var from = '2015-01-01T00:00:00.000Z';
-    var to = '2015-02-02T00:00:00.000Z';
-    var last = '01:00:00.000';
+    var from = new Date('2015-01-01T00:00:00.000Z');
+    var to = new Date('2015-02-02T00:00:00.000Z');
+    var last = moment.duration(1, "hour");
 
     test('read stochastic -source "cdn" | view view ', [[{from: null, to: null, last: null}]]);
-    test('read stochastic -source "cdn" -from :' + from + ': | view view ', [[{from: from, to: null, last: null}]]);
-    test('read stochastic -source "cdn" -from :' + from + ': -to :' + to + ': | view view ', [[{from: from, to: to, last: null}]]);
-    test('read stochastic -last :' + last + ': -source "cdn" | view view ', [[{from: null, to: null, last: last}]]);
+    test('read stochastic -source "cdn" -from :' + from.toISOString() + ': | view view ', [[{from: from, to: null, last: null}]]);
+    test('read stochastic -source "cdn" -from :' + from.toISOString() + ': -to :' + to.toISOString() + ': | view view ', [[{from: from, to: to, last: null}]]);
+    test('read stochastic -last :' + last.as("seconds") + 's' + ': -source "cdn" | view view ', [[{from: null, to: null, last: last}]]);
 
-    test('read stochastic -source "cdn" -from :' + from + ': | view view; read stochastic -last :' + last + ': -source "cdn"  | view view ',
+    test('read stochastic -source "cdn" -from :' + from.toISOString() + ': | view view; read stochastic -last :' + last.as("seconds") + 's' + ': -source "cdn"  | view view ',
          [[{from: from, to: null, last: null}], [{from: null, to: null, last: last}]]);
 
-    test('(read stochastic -source "cdn" -from :' + from + ':; read stochastic -last :' + last + ': -source "cdn" ) | view view ',
+    test('(read stochastic -source "cdn" -from :' + from.toISOString() + ':; read stochastic -last :' + last.as("seconds") + 's' + ': -source "cdn" ) | view view ',
          [[{from: from, to: null, last: null}, {from: null, to: null, last: last}]]);
 
 });

--- a/test/runtime/sinks.spec.js
+++ b/test/runtime/sinks.spec.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var juttle_test_utils = require('./specs/juttle-test-utils');
 var compile_juttle = juttle_test_utils.compile_juttle;
 var check_juttle = juttle_test_utils.check_juttle;
+var moment = require('moment');
 
 
 describe('Juttle sinks validation', function() {
@@ -174,11 +175,12 @@ describe('Juttle sinks validation', function() {
             } );
     } );
 
-    it('converts a duration sink option to a string representation', function() {
+    it('converts a duration sink option to a moment.duration', function() {
         var program = 'emit -limit 1 | view result -d :10 minutes:';
         return check_juttle({ program: program })
             .then(function(res) {
-                expect(sink_options(res.prog, 0).d).to.equal('00:10:00.000');
+                expect(moment.isDuration(sink_options(res.prog, 0).d)).to.equal(true);
+                expect(sink_options(res.prog, 0).d.as("minutes")).to.equal(10);
             } );
     } );
 
@@ -193,11 +195,12 @@ describe('Juttle sinks validation', function() {
             } );
     } );
 
-    it('converts a nested duration sink option to its string representation', function() {
+    it('converts a nested duration sink option to a moment.duration', function() {
         var program = 'emit -limit 1 | view result -a.b.c :250 milliseconds:';
         return check_juttle({ program: program })
             .then(function(res) {
-                expect(sink_options(res.prog, 0).a.b.c).to.equal('00:00:00.250');
+                expect(moment.isDuration(sink_options(res.prog, 0).a.b.c)).to.equal(true);
+                expect(sink_options(res.prog, 0).a.b.c.as("milliseconds")).to.equal(250);
             } );
     } );
 
@@ -212,11 +215,12 @@ describe('Juttle sinks validation', function() {
             } );
     } );
 
-    it('converts a duration sink option in an array to its string representation', function() {
+    it('converts a duration sink option in an array to be a moment.duration', function() {
         var program = 'emit -limit 1 | view result -d [ :1 day: ]';
         return check_juttle({ program: program })
             .then(function(res) {
-                expect(sink_options(res.prog, 0).d[0]).to.equal('1d');
+                expect(moment.isDuration(sink_options(res.prog, 0).d[0])).to.equal(true);
+                expect(sink_options(res.prog, 0).d[0].as("days")).to.equal(1);
             } );
     } );
 


### PR DESCRIPTION
This is necessary as part of the work we are doing with [jsdp](https://github.com/juttle/juttle-jsdp) so browser views can be instantiated with real values (instead of numeric or string representations) on the other side of the websocket.

@demmer @dmajda 