### PR TITLE
Change FTS sytnax to use the ?= operator

### DIFF
--- a/docs/concepts/filtering.md
+++ b/docs/concepts/filtering.md
@@ -107,21 +107,19 @@ present in any field.
 The [filter](../processors/filter.md) processor does not support full-text search -- it can only be used as part of a read from an external backend that supports search.
 
 
-The search terms for full-text search are currently expressed as standalone strings in the filter expression for `read`. Search terms and other filter expressions can be combined with the AND, OR, NOT operators.
-
-:construction: The syntax for full-text search will be changed soon to add a `?` operator.
+The search terms for full-text search are expressed using the `?=` operator followed by the search string in the filter expression for `read`. Search terms and other filter expressions can be combined with the AND, OR, NOT operators.
 
 
 For example the following searches all documents in the last day for the term "alarm":
 
 ```juttle
-read elastic -last :1 day: "alarm"
+read elastic -last :1 day: ?= "alarm"
 ```
 
 And the following searches all documents in the last day containing the term "alarm" and where the `env` field is not equal to "test".
 
 ```juttle
-read elastic -last :1 day: 'alarm' AND NOT env = 'test'
+read elastic -last :1 day: ?= 'alarm' AND NOT env = 'test'
 ```
 
 ### Quoted terms match exact phrases only
@@ -129,7 +127,7 @@ read elastic -last :1 day: 'alarm' AND NOT env = 'test'
 For example, the following matches points in which one or more fields contain the *exact phrase* "alarm failed":
 
 ```juttle
-read elastic -last :1 day: "alarm failed"
+read elastic -last :1 day: ?= "alarm failed"
 ```
 
 It does not match points in which one field contains "alarm" and
@@ -138,7 +136,7 @@ field contains "alarm has failed". To match those points, use this
 instead:
 
 ```juttle
-read elastic -last :1 day: "alarm" "failed"
+read elastic -last :1 day: ?= "alarm" ?= "failed"
 ```
 
 ### Terms analysis

