### PR TITLE
To json compatible

### DIFF
--- a/lib/runtime/juttle-utils.js
+++ b/lib/runtime/juttle-utils.js
@@ -25,19 +25,7 @@ function toNative(records, epsilon) {
 }
 
 function fromNative(records) {
-    function convert(record) {
-        _.each(record, function(value, key) {
-            if (values.isDate(value) || values.isDuration(value)) {
-                record[key] = value.valueOf();
-            } else if (values.isObject(value) || values.isArray(value)) {
-                convert(value);
-            }
-        });
-    }
-
-    _.each(records, convert);
-
-    return records;
+    return _.map(records, values.toJSONCompatible, values);
 }
 
 function isInteger(x) {

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -293,6 +293,33 @@ var values = {
         }
     },
 
+    // Returns a value that can be serialized to JSON.
+    toJSONCompatible: function(value) {
+        switch (values.typeOf(value)) {
+            case 'Null':
+            case 'Boolean':
+            case 'String':
+            case 'Number':
+                return value;
+
+            case 'RegExp':
+                return String(value);
+
+            case 'Date':
+            case 'Duration':
+                return value.valueOf();
+
+            case 'Filter':
+                return value.text;
+
+            case 'Array':
+                return _.map(value, this.toJSONCompatible, this);
+
+            case 'Object':
+                return _.mapObject(value, this.toJSONCompatible, this);
+        }
+    },
+
     // Returns string representation of a Juttle value. This representation is
     // intended to be used in places where readability has precedence over
     // exactness (e.g. gadgets, charts).

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -198,11 +198,14 @@ var values = {
             case 'Number':
             case 'String':
                 return a === b ? 0 : (a > b ? 1 : -1);
+
             case 'Date':
             case 'Duration':
                 return JuttleMoment.compare(a, b);
+
             case 'Array':
                 return compareArrays(a, b);
+
             default:
                 throw errors.typeErrorIncomparable(a, b);
         }

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -5,6 +5,79 @@ var JuttleMoment = require('../../lib/moment').JuttleMoment;
 var Filter = require('../../lib/runtime/filter');
 
 describe('Values tests', function () {
+    describe('toJSONCopmatible', function() {
+        it('returns correct representation', function() {
+            var tests = [
+                {
+                    value: true,
+                    expected: true,
+                },
+                {
+                    value: null,
+                    expected: null,
+                },
+                {
+                    value: 10,
+                    expected: 10,
+                },
+                {
+                    value: Infinity,
+                    expected: Infinity,
+                },
+                {
+                    value: NaN,
+                    expected: NaN,
+                },
+                {
+                    value: 'hello',
+                    expected: 'hello',
+                },
+                {
+                    value: new RegExp('abc'),
+                    expected: '/abc/',
+                },
+                {
+                    value: new JuttleMoment(0),
+                    expected: '1970-01-01T00:00:00.000Z',
+                },
+                {
+                    value: new Filter({
+                        type: 'ExpressionFilterTerm',
+                        expression: {
+                            type: 'BinaryExpression',
+                            operator: '<',
+                            left: { type: 'Variable', name: 'a' },
+                            right: { type: 'NumericLiteral', value: 5 }
+                        }
+                    },
+                    'a < 5'
+                    ),
+                    expected: 'a < 5',
+                },
+                {
+                    value: [1, 2, "a"],
+                    expected: [1, 2, "a"],
+                },
+                {
+                    value: [1, 2, new JuttleMoment(0)],
+                    expected: [1, 2, '1970-01-01T00:00:00.000Z']
+                },
+                {
+                    value: { a: 'b', c: 'd' },
+                    expected: { a: 'b', c: 'd' },
+                },
+                {
+                    value: [1, 2, { o: { a: new JuttleMoment(0), c: 'd' } }],
+                    expected: [1, 2, { o: { a: '1970-01-01T00:00:00.000Z', c: 'd' } }]
+                }
+            ];
+
+            _.each(tests, function(test) {
+                expect(values.toJSONCompatible(test.value)).to.deep.equal(test.expected);
+            });
+        });
+    });
+
     describe('compare', function() {
         describe('invalid comparison', function() {
             it('throws error', function() {

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -209,7 +209,7 @@ describe('Values tests', function () {
                     expected: '[ 1, 2, 3 ]'
                 },
                 {
-                    value: ["abcd", new JuttleMoment.duration('5', 'seconds') ],
+                    value: ['abcd', new JuttleMoment.duration('5', 'seconds') ],
                     expected: '[ "abcd", :00:00:05.000: ]'
                 },
                 {
@@ -221,7 +221,7 @@ describe('Values tests', function () {
                     expected: '{ a: 1, b: 2, c: 3 }'
                 },
                 {
-                    value: { a: "abcd", b: new JuttleMoment.duration('5', 'seconds') },
+                    value: { a: 'abcd', b: new JuttleMoment.duration('5', 'seconds') },
                     expected: '{ a: "abcd", b: :00:00:05.000: }'
                 },
             ];
@@ -307,7 +307,7 @@ describe('Values tests', function () {
                     expected: '[ 1, 2, 3 ]'
                 },
                 {
-                    value: ["abcd", new JuttleMoment.duration('5', 'seconds') ],
+                    value: ['abcd', new JuttleMoment.duration('5', 'seconds') ],
                     expected: '[ "abcd", :00:00:05.000: ]'
                 },
                 {
@@ -319,7 +319,7 @@ describe('Values tests', function () {
                     expected: '{ a: 1, b: 2, c: 3 }'
                 },
                 {
-                    value: { a: "abcd", b: new JuttleMoment.duration('5', 'seconds') },
+                    value: { a: 'abcd', b: new JuttleMoment.duration('5', 'seconds') },
                     expected: '{ a: "abcd", b: :00:00:05.000: }'
                 },
             ];


### PR DESCRIPTION
Converting juttle values to JSON compatible representation occurs
frequently enough to warrant a 'canonical' implementation.

Add `values.toJSONCompatible` and switch `JuttleUtils.fromNative` to use it.

refs: #209