### PR TITLE
Http server fixes

### DIFF
--- a/docs/adapters/http_server.md
+++ b/docs/adapters/http_server.md
@@ -23,6 +23,7 @@ Parameter         |             Description          | Required?
 `-port`           | Port for HTTP Server to listen on | No; default: `8080`
 `-method`         | HTTP method to use <br><br> Currently only supports `POST` or `PUT`. | No; default: `POST`
 `-timeField`      | The name of the field to use as the time field <br><br>The specified field will be renamed to `time` in the body of the HTTP request. If the points already contain a field called `time`, that field is overwritten. This is useful when the source data contains a time field whose values are not valid time stamps.  | No; defaults to keeping the `time` field as is
+`-rootPath`       | When the incoming data is JSON, use the specified path into the incoming object (expressed as `field1.field2`) to emit points | No
 
 Currently the `read http_server` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -12,6 +12,7 @@ These adapters are included in the Juttle runtime and can be used in Juttle prog
 
 * [file](../adapters/file.md)
 * [http](../adapters/http.md)
+* [http_server](../adapters/http_server.md)
 * [stdio](../adapters/stdio.md)
 * [stochastic](../adapters/stochastic.md)
 

--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -1,3 +1,4 @@
+var Promise = require('bluebird');
 var http = require('http');
 var _ = require('underscore');
 var contentType = require('content-type');
@@ -57,7 +58,8 @@ var Read = Juttle.proc.source.extend({
             catch(err) {
                 // type is undefined
             }
-            try {
+
+            Promise.try(function() {
                 if (req.method !== self.method) {
                     throw self.runtime_error('RT-INVALID-HTTP-METHOD', {
                         types: 'POST'
@@ -74,7 +76,7 @@ var Read = Juttle.proc.source.extend({
                 var emit_points = [];
 
                 var parser =  parsers.getParser(format , {rootPath: self.rootPath});
-                parser.parseStream(req, function(points) {
+                return parser.parseStream(req, function(points) {
                     if (!_.isArray(points)) {
                         points = [points];
                     }
@@ -87,13 +89,11 @@ var Read = Juttle.proc.source.extend({
 
                     res.statusCode = 200;
                     res.end();
-                })
-                .catch(function(err) {
-                    self._handle_listen_error(res, err);
                 });
-            } catch (err) {
+            })
+            .catch(function(err) {
                 self._handle_listen_error(res, err);
-            }
+            });
         });
 
         this.server.listen({

--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -14,7 +14,8 @@ var Read = Juttle.proc.source.extend({
         var allowed_options = [
             'port',
             'method',
-            'timeField'
+            'timeField',
+            'rootPath'
         ];
 
         var unknown = _.difference(_.keys(options), allowed_options);
@@ -35,6 +36,7 @@ var Read = Juttle.proc.source.extend({
         this.port = options.port || 8080;
         this.method = options.method || 'POST';
         this.timeField = options.timeField;
+        this.rootPath = options.rootPath;
 
         if (params.filter_ast) {
             throw this.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER', {

--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -48,9 +48,9 @@ var Read = Juttle.proc.source.extend({
 
     start: function() {
         var self = this;
-        var format;
 
         this.server = http.createServer(function(req, res) {
+            var format;
             try {
                 format = contentType.parse(req).type.split('/')[1];
             }

--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -132,6 +132,31 @@ describe('read http_server', function() {
         });
     });
 
+    it('correctly handles rootPath option', function() {
+        var program, finish;
+        return compile_juttle({
+            program: 'read http_server -port 2000 -rootPath \'root.root\''
+        })
+        .then(function(prog) {
+            program = prog;
+            finish = run_juttle(program);
+
+            return request({
+                uri: 'http://localhost:2000',
+                method: 'POST',
+                json: true,
+                body: { root: { root: { actual_root: true }}}
+            });
+        })
+        .then(function() {
+            program.deactivate();
+            return finish;
+        })
+        .then(function(results) {
+            expect(results.sinks.table).to.deep.equal([{ actual_root: true }]);
+        });
+    });
+
     it('invalid content type returns error', function() {
         var program, finish;
         var json_body = JSON.stringify([{person: 'matt', awesome_rating: 100}]);


### PR DESCRIPTION
Some follow up fixes/improvements from @davidvgalbraith comments in pr #224.

All these pertain to the `http_server` adapter. Here's the skinny
- Added support for `-rootPath` option
- Fix improperly scoped `format` variable
- Use `Promise.try` instead of a million try/catch blocks.
- Add link to `http_server` documentation, in adapter index