### PR TITLE
updating to our own node-grok fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment-duration-format": "^1.3.0",
     "moment-parser": "^0.3.0",
     "moment-timezone": "^0.4.0",
-    "node-grok": "github:beh01der/node-grok#b76dae6dc4efa745e6bf75a3cb8d113aa47bc16e",
+    "node-grok": "github:rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe",
     "oboe": "^2.1.2",
     "pegjs": "^0.9.0",
     "request": "^2.67.0",


### PR DESCRIPTION
fixes #225

due to issues in a package dependency of node-grok this is a quick fix
to depend on our own fixed version of the node-grok source.