### PR TITLE
add all .js files to test lint checking

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,7 @@ gulp.task('juttle-spec', ['juttle-spec-clean'], function() {
 
 gulp.task('lint-test', function() {
     return gulp.src([
-        'test/**/*.spec.js',
+        'test/**/*.js',
         '!test/runtime/specs/juttle-spec/**/*.js'
     ])
 	.pipe(eslint())

--- a/test/runtime/test-adapter.js
+++ b/test/runtime/test-adapter.js
@@ -32,7 +32,7 @@ function TestAdapter(config) {
             // If invoked with -debug 'timeBounds', then instead of emitting
             // points, emit the -from and -to time options.
             if (options.debug && options.debug === 'timeBounds') {
-                this.logger.debug('debug mode: timeBounds')
+                this.logger.debug('debug mode: timeBounds');
                 this.debug_info = {from: this.from.toJSON(), to: this.to.toJSON()};
                 return;
             }


### PR DESCRIPTION
we were missing lint checking on a few `.js` files in test that were
not `.spec.js` files so lets make sure to cover those.