### PR TITLE
filters: Don’t semantically check FilterLiterals in FilterChecker

### DIFF
--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -14,7 +14,6 @@
 // pipeline).
 
 var ASTVisitor = require('../ast-visitor');
-var SemanticPass = require('../semantic');
 var errors = require('../../errors');
 
 var NODE_TYPE_DISPLAY_NAMES = {
@@ -37,15 +36,6 @@ var FilterChecker = ASTVisitor.extend({
         this.options = options;
 
         this.visit(node);
-    },
-
-    visitFilterLiteral: function(node) {
-        // This is somewhat ugly becasue the semantic pass modifies the AST
-        // which the checker generally avoids. May be worth extracting into a
-        // separate pass later.
-        var semantic = new SemanticPass({ now: this.options.now });
-        node.ast = semantic.sa_expr(node.ast);
-        this.visit(node.ast);
     },
 
     visitExpressionFilterTerm: function(node) {

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -7,6 +7,7 @@ var _ = require('underscore');
 var values = require('../runtime/values');
 var Juttle = require('../runtime/procs/procs');
 var errors = require('../errors');
+var SemanticPass = require('./semantic');
 
 function proc_name(node) {
     return (node.name || node.type).replace('Proc', '').toLowerCase();
@@ -256,7 +257,9 @@ var GraphBuilder = Base.extend({
         return this.consts[uname];
     },
     value_ast: function(result) {
-        return value_ast(result);
+        // The _semantic_ast call is needed to correctly process filter
+        // literals.
+        return this._semantic_ast(value_ast(result));
     },
     build_sub_args: function (sub_sig, callopts, subname, location) {
         var opts = {};
@@ -304,6 +307,10 @@ var GraphBuilder = Base.extend({
         }
 
         return null;
+    },
+    _semantic_ast: function(ast) {
+        var semantic = new SemanticPass({ now: this.now });
+        return semantic.sa_expr(ast);
     }
 });
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -858,6 +858,12 @@ var SemanticPass = Base.extend({
         ast.d = false;
         return ast;
     },
+    sa_FilterLiteral: function(ast) {
+        ast.ast = this.sa_expr(ast.ast);
+        // will be carried in AST form to a proc implementation
+        ast.d = false;
+        return ast;
+    },
     sa_filter_proc: function(ast, opts) {
         if (ast.filter) {
             ast.filter = this.sa_expr(ast.filter, opts);
@@ -1191,6 +1197,7 @@ var SemanticPass = Base.extend({
             case 'PostfixExpression':
             case 'ExpressionFilterTerm':
             case 'SimpleFilterTerm':
+            case 'FilterLiteral':
                 return this['sa_' + ast.type](ast, opts);
 
             default:


### PR DESCRIPTION
Inputs of type `filter` produce `FilterLiteral` AST nodes that need to be semantically checked before they are compiled as part of a filter. The check is needed mainly to convert any `Variable` nodes into field
references (`UnaryExpression` nodes with `*` as the operator).

Until now, these checks were done in `FilterChecker` after `FilterLiteral` nodes coming from input values were embedded into filter expressions used by procs in the build phase. This was not ideal for two reasons:

  1. `FilterChecker` is not supposed to modify checked filter AST, but applying a semantic check to `FilterLiteral`s did modify it.

  2. We want to check the `FilterLiteral` itself, not its (possible many) embeddings.

This commit addresses the problems by moving the semantic check to `GraphBuilder` and applying it to ASTs of all input values for generality. This seems a little bit cleaner.

Part of the work on #57.