### PR TITLE
Add json module

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -48,6 +48,7 @@ var SemanticPass = Base.extend({
         this.import_date_module();
         this.import_duration_module();
         this.import_object_module();
+        this.import_json_module();
         this.import_juttle_module();
     },
     import_math_module: function() {
@@ -215,6 +216,16 @@ var SemanticPass = Base.extend({
                 new:          { type: 'function', exported: true, name: 'juttle.modules.duration.new',          arg_count: 1 },
                 seconds:      { type: 'function', exported: true, name: 'juttle.modules.duration.seconds',      arg_count: 1 },
                 toString:     { type: 'function', exported: true, name: 'juttle.modules.duration.toString',     arg_count: 1 },
+            }
+        });
+    },
+    import_json_module: function() {
+        this.scope.put('JSON', {
+            type: 'import',
+            exported: false,
+            exports: {
+                parse:       { type: 'function', exported: true, name: 'juttle.modules.json.parse',       arg_count: 1 },
+                stringify:   { type: 'function', exported: true, name: 'juttle.modules.json.stringify',   arg_count: 1 },
             }
         });
     },

--- a/lib/runtime/errors.js
+++ b/lib/runtime/errors.js
@@ -38,6 +38,14 @@ var errors = {
         return juttleErrors.runtimeError('RT-TYPE-ERROR', { message: message });
     },
 
+    jsonParseError: function(message, value) {
+        var detail = message
+            + ' in '
+            + values.typeDisplayName(values.typeOf(value)) + valueString(value) + '.';
+
+        return juttleErrors.runtimeError('RT-INVALID-JSON-ERROR', { detail: detail });
+    },
+
     typeErrorTime: function(value) {
         var message = 'Invalid type assigned to time: '
             + values.typeDisplayName(values.typeOf(value)) + valueString(value) + '.';

--- a/lib/runtime/modules/index.js
+++ b/lib/runtime/modules/index.js
@@ -11,6 +11,7 @@ var regexp = require('./regexp');
 var string = require('./string');
 var object = require('./object');
 var juttle = require('./juttle');
+var json = require('./json');
 
 var modules = {
     boolean: boolean,
@@ -18,6 +19,7 @@ var modules = {
     date: date,
     duration: duration,
     juttle: juttle,
+    json: json,
     math: math,
     null: null_,
     number: number,

--- a/lib/runtime/modules/json.js
+++ b/lib/runtime/modules/json.js
@@ -1,0 +1,24 @@
+/* Implementation of Juttle built-in JSON module. */
+
+var errors = require('../errors');
+var values = require('../values');
+
+var json = {
+    stringify: function(value) {
+        return JSON.stringify(values.toJSONCompatible(value));
+    },
+
+    parse: function(string) {
+        if (!values.isString(string)) {
+            throw errors.typeErrorFunction('JSON.parse', 'string', string);
+        }
+
+        try {
+            return JSON.parse(string);
+        } catch (e) {
+            throw errors.jsonParseError(e.message, string);
+        }
+    }
+};
+
+module.exports = json;

--- a/test/runtime/specs/juttle-spec/modules/json/parse.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/json/parse.spec.md
@@ -1,0 +1,46 @@
+The `JSON.parse` function
+=============================
+
+Returns correct result with array
+---------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = JSON.parse("[1,2,3]") | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "result": [1, 2, 3] }
+
+Returns correct result with a nested object
+-------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = JSON.parse('[1,2,{ "key": "value" }]') | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "result": [1, 2, { "key": "value" }] }
+
+Produces an error when argument `string` cannot be parsed
+--------------------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = JSON.parse("[1,2,") | view result
+
+### Warnings
+
+  * Unexpected end of input in string ([1,2,)
+
+Produces an error when argument `string` is not a string
+--------------------------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = JSON.parse(1) | view result
+
+### Warnings
+
+  * Error: Invalid argument type for "JSON.parse": expected string

--- a/test/runtime/specs/juttle-spec/modules/json/stringify.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/json/stringify.spec.md
@@ -1,0 +1,43 @@
+The `JSON.stringify` function
+=============================
+
+Returns correct result with array
+---------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1
+    | put array = [1, 2, 3]
+    | put result = JSON.stringify(#array)
+    | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "array": [1, 2, 3], "result": "[1,2,3]" }
+
+Returns correct result with a nested object
+-------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1
+    | put nested = [1,2, { key: "value" }]
+    | put result = JSON.stringify(#nested)
+    | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "nested": [1, 2, { "key": "value" }], "result": "[1,2,{\"key\":\"value\"}]" }
+
+Returns correct result with a moment
+------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1
+    | put result = JSON.stringify(#time)
+    | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "result": "\"1970-01-01T00:00:00.000Z\"" }


### PR DESCRIPTION
A draft for implementing Json module for Juttle.

The reasoning behind introducing a `Json` module is that adapters can produce serialised JSON values, which the user might want to parse, e.g. in the cases when the JSON type cannot be inferred from the schema.

There are two open questions:

1. how should we report parse errors from JSON parser? As a warning?
2. there seems to be a bug in juttle-spec dealing with nested objects, as mocha outputs (this can be observed when running the tests):
```
    -      {
    -        "key": "value"
    -      }
    +      [
    +        [Function]
    +      ]
```