### PR TITLE
filters: Rewrite FilterChecker in more declarative style

### DIFF
--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -13,6 +13,7 @@
 // already (the idea is to do them as soon as possible in the compiler
 // pipeline).
 
+var _ = require('underscore');
 var ASTVisitor = require('../ast-visitor');
 var errors = require('../../errors');
 
@@ -31,6 +32,115 @@ var NODE_TYPE_DISPLAY_NAMES = {
     ObjectLiteral:            'object'
 };
 
+// For ExpressionFilterTerms, we use a table of allowed forms for each operator.
+// Descriptions of these forms use the following checks to test their operands.
+
+var checks = {
+    isSimpleFieldReference: {
+        displayName: 'field',
+
+        test: function(node) {
+            return node.type === 'UnaryExpression'
+                && node.operator === '*'
+                && node.expression.type === 'StringLiteral';
+        }
+    },
+
+    isStringLiteral: {
+        displayName: 'string',
+
+        test: function(node) {
+            return node.type === 'StringLiteral';
+        }
+    },
+
+    isRegularExpressionLiteral: {
+        displayName: 'regexp',
+
+        test: function(node) {
+            return node.type === 'RegularExpressionLiteral';
+        }
+    },
+
+    isSimpleLiteral: {
+        displayName: 'value',
+
+        test: function(node) {
+            return node.type === 'NullLiteral'
+                || node.type === 'BooleanLiteral'
+                || node.type === 'NumericLiteral'
+                || node.type === 'InfinityLiteral'
+                || node.type === 'NaNLiteral'
+                || node.type === 'StringLiteral'
+                || node.type === 'MomentLiteral'
+                || node.type === 'DurationLiteral';
+        }
+    },
+
+    isSimpleArrayLiteral: {
+        displayName: 'array',
+
+        test: function(node) {
+            return node.type === 'ArrayLiteral'
+                && _.every(node.elements, checks.isSimpleLiteral.test);
+        }
+    }
+};
+
+// And here comes the description of allowed operator forms.
+
+var ALLOWED_OP_FORMS = {
+    '==': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '!=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '=~': [
+        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
+        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+    ],
+
+    '!~': [
+        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
+        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+    ],
+
+    '<': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '>': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '<=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '>=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    'in': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleArrayLiteral },
+    ]
+};
+
+var ALLOWED_OP_FORMS_FIELD_COMPARISON = _(ALLOWED_OP_FORMS).mapObject(function(forms, operator) {
+    return _.clone(forms).concat(
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleFieldReference }
+    );
+});
+
 var FilterChecker = ASTVisitor.extend({
     check: function(node, options) {
         this.options = options;
@@ -39,23 +149,28 @@ var FilterChecker = ASTVisitor.extend({
     },
 
     visitExpressionFilterTerm: function(node) {
-        var expression = node.expression;
+        var forms = this.options.allowFieldComparisons
+            ? ALLOWED_OP_FORMS_FIELD_COMPARISON[node.expression.operator]
+            : ALLOWED_OP_FORMS[node.expression.operator];
 
-        if (this._isSimpleFieldReference(expression.left) && this._isSimpleFieldReference(expression.right)) {
-            if (this.options.allowFieldComparisons) {
-                this._checkFieldNode(expression.left, expression.location);
-                this._checkFieldNode(expression.right, expression.location);
-            } else {
-                throw new Error('At least one operand must not be a field reference.');
-            }
-        } else if (this._isSimpleFieldReference(expression.left)) {
-            this._checkFieldNode(expression.left, expression.location);
-            this._checkValueNode(expression.right, expression.operator, expression.location);
-        } else if (this._isSimpleFieldReference(expression.right)) {
-            this._checkValueNode(expression.left, expression.operator, expression.location);
-            this._checkFieldNode(expression.right, expression.location);
-        } else {
-            throw new Error('At least one operand must be a field reference.');
+        var valid = _.any(forms, function(form) {
+            return form.left.test(node.expression.left)
+                && form.right.test(node.expression.right);
+        });
+
+        if (!valid) {
+            var formsDescription = _.map(forms, function(form) {
+                return JSON.stringify(form.left.displayName
+                    + ' '
+                    + node.expression.operator
+                    + ' '
+                    + form.right.displayName);
+            }).join(', ');
+
+            throw errors.compileError('RT-INVALID-EXPRESSION-FILTER-TERM', {
+                forms: formsDescription,
+                location: node.location
+            });
         }
     },
 
@@ -74,73 +189,6 @@ var FilterChecker = ASTVisitor.extend({
                     location: node.location
                 });
         }
-    },
-
-    _checkFieldNode: function(node, location) {
-        if (!this._isValidFieldNode(node)) {
-            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
-                operator: '*',
-                type: this._nodeTypeDisplayName(node.expression.type),
-                // This should really point to node.expression.location but node
-                // won't have the "location" property set because it is rebuilt
-                // from a JavaScript value created at the build phase. This is
-                // yet another place where our double-compilation architecture
-                // hurts us.
-                location: location
-            });
-        }
-    },
-
-    _checkValueNode: function(node, operator, location) {
-        if (!this._isAllowedValueNodeForOperator(node, operator)) {
-            throw errors.compileError('RT-INVALID-OPERAND-TYPE', {
-                operator: operator,
-                type: this._nodeTypeDisplayName(node.type),
-                // This should really point to node.location but node won't have
-                // the "location" property set because it is rebuilt from a
-                // JavaScript value created at the build phase. This is yet
-                // another place where our double-compilation architecture hurts
-                // us.
-                location: location
-            });
-        }
-    },
-
-    _isSimpleFieldReference: function(node) {
-        return node.type === 'UnaryExpression' && node.operator === '*';
-    },
-
-    _isValidFieldNode: function(node) {
-        return node.expression.type === 'StringLiteral';
-    },
-
-    _isAllowedValueNodeForOperator: function(node, operator) {
-        var self = this;
-
-        switch (operator) {
-            case '=~':
-            case '!~':
-                return node.type === 'StringLiteral'
-                    || node.type === 'RegularExpressionLiteral';
-
-            case 'in':
-                return node.type === 'ArrayLiteral'
-                    && node.elements.every(function(e) { return self._isSimpleLiteral(e); });
-
-            default:
-                return this._isSimpleLiteral(node);
-        }
-    },
-
-    _isSimpleLiteral: function(node) {
-        return node.type === 'NullLiteral'
-            || node.type === 'BooleanLiteral'
-            || node.type === 'NumericLiteral'
-            || node.type === 'InfinityLiteral'
-            || node.type === 'NaNLiteral'
-            || node.type === 'StringLiteral'
-            || node.type === 'MomentLiteral'
-            || node.type === 'DurationLiteral';
     },
 
     _nodeTypeDisplayName: function (type) {

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -114,6 +114,7 @@
   "RT-SUB-MISSING-ARG": "Subgraph {sub} called without argument {arg}",
   "RT-INVALID-OPERAND-TYPE": "The \"{operator}\" operator: Invalid operand type ({type}).",
   "RT-INVALID-TERM-TYPE": "Invalid term type ({type}).",
+  "RT-INVALID-EXPRESSION-FILTER-TERM": "Invalid filter term. Valid forms are: {forms}.",
   "RT-IMPORT-INTERPOLATION": "Cannot use interpolation in imported module name.",
   "RT-MODULE-NOT-FOUND": "could not find module \"{module}\"",
   "RT-FIELD-NOT-STRING": "field {field} is not a string",

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -49,7 +49,7 @@ The `*` operator: Produces an error when the expression has an invalid type
 
 ### Errors
 
-  * The "*" operator: Invalid operand type (null).
+  * Invalid filter term. Valid forms are: "field == value", "value == field", "field == field".
 
 The `=~` operator: Produces an error for `non-field @ *`
 --------------------------------------------------------
@@ -162,7 +162,7 @@ The `=~` operator: Produces an error when RHS has an invalid type
 
 ### Errors
 
-  * The "=~" operator: Invalid operand type (array).
+  * Invalid filter term. Valid forms are: "field =~ string", "field =~ regexp".
 
 The `=~` operator: Returns `false` when LHS is a non-string value
 -----------------------------------------------------------------
@@ -189,7 +189,7 @@ The `!~` operator: Produces an error when RHS has an invalid type
 
 ### Errors
 
-  * The "!~" operator: Invalid operand type (array).
+  * Invalid filter term. Valid forms are: "field !~ string", "field !~ regexp".
 
 The `!~` operator: Returns `true` when LHS is a non-string value
 ----------------------------------------------------------------
@@ -218,7 +218,7 @@ The `in` operator: Produces an error when used on operand of invalid type
 
 ### Errors
 
-  * The "in" operator: Invalid operand type (string).
+  * Invalid filter term. Valid forms are: "field in array".
 
 Other operators: Produces an error when used on operand of invalid type
 -----------------------------------------------------------------------
@@ -229,4 +229,4 @@ Other operators: Produces an error when used on operand of invalid type
 
 ### Errors
 
-  * The "==" operator: Invalid operand type (array).
+  * Invalid filter term. Valid forms are: "field == value", "value == field".


### PR DESCRIPTION
`FilterChecker` was a bit of a spaghetti code which was hard to orient in. This commit rewrites it in more declarative style and makes it driven by a table of allowed forms for each operator. Beside making the code easier to follow this solution is more flexible and extensible (for example, it would be relatively easy to make the checks customizable for adapters).

The change doesn’t change the semantics of filter expressions in any way, but it changes some error messages (to the better, I hope).

Part of the work on #57.