### PR TITLE
http_server: use a free port for each test

### DIFF
--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -117,11 +117,11 @@ var Read = Juttle.proc.source.extend({
     },
 
     teardown: function() {
-        this.emit_eof();
-
         if (this.server) {
             this.server.close();
         }
+
+        this.emit_eof();
     }
 });
 


### PR DESCRIPTION
Stop using hard-coded ports in the http server test since they're causing travis flakiness, and instead grab a free port for each test case.

Note that I tried grabbing a single free port for the whole test suite, but it seemed like there were still races in which one test case wouldn't release the port before the next one started, so I just used a simple beforeEach() to grab a new one each time.

