### PR TITLE
Changes for 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents all notable changes to Juttle. The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.3.1
+
+Released 2016-01-21
+
+### Bug Fixes
+
+- Use our own `node-grok` fork which uses `collections^2.0` to avoid buggy reimplementation of `Array.prototype.find` in earlier versions. [[#225](https://github.com/juttle/juttle/issues/225)]
+
 ## 0.3.0
 
 Released 2016-01-20

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "moment-duration-format": "^1.3.0",
     "moment-parser": "^0.3.0",
     "moment-timezone": "^0.4.0",
-    "node-grok": "github:beh01der/node-grok#b76dae6dc4efa745e6bf75a3cb8d113aa47bc16e",
+    "node-grok": "github:rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe",
     "oboe": "^2.1.2",
     "pegjs": "^0.9.0",
     "request": "^2.67.0",


### PR DESCRIPTION
This PR contains changes needed for 0.3.1:

  * Copy of the fix for #225
  * `CHANGELOG.md` update

The PR is against the `0.3.x` branch started off the `v0.3.0` tag. The idea is to release `0.3.1` off this branch instead of master in order to avoid carrying any other changes than the fix.