### PR TITLE
better json serializer appending

### DIFF
--- a/docs/adapters/file.md
+++ b/docs/adapters/file.md
@@ -85,8 +85,7 @@ Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
 `-file`           | File path on the local filesystem, absolute or relative to the current working directory  | Yes
 `-bufferLimit`    | Maximum number of points that will be written to the file. | No; defaults to 100
-`-maxFilesize`    | Maximum size of the file being written to, limited since the entire JSON needs to fit in memory | No; defaults to 200MB
-`-limit` | Maximum number of points in a file before we'd stop writing points to the file to avoid running out of memory | No; defaults to 100000
+`-append`         | When set to true your JSON data is append to an existing file otherwise the file is truncated and data from the current program is written out | No; defaults to false
 
 If the file already exists and contains a valid JSON array, the write will append new data rather than overwrite.
 

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -1,14 +1,14 @@
 'use strict';
 
 var _ = require('underscore');
+var fs = require('fs');
 var Juttle = require('../../runtime/index').Juttle;
-var Promise = require('bluebird');
-var fs = Promise.promisifyAll(require('fs'));
+var jsoner = require('jsoner');
 
 var Write = Juttle.proc.sink.extend({
     procName: 'write-file',
     initialize: function(options, params) {
-        var allowed_options = ['file', 'limit', 'maxFilesize', 'bufferLimit'];
+        var allowed_options = ['file', 'bufferLimit', 'append'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -24,21 +24,6 @@ var Write = Juttle.proc.sink.extend({
             });
         }
 
-        this.limit = options.limit || 100000;
-        if (!_.isNumber(this.limit) || this.limit < 0 ) {
-            throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: 'limit'
-            });
-        }
-
-        // 200MB limit on file
-        this.maxFilesize = options.maxFilesize || 200*1024*1024;
-        if (!_.isNumber(this.maxFilesize) || this.maxFilesize < 0 ) {
-            throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: 'maxFilesize'
-            });
-        }
-
         // flush every 100 points
         this.bufferLimit = options.bufferLimit ? options.bufferLimit : 100;
         if (!_.isNumber(this.bufferLimit) || this.bufferLimit < 0 ) {
@@ -47,79 +32,35 @@ var Write = Juttle.proc.sink.extend({
             });
         }
 
+        this.append = options.append || false;
         this.filename = options.file;
+        this.flushPromise = Promise.resolve();
         this.queue = [];
