### PR TITLE
fix memory leak in JSON parser

### DIFF
--- a/lib/adapters/parsers/json.js
+++ b/lib/adapters/parsers/json.js
@@ -42,6 +42,8 @@ module.exports = base.extend({
                     emit(buffer);
                     buffer = [];
                 }
+                
+                return oboe.drop;
             })
             .on('end', function(){
                 emit(buffer);


### PR DESCRIPTION
fixes #258

we were not correctly returning `oboe.drop` while using oboe to steam
JSON objects and therefore oboe was holding onto the references to each
of the parsed JSON objects and eventually blowing up as identified in
the issue #258