### PR TITLE
CSV stdio serializer supports arrays/objects

### DIFF
--- a/lib/adapters/serializers/csv.js
+++ b/lib/adapters/serializers/csv.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var base = require('./base');
 var csv = require('csv-write-stream');
 var errors = require('../../errors');
+var values = require('../../runtime/values');
 
 module.exports = base.extend({
 
@@ -10,6 +11,12 @@ module.exports = base.extend({
 
         _.each(points, function(point) {
             var keys = _.keys(point);
+
+            _.each(point, function(value, key) {
+                if (values.isArray(value) || values.isObject(value)) {
+                    point[key] = JSON.stringify(value);
+                }
+            });
 
             if (!self.headers) {
                 self.headers = keys;


### PR DESCRIPTION
Serialize array/object values using JSON, to keep point structure flat
and processable by CSV writer.