--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -45,7 +45,8 @@ var NODE_CHILDREN = {
 
     /* Filter expressions */
     ExpressionFilterTerm:     ['expression'],
-    SimpleFilterTerm:         ['expression'],
+    FulltextFilterTerm:       ['expression'],
+    ReferenceFilterTerm:      ['expression'],
     FilterLiteral:            ['ast'],
 
     /* Procs (sorted alphabetically) */

--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -67,20 +67,23 @@ var FilterChecker = ASTVisitor.extend({
         }
     },
 
-    visitSimpleFilterTerm: function(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-                break;
+    visitFulltextFilterTerm: function(node) {
+        if (node.expression.type !== 'StringLiteral') {
+            throw errors.compileError('RT-INVALID-TERM-TYPE', {
+                type: this._nodeTypeDisplayName(node.expression.type),
+                location: node.location
+            });
+        }
+    },
 
-            case 'FilterLiteral':
-                this.visit(node.expression);
-                break;
-
-            default:
-                throw errors.compileError('RT-INVALID-TERM-TYPE', {
-                    type: this._nodeTypeDisplayName(node.expression.type),
-                    location: node.location
-                });
+    visitReferenceFilterTerm: function(node) {
+        if (node.expression.type === 'FilterLiteral') {
+            this.visit(node.expression);
+        } else {
+            throw errors.compileError('RT-INVALID-TERM-TYPE', {
+                type: this._nodeTypeDisplayName(node.expression.type),
+                location: node.location
+            });
         }
     },
 

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -96,17 +96,12 @@ var FilterJSCompiler = ASTVisitor.extend({
         return this.visit(node.expression);
     },
 
-    visitSimpleFilterTerm: function(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-                throw errors.compileError('RT-NO-FREE-TEXT');
+    visitFulltextFilterTerm: function(node) {
+        throw errors.compileError('RT-NO-FREE-TEXT');
+    },
 
-            case 'FilterLiteral':
-                return this.visit(node.expression);
-
-            default:
-                throw new Error('Invalid node type: ' + node.expression.type + '.');
-        }
+    visitReferenceFilterTerm: function(node) {
+        return this.visit(node.expression);
     }
 });
 

--- a/lib/compiler/filters/filter-searcher.js
+++ b/lib/compiler/filters/filter-searcher.js
@@ -29,19 +29,13 @@ var FilterSearcher = ASTVisitor.extend({
             this.visit(node.expression);
         }
     },
-    visitSimpleFilterTerm: function(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-                this.ftt = true;
-                break;
 
-            case 'FilterLiteral':
-                this.visit(node.expression);
-                break;
+    visitFulltextFilterTerm: function(node) {
+        this.ftt = true;
+    },
 
-            default:
-                throw new Error('Invalid node type: ' + node.expression.type + '.');
-        }
+    visitReferenceFilterTerm: function(node) {
+        this.visit(node.expression);
     }
 });
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -839,7 +839,13 @@ var SemanticPass = Base.extend({
         ast.d = false;
         return ast;
     },
-    sa_SimpleFilterTerm: function(ast) {
+    sa_FulltextFilterTerm: function(ast) {
+        ast.expression = this.sa_expr(ast.expression);
+        // will be carried in AST form to a proc implementation
+        ast.d = false;
+        return ast;
+    },
+    sa_ReferenceFilterTerm: function(ast) {
         ast.expression = this.sa_expr(ast.expression);
         // will be carried in AST form to a proc implementation
         ast.d = false;
@@ -1177,7 +1183,8 @@ var SemanticPass = Base.extend({
             case 'PropertyAccess':
             case 'PostfixExpression':
             case 'ExpressionFilterTerm':
-            case 'SimpleFilterTerm':
+            case 'FulltextFilterTerm':
+            case 'ReferenceFilterTerm':
                 return this['sa_' + ast.type](ast, opts);
 
             default:

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1388,16 +1388,30 @@ ExpressionFilterTermToplevel
           });
       }
 
-SimpleFilterTerm
-    = expression:ShiftExpression {
-          return createNode('SimpleFilterTerm', location(), {
+FulltextFilterTerm
+    = '?=' __ expression:ShiftExpression {
+          return createNode('FulltextFilterTerm', location(), {
               expression: expression
           });
       }
 
-SimpleFilterTermToplevel
+FulltextFilterTermToplevel
+    = '?=' __ expression:ShiftExpressionToplevel {
+          return createNode('FulltextFilterTerm', location(), {
+              expression: expression
+          });
+      }
+
+ReferenceFilterTerm
+    = expression:ShiftExpression {
+          return createNode('ReferenceFilterTerm', location(), {
+              expression: expression
+          });
+      }
+
+ReferenceFilterTermToplevel
     = expression:ShiftExpressionToplevel {
-          return createNode('SimpleFilterTerm', location(), {
+          return createNode('ReferenceFilterTerm', location(), {
               expression: expression
           });
       }
@@ -1408,10 +1422,10 @@ FilterPrimaryExpression
     = ExpressionFilterTerm
     / '(' __ expression:FilterExpression __ ')' { return expression; }
     // The predicate below ensures that parens wrapping a part of parsed filter
-    // expression are never parsed as part of SimpleFilterTerm. This is bit of a
-    // hack but it avoids introducing another expression hierarchy (one in which
-    // PrimaryExpression wouldn't parse parenthesized Expressions).
-    / !('(' __ expression:Expression __ ')') term:SimpleFilterTerm { return term; }
+    // expression are never parsed as part of ReferenceFilterTerm. This is bit
+    // of a hack but it avoids introducing another expression hierarchy (one in
+    // which PrimaryExpression wouldn't parse parenthesized Expressions).
+    / !('(' __ expression:Expression __ ')') term:(FulltextFilterTerm / ReferenceFilterTerm) { return term; }
 
 // Ordering of choices in this rule is tricky. Before you change it or
 // add/remove choices, read and understand PROD-6646.
@@ -1419,10 +1433,11 @@ FilterPrimaryExpressionToplevel
     = ExpressionFilterTermToplevel
     / '(' __ expression:FilterExpression __ ')' { return expression; }
     // The predicate below ensures that parens wrapping a part of parsed filter
-    // expression are never parsed as part of SimpleFilterTermToplevel. This is
-    // bit of a hack but it avoids introducing another expression hierarchy (one
-    // in which PrimaryExpression wouldn't parse parenthesized Expressions).
-    / !('(' __ expression:Expression __ ')') term:SimpleFilterTermToplevel { return term; }
+    // expression are never parsed as part of ReferenceFilterTermToplevel. This
+    // is bit of a hack but it avoids introducing another expression hierarchy
+    // (one in which PrimaryExpression wouldn't parse parenthesized
+    // Expressions).
+    / !('(' __ expression:Expression __ ')') term:(FulltextFilterTermToplevel / ReferenceFilterTermToplevel) { return term; }
 
 FilterNOTExpression
     = operator:FilterNOTOperator __ expression:FilterNOTExpression {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -292,7 +292,7 @@ describe('FilterJSCompiler', function() {
             it('finds correct points', function() {
                 testFilter(
                     {
-                        type: 'SimpleFilterTerm',
+                        type: 'ReferenceFilterTerm',
                         expression: {
                             type: 'FilterLiteral',
                             ast: {

--- a/test/compiler/filters/filter-searcher.spec.js
+++ b/test/compiler/filters/filter-searcher.spec.js
@@ -54,11 +54,11 @@ describe('FilterSearcher', function() {
 
         describe('filters with fulltext term(s)', function() {
             var filters = [
-                '"value"',
-                'NOT "value"',
-                'NOT ("value")',
-                '"value" == v OR (value <= 0 AND "thing")',
-                '"search term" value in ["value"]'
+                '?= "value"',
+                'NOT ?= "value"',
+                'NOT (?= "value")',
+                '"value" == v OR (value <= 0 AND ?= "thing")',
+                '?= "search term" value in ["value"]'
             ];
 
             _.each(filters, function (filter) {

--- a/test/runtime/specs/juttle-spec/filter-expressions/fulltext-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/fulltext-filter-terms.spec.md
@@ -1,12 +1,12 @@
-Simple filter terms
-===================
+Fulltext filter terms
+=====================
 
 Produces an error when used on term of invalid type
 ---------------------------------------------------
 
 ### Juttle
 
-    read test [1, 2, 3]
+    read test ?= [1, 2, 3]
 
 ### Errors
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/reference-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/reference-filter-terms.spec.md
@@ -1,0 +1,13 @@
+Reference filter terms
+======================
+
+Produces an error when used on term of invalid type
+---------------------------------------------------
+
+### Juttle
+
+    read test [1, 2, 3]
+
+### Errors
+
+  * Invalid term type (array).

--- a/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
@@ -13,7 +13,7 @@ stochastic with bad type complains
 stochastic with FTS complains
 -------------------------
 ### Juttle
-    read stochastic -source "cdn" "Never gonna get it" | view result
+    read stochastic -source "cdn" ?= "Never gonna get it" | view result
 
 ### Errors
 


### PR DESCRIPTION
Before this commit, FTS was expressed by using standalone strings in
filter expressions:

    read elastic "keyword"

This commit changes the syntax to use a new `?=` operator:

    read elastic ?= "keyword"

The change includes updating tests and documentation. See the commit message for more details.

Resolves #56.