+
+        if (!this.append) {
+            // if we're not appending then lets open file for writing, as the
+            // file is created (if it does not exist) or truncated
+            // (if it exists).
+            var fd = fs.openSync(this.filename, 'w');
+            fs.closeSync(fd);
+        }
     },
 
     process: function(points) {
         this.logger.debug('process', points);
         this.queue = this.queue.concat(points);
-        // if we're due for a flush and don't have a flush in course then
-        // fire off another flush
-        if (this.queue.length > this.bufferLimit && !this.flushPromise) {
+
+        if (this.queue.length > this.bufferLimit) {
             this.flush();
         }
     },
 
     flush: function() {
-        var self = this;
-        var points = [];
-
-        this.flushPromise = fs.statAsync(this.filename)
-        .then(function(stats) {
-            if (stats.size > self.maxFilesize) {
-                throw self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                    option: 'maxFilesize',
-                    value: self.maxFilesize + ' bytes'
-                });
-            }
-            // we can only read the file if it exists which would be here
-            // and only after verifying the maxFileSize has not been
-            // exceeded
-            return fs.readFileAsync(self.filename, 'utf8')
-            .then(function(data) {
-                points = JSON.parse(data);
-            });
-        })
-        .catch(function(err) {
-            // ignore the ENOENT since that means we don't have an output
-            // file to begin with
-            if (err.code !== 'ENOENT') {
-                throw err;
-            }
-        })
-        .then(function() {
-            if (points.length > self.limit) {
-                self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                    option: 'limit',
-                    value: self.limit,
-                    extra: ', dropping points.'
-                }));
-                return Promise.resolve();
-            } else {
-                var space_left = self.limit - points.length;
-                if (space_left < self.queue.length) {
-                    points = points.concat(self.queue.slice(0, space_left));
-                    // error since we really can't take any more points after this and
-                    // should stop the whole pipeline
-                    self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                        option: 'limit',
-                        value: self.limit,
-                        extra: ', dropping points.'
-                    }));
-                } else {
-                    // lets write out some more points
-                    points = points.concat(self.queue);
-                }
-                var data = JSON.stringify(points, null, 4);
-                self.queue = [];
-                return fs.writeFileAsync(self.filename, data);
-            }
-        })
-        .catch(function(err) {
-            self.trigger('error', err);
-        }).finally(function() {
-            self.flushPromise = null;
+        this.flushPromise = this.flushPromise
+        .then(() => {
+            var buffer = this.queue;
+            this.queue = [];
+            return jsoner.appendFile(this.filename, buffer);
         });
 
         return this.flushPromise;
@@ -127,17 +68,9 @@ var Write = Juttle.proc.sink.extend({
 
     eof: function() {
         this.logger.debug('eof');
-        var self = this;
-        var currentFlush = this.flushPromise || Promise.resolve();
-        currentFlush.then(function() {
-            // after the current flush is done lets make sure to fire off
-            // another one as the previous one could have been somewhere
-            // in the middle of the async write and without another flush we
-            // would leave points on the self.queue
-            return self.flush();
-        })
-        .then(function() {
-            self.done();
+        this.flush()
+        .then(() => {
+            this.done();
         });
     }
 });

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "heap": "^0.2.3",
     "isomorphic-fetch": "^2.2.0",
     "js-beautify": "^1.5.4",
+    "jsoner": "^0.2.3",
     "log4js": "^0.6.28",
     "marked": "0.3.3",
     "minimist": "1.1.0",

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -240,15 +240,12 @@ describe('file adapter tests', function () {
             return expect_to_fail(failing_write, message);
         });
 
-        _.each(['limit', 'maxFilesize', 'bufferLimit'], function(option) {
-            it('fails when you provide an invalid ' + option, function() {
-                var message = util.format('option %s should be a positive integer', option);
-                var failing_write = check_juttle({
-                    program: 'emit -limit 1 | write file -file "' + tmp_file + '" -' + option + ' -1'
-                });
-
-                return expect_to_fail(failing_write, message);
+        it('fails when you provide an invalid bufferLimit', function() {
+            var failing_write = check_juttle({
+                program: 'emit -limit 1 | write file -file "' + tmp_file + '" -bufferLimit -1'
             });
+
+            return expect_to_fail(failing_write, 'option bufferLimit should be a positive integer');
         });
 
         it('can write a point and read it back', function() {
@@ -264,36 +261,6 @@ describe('file adapter tests', function () {
                 expect(result.errors.length).equal(0);
                 expect(result.sinks.table.length).equal(1);
                 expect(result.sinks.table[0].message).equal('hello test');
-            });
-        });
-
-        it('fails when you attempt to write to a file larger than -maxFilesize', function() {
-            return check_juttle({
-                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + tmp_file + '"'
-            })
-            .then(function() {
-                return check_juttle({
-                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + tmp_file + '" -maxFilesize 2'
-                });
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(1);
-                expect(result.errors[0]).to.contain('option maxFilesize exceeded limit of 2 bytes');
-            });
-        });
-
-        it('fails when you exceed the -limit value', function() {
-            return check_juttle({
-                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + tmp_file + '" -limit 1'
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(1);
-                expect(result.errors[0]).to.equal('option limit exceeded limit of 1, dropping points.');
-
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.sinks.table.length).equal(1);
             });
         });
 
@@ -339,30 +306,36 @@ describe('file adapter tests', function () {
             });
         });
 
-        it('fails when you attempt to write to a file with more points than than -limit allows', function() {
+        it('truncates the file on subsequent program run', function() {
             return check_juttle({
-                program: 'emit -limit 3 -from :2014-01-01: | write file -file "' + tmp_file + '"'
-            })
-            .then(function() {
-                return check_juttle({
-                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + tmp_file + '" -limit 2'
-                });
+                program: 'emit -limit 1 | put message = "hello test 1" | write file -file "' + tmp_file + '"'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(1);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.errors[0]).to.contain('option limit exceeded limit of 2, dropping points.');
-
+                expect(result.errors.length).equal(0);
                 return run_read_file_juttle(tmp_file);
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.sinks.table.length).to.equal(3);
+                expect(result.errors.length).equal(0);
+                expect(result.sinks.table.length).equal(1);
+                expect(result.sinks.table[0].message).equal('hello test 1');
+            })
+            .then(function() {
+                return check_juttle({
+                    program: 'emit -limit 1 | put message = "hello test 2" | write file -file "' + tmp_file + '"'
+                });
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                return run_read_file_juttle(tmp_file);
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                expect(result.sinks.table.length).equal(1);
+                expect(result.sinks.table[0].message).equal('hello test 2');
             });
         });
 
-        it('can write two points and read them back again', function() {
+        it('can write two points using -append true and read them back again', function() {
             return check_juttle({
                 program: 'emit -limit 1 | put message = "hello test 2" | write file -file "' + tmp_file + '"'
             })
@@ -371,7 +344,7 @@ describe('file adapter tests', function () {
             })
             .then(function() {
                 return check_juttle({
-                    program: 'emit -limit 1 | put message = "hello test 3" | write file -file "' + tmp_file + '"'
+                    program: 'emit -limit 1 | put message = "hello test 3" | write file -file "' + tmp_file + '" -append true'
                 });
             })
             .then(function(result) {


### PR DESCRIPTION
By using the `jsoner` package we can append to JSON objects in a file
without having to load the whole file. This removes the need for those
various options to handle maximum number of points and maximum filesize.