### PR TITLE
juttle-utils#toNative: Convert JavaScript Date to JuttleMoment

### DIFF
--- a/lib/runtime/juttle-utils.js
+++ b/lib/runtime/juttle-utils.js
@@ -6,6 +6,8 @@ var values = require('./values');
 var JuttleMoment = require('../moment').JuttleMoment;
 
 function makeDate(time) {
+    if (time instanceof Date) { return time; }
+
     var number = Number(time);
     if (number === number) { // check for NaN
         time = number * 1000; // convert seconds to milliseconds for Date constructor

--- a/test/runtime/juttle-utils.spec.js
+++ b/test/runtime/juttle-utils.spec.js
@@ -20,4 +20,46 @@ describe('juttle utils tests', function() {
             expect(converted.obj.time).to.equal(time.valueOf());
         });
     });
+
+    describe('toNative', function() {
+        it('converts Date to JuttleMoment', function() {
+            var time = new Date(2000);
+
+            var points = [
+                { time: time }
+            ];
+
+            var converted = utils.toNative(points)[0];
+
+            expect(converted.time).instanceOf(JuttleMoment);
+            expect(converted.time.unixms()).to.equal(time.getTime());
+        });
+
+        it('converts ISO string to JuttleMoment', function() {
+            var time = new Date(2000);
+
+            var points = [
+                { time: time.toISOString() }
+            ];
+
+            var converted = utils.toNative(points)[0];
+
+            expect(converted.time).instanceOf(JuttleMoment);
+            expect(converted.time.unixms()).to.equal(time.getTime());
+        });
+
+        it('converts seconds to JuttleMoment', function() {
+            var seconds = 2;
+            var time = new Date(seconds * 1000);
+
+            var points = [
+                { time: seconds }
+            ];
+
+            var converted = utils.toNative(points)[0];
+
+            expect(converted.time).instanceOf(JuttleMoment);
+            expect(converted.time.unixms()).to.equal(time.getTime());
+        });
+    });
 });


### PR DESCRIPTION
So adapters can successfully convert points with time fields of type `Date` into points with `JuttleMoment`  values (for emitting into the flowgraph).

This does create some asymmetry between `toNative` and `fromNative` (which returns an ISO string for `JuttleMoment`). But `toNative` does already accept ISO strings _or_ number of seconds so being liberal in what we accept on the `toNative` side makes sense.

@davidvgalbraith @demmer 