### PR TITLE
juttle-spec: Fix handling of nested arrays/objects

### DIFF
--- a/test/runtime/specs/juttle-spec/juttle-spec.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-spec.spec.md
@@ -76,3 +76,14 @@ Marks with time
     {"time": "1970-01-01T00:00:01.000Z", "mark": true }
     {"time": "1970-01-01T00:00:01.000Z"}
     {"time": "1970-01-01T00:00:02.000Z", "mark": true}
+
+Array/Object values
+-------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = [1, 2, { "key": "value" }] | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", "result": [1, 2, { "key": "value" }] }

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -156,7 +156,7 @@ var SpecRenderer = Base.extend({
         ].join('\n'));
 
         if (test.output !== null) {
-            parts.push('            expect(res.sinks.result).to.deep.equal(' + util.inspect(test.output) + ');');
+            parts.push('            expect(res.sinks.result).to.deep.equal(' + util.inspect(test.output, { depth: null }) + ');');
         }
         if (test.errors.length > 0) {
             for (var erri=0 ; erri < test.errors.length ; erri++) {


### PR DESCRIPTION
When generating test expectation, `util.inspect` was used with the default
level of depth 2. This lead to fake test failures when the expected
object was deeper than that and its values were represented by a
placeholder, e.g. `[Object]` or `[Array]`.

Pass `depth: null` parameter to `util.inspect` for infinite depth.