### PR TITLE
view options: don't use convert_options

### DIFF
--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var Promise = require('bluebird');
-var JuttleMoment = require('../../moment').JuttleMoment;
 var errors = require('../../errors');
 
 var reducers = require('../reducers').reducers;
@@ -203,35 +202,6 @@ function alloc_channel(prefix) {
 
 Juttle.alloc_channel = alloc_channel;
 
-// options passed to views don't want to see moments.
-// so convert moments to Dates and durations to numbers in seconds.
-function convert_options(o) {
-    if (o instanceof JuttleMoment) {
-        if (o.duration) {
-            return o.valueOf();
-        }
-        else {
-            return o.moment.toDate();
-        }
-    }
-
-    if (!_.isObject(o)) { return o; }
-    if (_.isArray(o)) {
-        return _.map(o, convert_options);
-    }
-
-    var r = {};
-    _.each(o, function(val, name) {
-        if (_.isObject(val) && !_.isFunction(val)) {
-            r[name] = convert_options(val);
-        }
-        else {
-            r[name] = val;
-        }
-    } );
-    return r;
-}
-
 var SINK_INFO = {
     type: 'sink',
     options: {}   // documented, non-deprecated options only
@@ -242,7 +212,7 @@ var SINK_INFO = {
 Juttle.proc.view = Juttle.proc.publish.extend({
     initialize: function(options, params) {
         this.name = params.name;
-        this.options = convert_options(options);
+        this.options = options;
         var chan = alloc_channel('sink');
         this.channel = chan;
     },

--- a/test/compiler/views_sourceinfo.spec.js
+++ b/test/compiler/views_sourceinfo.spec.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var compiler = require('../../lib/compiler');
 var views_sourceinfo = require('../../lib/compiler/flowgraph/views_sourceinfo.js');
 var juttle_test_utils = require('../runtime/specs/juttle-test-utils'); // jshint ignore: line
+var JuttleMoment = require('../../lib/moment').JuttleMoment;
 
 describe('Views get info on source time bounds', function() {
     function test(juttle, spec) {
@@ -16,19 +17,19 @@ describe('Views get info on source time bounds', function() {
                     actual = views[i].options._jut_time_bounds[j];
 
                     if (expected.from !== null) {
-                        expect(expected.from).to.equal(actual.from.toISOString());
+                        expect(JuttleMoment.eq(expected.from, actual.from)).to.equal(true);
                     } else {
                         expect(expected.from).to.be.null;
                     }
 
                     if (expected.to !== null) {
-                        expect(expected.to).to.equal(actual.to.toISOString());
+                        expect(JuttleMoment.eq(expected.to, actual.to)).to.equal(true);
                     } else {
                         expect(expected.to).to.be.null;
                     }
 
                     if (expected.last !== null) {
-                        expect(expected.last).to.equal(actual.last);
+                        expect(JuttleMoment.eq(expected.last, actual.last)).to.equal(true);
                     } else {
                         expect(expected.last).to.be.null;
                     }
@@ -37,19 +38,19 @@ describe('Views get info on source time bounds', function() {
         });
     }
 
-    var from = '2015-01-01T00:00:00.000Z';
-    var to = '2015-02-02T00:00:00.000Z';
-    var last = '01:00:00.000';
+    var from = new JuttleMoment({ raw: '2015-01-01T00:00:00.000Z' });
+    var to = new JuttleMoment({ raw: '2015-02-02T00:00:00.000Z' });
+    var last = new JuttleMoment.duration(1, "hour");
 
     test('read stochastic -source "cdn" | view view ', [[{from: null, to: null, last: null}]]);
-    test('read stochastic -source "cdn" -from :' + from + ': | view view ', [[{from: from, to: null, last: null}]]);
-    test('read stochastic -source "cdn" -from :' + from + ': -to :' + to + ': | view view ', [[{from: from, to: to, last: null}]]);
-    test('read stochastic -last :' + last + ': -source "cdn" | view view ', [[{from: null, to: null, last: last}]]);
+    test('read stochastic -source "cdn" -from :' + from.valueOf() + ': | view view ', [[{from: from, to: null, last: null}]]);
+    test('read stochastic -source "cdn" -from :' + from.valueOf() + ': -to :' + to.valueOf() + ': | view view ', [[{from: from, to: to, last: null}]]);
+    test('read stochastic -last :' + last.valueOf() + ': -source "cdn" | view view ', [[{from: null, to: null, last: last}]]);
 
-    test('read stochastic -source "cdn" -from :' + from + ': | view view; read stochastic -last :' + last + ': -source "cdn"  | view view ',
+    test('read stochastic -source "cdn" -from :' + from.valueOf() + ': | view view; read stochastic -last :' + last.valueOf() + ': -source "cdn"  | view view ',
          [[{from: from, to: null, last: null}], [{from: null, to: null, last: last}]]);
 
-    test('(read stochastic -source "cdn" -from :' + from + ':; read stochastic -last :' + last + ': -source "cdn" ) | view view ',
+    test('(read stochastic -source "cdn" -from :' + from.valueOf() + ':; read stochastic -last :' + last.valueOf() + ': -source "cdn" ) | view view ',
          [[{from: from, to: null, last: null}, {from: null, to: null, last: last}]]);
 
 });

--- a/test/runtime/sinks.spec.js
+++ b/test/runtime/sinks.spec.js
@@ -163,63 +163,6 @@ describe('Juttle sinks validation', function() {
             } );
     } );
 
-    it('converts a moment sink option to a Date', function() {
-        var now = new Date();
-        var program = 'emit -limit 1 | view result -d'
-            + ' :' + now.toISOString() + ':';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).d.getTime())
-                    .to.equal(now.getTime());
-            } );
-    } );
-
-    it('converts a duration sink option to a string representation', function() {
-        var program = 'emit -limit 1 | view result -d :10 minutes:';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).d).to.equal('00:10:00.000');
-            } );
-    } );
-
-    it('converts a nested moment sink option to a Date', function() {
-        var now = new Date();
-        var program = 'emit -limit 1 | view result -a.b.c'
-            + ' :' + now.toISOString() + ':';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).a.b.c.getTime())
-                    .to.equal(now.getTime());
-            } );
-    } );
-
-    it('converts a nested duration sink option to its string representation', function() {
-        var program = 'emit -limit 1 | view result -a.b.c :250 milliseconds:';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).a.b.c).to.equal('00:00:00.250');
-            } );
-    } );
-
-    it('converts a moment sink option in an array to a Date', function() {
-        var now = new Date();
-        var program = 'emit -limit 1 | view result -d'
-            + ' [ :' + now.toISOString() + ': ]';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).d[0].getTime())
-                    .to.equal(now.getTime());
-            } );
-    } );
-
-    it('converts a duration sink option in an array to its string representation', function() {
-        var program = 'emit -limit 1 | view result -d [ :1 day: ]';
-        return check_juttle({ program: program })
-            .then(function(res) {
-                expect(sink_options(res.prog, 0).d[0]).to.equal('1d');
-            } );
-    } );
-
     it('handles dots for nested sink arguments', function() {
         var program = 'emit -limit 1 | view result -foo.bar.baz 5';
         var nested = {


### PR DESCRIPTION
Emit view options as they are, instead of converting moments to JS Dates and moment durations to seconds.

This is necessary as part of the work we are doing with jsdp so browser views can be instantiated with real values (instead of numeric or string representations) on the other side of the websocket.

@dmajda cc @demmer 