### PR TITLE
Implement Juttle value ↔ AST conversions

### DIFF
--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -21,58 +21,6 @@ function is_sink(node) {
     return node.type === 'View' || Juttle.proc[proc_name(node)].info.type === 'sink';
 }
 
-function value_ast(result) {
-    switch (values.typeOf(result)) {
-        case 'Null':
-            return {type: 'NullLiteral'};
-        case 'Array':
-            return {type: 'ArrayLiteral',
-                    elements: _.map(result, function(el) { return value_ast(el);})};
-        case 'RegExp':
-            var flags = '';
-            flags += result.global ? 'g' : '';
-            flags += result.multiline ? 'm' : '';
-            flags += result.ignoreCase ? 'i' : '';
-            return {type: 'RegularExpressionLiteral',
-                    value: result.source,
-                    flags: flags};
-        case 'Date':
-            return {type:'MomentLiteral',
-                    value:result.valueOf()};
-        case 'Duration':
-            return {type:'DurationLiteral',
-                    value:result.valueOf()};
-        case 'String':
-            return {type: 'StringLiteral',
-                    value: result};
-        case 'Number':
-            if (result === Infinity) {
-                return {type: 'InfinityLiteral', negative: false};
-            } else if (result === -Infinity) {
-                return {type: 'InfinityLiteral', negative: true};
-            } else if (result !== result) {
-                return {type: 'NaNLiteral'};
-            } else {
-                return {type: 'NumericLiteral', value: result};
-            }
-            break;   // silence JSHint
-        case 'Boolean':
-            return {type: 'BooleanLiteral',
-                    value: result};
-        case 'Object':
-            return {type: 'ObjectLiteral',
-                    properties: _.map(result, function(value, key) {
-                        return {type: 'ObjectProperty', key: value_ast(key), value: value_ast(value)};
-                    })};
-        case 'Filter':
-            return {type: 'FilterLiteral',
-                    ast: result.ast,
-                    text: result.text};
-        default:
-            return result;
-    }
-}
-
 function build_pname(index) {
     return 'p' + index;
 }
@@ -259,7 +207,7 @@ var GraphBuilder = Base.extend({
     value_ast: function(result) {
         // The _semantic_ast call is needed to correctly process filter
         // literals.
-        return this._semantic_ast(value_ast(result));
+        return this._semantic_ast(values.toAST(result));
     },
     build_sub_args: function (sub_sig, callopts, subname, location) {
         var opts = {};
@@ -316,7 +264,6 @@ var GraphBuilder = Base.extend({
 
 module.exports = {
     GraphBuilder: GraphBuilder,
-    value_ast: value_ast,
     build_pname: build_pname,
     is_sink: is_sink
 };

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 var Base = require('extendable-base');
 var Filter = require('./runtime/filter');
 var JuttleMoment = require('./moment').JuttleMoment;
-var value_ast = require('./compiler/graph-builder').value_ast;
+var values = require('./runtime/values');
 var build_pname = require('./compiler/graph-builder').build_pname;
 
 
@@ -75,7 +75,7 @@ var Graph = Base.extend({
     },
     // If an option with this name is already present, it will be overridden
     node_set_option: function(node, name, value) {
-        var ast = value_ast(value);
+        var ast = values.toAST(value);
         var opt_ast = _.findWhere(node.options, {id: name});
         if (opt_ast) {
             opt_ast.val = ast;

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -3,8 +3,6 @@
 
 var _ = require('underscore');
 var Base = require('extendable-base');
-var Filter = require('./runtime/filter');
-var JuttleMoment = require('./moment').JuttleMoment;
 var values = require('./runtime/values');
 var build_pname = require('./compiler/graph-builder').build_pname;
 
@@ -99,36 +97,10 @@ var Graph = Base.extend({
     node_get_option: function(node, name) {
         var opt_ast = _.findWhere(node.options, {id: name});
 
-        function build_literal(literal_ast) {
-            switch(literal_ast.type) {
-                case 'NumericLiteral':
-                case 'StringLiteral':
-                case 'BooleanLiteral':
-                    return literal_ast.value;
-                case 'InfinityLiteral':
-                    return literal_ast.negative ? -Infinity : Infinity;
-                case 'NaNLiteral':
-                    return NaN;
-                case 'ArrayLiteral':
-                    return _.map(literal_ast.elements, build_literal);
-                case 'ObjectLiteral':
-                    return _.object(_.map(literal_ast.properties, function(prop) {
-                        return [build_literal(prop.key), build_literal(prop.value)];
-                    }));
-                case 'DurationLiteral':
-                    return new JuttleMoment.duration(literal_ast.value);
-                case 'MomentLiteral':
-                    return new JuttleMoment(literal_ast.value);
-                case 'FilterLiteral':
-                    return new Filter(literal_ast.ast, literal_ast.text);
-                default:
-                    throw new Error('Program.node_get_option doesn\'t know how to handle ' + literal_ast.type);
-            }
-        }
         if (opt_ast === undefined) {
             return undefined;
         }
-        return build_literal(opt_ast.val);
+        return values.fromAST(opt_ast.val);
     },
     // Returns whether or not the given node has only the given option keys
     node_contains_only_options: function(node, options) {

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -398,6 +398,63 @@ var values = {
                     + _.map(value, function(v, k) { return k + ': ' + values.inspect(v); }).join(', ')
                     + ' }';
         }
+    },
+
+    // Returns an AST corresponding to a Juttle value.
+    toAST: function(value) {
+        switch (values.typeOf(value)) {
+            case 'Null':
+                return { type: 'NullLiteral' };
+
+            case 'Boolean':
+                return { type: 'BooleanLiteral', value: value };
+
+            case 'Number':
+                if (value !== value) {
+                    return { type: 'NaNLiteral' };
+                } else if (value === Infinity) {
+                    return { type: 'InfinityLiteral', negative: false };
+                } else if (value === -Infinity) {
+                    return { type: 'InfinityLiteral', negative: true };
+                } else {
+                    return { type: 'NumericLiteral', value: value };
+                }
+                break;   // silence ESLint
+
+            case 'String':
+                return { type: 'StringLiteral', value: value };
+
+            case 'RegExp':
+                return {
+                    type: 'RegularExpressionLiteral',
+                    value: value.source,
+                    flags: value.toString().match(/\/(\w*)$/)[1]
+                };
+
+            case 'Date':
+                return { type: 'MomentLiteral', value: value.valueOf() };
+
+            case 'Duration':
+                return { type: 'DurationLiteral', value: value.valueOf() };
+
+            case 'Filter':
+                return { type: 'FilterLiteral', ast: value.ast, text: value.text };
+
+            case 'Array':
+                return { type: 'ArrayLiteral', elements: _.map(value, values.toAST) };
+
+            case 'Object':
+                return {
+                    type: 'ObjectLiteral',
+                    properties: _.map(value, function(value, key) {
+                        return {
+                            type: 'ObjectProperty',
+                            key: values.toAST(key),
+                            value: values.toAST(value)
+                        };
+                    })
+                };
+        }
     }
 };
 

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -3,6 +3,7 @@
 // Utilities for manipulating Juttle values.
 
 var _ = require('underscore');
+var ASTVisitor = require('../compiler/ast-visitor');
 var Filter = require('./filter');
 var JuttleMoment = require('../moment').JuttleMoment;
 var errors = require('../errors');
@@ -19,6 +20,64 @@ var TYPE_DISPLAY_NAMES = {
     Array:    'array',
     Object:   'object'
 };
+
+var ValueBuilder = ASTVisitor.extend({
+    buildValue: function(ast) {
+        return this.visit(ast);
+    },
+
+    visitNullLiteral: function() {
+        return null;
+    },
+
+    visitBooleanLiteral: function(node) {
+        return node.value;
+    },
+
+    visitNumericLiteral: function(node) {
+        return node.value;
+    },
+
+    visitInfinityLiteral: function(node) {
+        return node.negative ? -Infinity : Infinity;
+    },
+
+    visitNaNLiteral: function(node) {
+        return NaN;
+    },
+
+    visitStringLiteral: function(node) {
+        return node.value;
+    },
+
+    visitRegularExpressionLiteral: function(node) {
+        return new RegExp(node.value, node.flags);
+    },
+
+    visitMomentLiteral: function(node) {
+        return new JuttleMoment(node.value);
+    },
+
+    visitDurationLiteral: function(node) {
+        return new JuttleMoment.duration(node.value);
+    },
+
+    visitFilterLiteral: function(node) {
+        return new Filter(node.ast, node.text);
+    },
+
+    visitArrayLiteral: function(node) {
+        return _.map(node.elements, this.visit, this);
+    },
+
+    visitObjectLiteral: function(node) {
+        return _.object((_.map(node.properties, this.visit, this)));
+    },
+
+    visitObjectProperty: function(node) {
+        return [this.visit(node.key), this.visit(node.value)];
+    }
+});
 
 var values = {
 
@@ -398,6 +457,13 @@ var values = {
                     + _.map(value, function(v, k) { return k + ': ' + values.inspect(v); }).join(', ')
                     + ' }';
         }
+    },
+
+    // Returns a value corresponding to an AST.
+    fromAST: function(ast) {
+        var builder = new ValueBuilder();
+
+        return builder.buildValue(ast);
     },
 
     // Returns an AST corresponding to a Juttle value.

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -573,6 +573,17 @@ describe('Values tests', function () {
         },
     ];
 
+    describe('fromAST', function() {
+        it('returns correct value', function() {
+            _.each(AST_TESTCASES, function(testcase) {
+                expect(values.fromAST(testcase.ast)).to.deep.equal(
+                    testcase.value,
+                    JSON.stringify(testcase.ast)
+                );
+            });
+        });
+    });
+
     describe('toAST', function() {
         it('returns correct AST', function() {
             _.each(AST_TESTCASES, function(testcase) {

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -483,4 +483,104 @@ describe('Values tests', function () {
             });
         });
     });
+
+    describe('toAST', function() {
+        it('returns correct AST', function() {
+            var testcases = [
+                {
+                    value: null,
+                    ast: { type: 'NullLiteral' }
+                },
+                {
+                    value: true,
+                    ast: { type: 'BooleanLiteral', value: true }
+                },
+                {
+                    value: false,
+                    ast: { type: 'BooleanLiteral', value: false }
+                },
+                {
+                    value: 5,
+                    ast: { type: 'NumericLiteral', value: 5 }
+                },
+                {
+                    value: Infinity,
+                    ast: { type: 'InfinityLiteral', negative: false }
+                },
+                {
+                    value: -Infinity,
+                    ast: { type: 'InfinityLiteral', negative: true }
+                },
+                {
+                    value: NaN,
+                    ast: { type: 'NaNLiteral' }
+                },
+                {
+                    value: 'abcd',
+                    ast: { type: 'StringLiteral', value: 'abcd' }
+                },
+                {
+                    value: /abcd/i,
+                    ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'i' }
+                },
+                {
+                    value: /abcd/gim,
+                    ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'gim' }
+                },
+                {
+                    value: new JuttleMoment('2015-01-01T00:00:05.000Z'),
+                    ast: { type: 'MomentLiteral', value: '2015-01-01T00:00:05.000Z' }
+                },
+                {
+                    value: new JuttleMoment.duration('00:00:05.000'),
+                    ast: { type: 'DurationLiteral', value: '00:00:05.000' }
+                },
+                {
+                    value: new Filter(FILTER_AST, 'a < 5'),
+                    ast: { type: 'FilterLiteral', ast: FILTER_AST, text: 'a < 5' }
+                },
+                {
+                    value: [ 1, 2, 3 ],
+                    ast: {
+                        type: 'ArrayLiteral',
+                        elements: [
+                            { type: 'NumericLiteral', value: 1 },
+                            { type: 'NumericLiteral', value: 2 },
+                            { type: 'NumericLiteral', value: 3 }
+                        ]
+                    }
+                },
+                {
+                    value: { a: 1, b: 2, c: 3 },
+                    ast: {
+                        type: 'ObjectLiteral',
+                        properties: [
+                            {
+                                type: 'ObjectProperty',
+                                key: { type: 'StringLiteral', value: 'a' },
+                                value: { type: 'NumericLiteral', value: 1 }
+                            },
+                            {
+                                type: 'ObjectProperty',
+                                key: { type: 'StringLiteral', value: 'b' },
+                                value: { type: 'NumericLiteral', value: 2 }
+                            },
+                            {
+                                type: 'ObjectProperty',
+                                key: { type: 'StringLiteral', value: 'c' },
+                                value: { type: 'NumericLiteral', value: 3 }
+                            }
+                        ]
+                    }
+                },
+            ];
+
+            _.each(testcases, function(testcase) {
+                expect(values.toAST(testcase.value)).to.deep.equal(
+                    testcase.ast,
+                    values.inspect(testcase.value)
+                );
+            });
+        });
+    });
 });

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -7,6 +7,16 @@ var JuttleMoment = require('../../lib/moment').JuttleMoment;
 var Filter = require('../../lib/runtime/filter');
 
 describe('Values tests', function () {
+    var FILTER_AST = {
+        type: 'ExpressionFilterTerm',
+        expression: {
+            type: 'BinaryExpression',
+            operator: '<',
+            left: { type: 'Variable', name: 'a' },
+            right: { type: 'NumericLiteral', value: 5 }
+        }
+    };
+
     describe('toJSONCopmatible', function() {
         it('returns correct representation', function() {
             var tests = [
@@ -43,17 +53,7 @@ describe('Values tests', function () {
                     expected: '1970-01-01T00:00:00.000Z',
                 },
                 {
-                    value: new Filter({
-                        type: 'ExpressionFilterTerm',
-                        expression: {
-                            type: 'BinaryExpression',
-                            operator: '<',
-                            left: { type: 'Variable', name: 'a' },
-                            right: { type: 'NumericLiteral', value: 5 }
-                        }
-                    },
-                    'a < 5'
-                    ),
+                    value: new Filter(FILTER_AST, 'a < 5'),
                     expected: 'a < 5',
                 },
                 {
@@ -262,17 +262,7 @@ describe('Values tests', function () {
                     expected: '2015-01-01T00:00:05.000Z'
                 },
                 {
-                    value: new Filter({
-                        type: 'ExpressionFilterTerm',
-                        expression: {
-                            type: 'BinaryExpression',
-                            operator: '<',
-                            left: { type: 'Variable', name: 'a' },
-                            right: { type: 'NumericLiteral', value: 5 }
-                        }
-                    },
-                        'a < 5'
-                    ),
+                    value: new Filter(FILTER_AST, 'a < 5'),
                     expected: 'a < 5'
                 },
                 {
@@ -360,17 +350,7 @@ describe('Values tests', function () {
                     expected: ':2015-01-01T00:00:05.000Z:'
                 },
                 {
-                    value: new Filter({
-                        type: 'ExpressionFilterTerm',
-                        expression: {
-                            type: 'BinaryExpression',
-                            operator: '<',
-                            left: { type: 'Variable', name: 'a' },
-                            right: { type: 'NumericLiteral', value: 5 }
-                        }
-                    },
-                        'a < 5'
-                    ),
+                    value: new Filter(FILTER_AST, 'a < 5'),
                     expected: 'filter(a < 5)'
                 },
                 {
@@ -444,17 +424,7 @@ describe('Values tests', function () {
                     expected: 'Duration',
                 },
                 {
-                    value: new Filter({
-                        type: 'ExpressionFilterTerm',
-                        expression: {
-                            type: 'BinaryExpression',
-                            operator: '<',
-                            left: { type: 'Variable', name: 'a' },
-                            right: { type: 'NumericLiteral', value: 5 }
-                        }
-                    },
-                    'a < 5'
-                    ),
+                    value: new Filter(FILTER_AST, 'a < 5'),
                     expected: 'Filter',
                 },
                 {
@@ -495,17 +465,7 @@ describe('Values tests', function () {
                 new RegExp('abcd'),
                 new JuttleMoment(0),
                 JuttleMoment.duration('5', 's'),
-                new Filter({
-                    type: 'ExpressionFilterTerm',
-                    expression: {
-                        type: 'BinaryExpression',
-                        operator: '<',
-                        left: { type: 'Variable', name: 'a' },
-                        right: { type: 'NumericLiteral', value: 5 }
-                    }
-                },
-                    'a < 5'
-                ),
+                new Filter(FILTER_AST, 'a < 5'),
                 [1, 2, 3],
                 { a: 'b', c: 'd' }
             ];

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -484,98 +484,98 @@ describe('Values tests', function () {
         });
     });
 
+    var AST_TESTCASES = [
+        {
+            value: null,
+            ast: { type: 'NullLiteral' }
+        },
+        {
+            value: true,
+            ast: { type: 'BooleanLiteral', value: true }
+        },
+        {
+            value: false,
+            ast: { type: 'BooleanLiteral', value: false }
+        },
+        {
+            value: 5,
+            ast: { type: 'NumericLiteral', value: 5 }
+        },
+        {
+            value: Infinity,
+            ast: { type: 'InfinityLiteral', negative: false }
+        },
+        {
+            value: -Infinity,
+            ast: { type: 'InfinityLiteral', negative: true }
+        },
+        {
+            value: NaN,
+            ast: { type: 'NaNLiteral' }
+        },
+        {
+            value: 'abcd',
+            ast: { type: 'StringLiteral', value: 'abcd' }
+        },
+        {
+            value: /abcd/i,
+            ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'i' }
+        },
+        {
+            value: /abcd/gim,
+            ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'gim' }
+        },
+        {
+            value: new JuttleMoment('2015-01-01T00:00:05.000Z'),
+            ast: { type: 'MomentLiteral', value: '2015-01-01T00:00:05.000Z' }
+        },
+        {
+            value: new JuttleMoment.duration('00:00:05.000'),
+            ast: { type: 'DurationLiteral', value: '00:00:05.000' }
+        },
+        {
+            value: new Filter(FILTER_AST, 'a < 5'),
+            ast: { type: 'FilterLiteral', ast: FILTER_AST, text: 'a < 5' }
+        },
+        {
+            value: [ 1, 2, 3 ],
+            ast: {
+                type: 'ArrayLiteral',
+                elements: [
+                    { type: 'NumericLiteral', value: 1 },
+                    { type: 'NumericLiteral', value: 2 },
+                    { type: 'NumericLiteral', value: 3 }
+                ]
+            }
+        },
+        {
+            value: { a: 1, b: 2, c: 3 },
+            ast: {
+                type: 'ObjectLiteral',
+                properties: [
+                    {
+                        type: 'ObjectProperty',
+                        key: { type: 'StringLiteral', value: 'a' },
+                        value: { type: 'NumericLiteral', value: 1 }
+                    },
+                    {
+                        type: 'ObjectProperty',
+                        key: { type: 'StringLiteral', value: 'b' },
+                        value: { type: 'NumericLiteral', value: 2 }
+                    },
+                    {
+                        type: 'ObjectProperty',
+                        key: { type: 'StringLiteral', value: 'c' },
+                        value: { type: 'NumericLiteral', value: 3 }
+                    }
+                ]
+            }
+        },
+    ];
+
     describe('toAST', function() {
         it('returns correct AST', function() {
-            var testcases = [
-                {
-                    value: null,
-                    ast: { type: 'NullLiteral' }
-                },
-                {
-                    value: true,
-                    ast: { type: 'BooleanLiteral', value: true }
-                },
-                {
-                    value: false,
-                    ast: { type: 'BooleanLiteral', value: false }
-                },
-                {
-                    value: 5,
-                    ast: { type: 'NumericLiteral', value: 5 }
-                },
-                {
-                    value: Infinity,
-                    ast: { type: 'InfinityLiteral', negative: false }
-                },
-                {
-                    value: -Infinity,
-                    ast: { type: 'InfinityLiteral', negative: true }
-                },
-                {
-                    value: NaN,
-                    ast: { type: 'NaNLiteral' }
-                },
-                {
-                    value: 'abcd',
-                    ast: { type: 'StringLiteral', value: 'abcd' }
-                },
-                {
-                    value: /abcd/i,
-                    ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'i' }
-                },
-                {
-                    value: /abcd/gim,
-                    ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'gim' }
-                },
-                {
-                    value: new JuttleMoment('2015-01-01T00:00:05.000Z'),
-                    ast: { type: 'MomentLiteral', value: '2015-01-01T00:00:05.000Z' }
-                },
-                {
-                    value: new JuttleMoment.duration('00:00:05.000'),
-                    ast: { type: 'DurationLiteral', value: '00:00:05.000' }
-                },
-                {
-                    value: new Filter(FILTER_AST, 'a < 5'),
-                    ast: { type: 'FilterLiteral', ast: FILTER_AST, text: 'a < 5' }
-                },
-                {
-                    value: [ 1, 2, 3 ],
-                    ast: {
-                        type: 'ArrayLiteral',
-                        elements: [
-                            { type: 'NumericLiteral', value: 1 },
-                            { type: 'NumericLiteral', value: 2 },
-                            { type: 'NumericLiteral', value: 3 }
-                        ]
-                    }
-                },
-                {
-                    value: { a: 1, b: 2, c: 3 },
-                    ast: {
-                        type: 'ObjectLiteral',
-                        properties: [
-                            {
-                                type: 'ObjectProperty',
-                                key: { type: 'StringLiteral', value: 'a' },
-                                value: { type: 'NumericLiteral', value: 1 }
-                            },
-                            {
-                                type: 'ObjectProperty',
-                                key: { type: 'StringLiteral', value: 'b' },
-                                value: { type: 'NumericLiteral', value: 2 }
-                            },
-                            {
-                                type: 'ObjectProperty',
-                                key: { type: 'StringLiteral', value: 'c' },
-                                value: { type: 'NumericLiteral', value: 3 }
-                            }
-                        ]
-                    }
-                },
-            ];
-
-            _.each(testcases, function(testcase) {
+            _.each(AST_TESTCASES, function(testcase) {
                 expect(values.toAST(testcase.value)).to.deep.equal(
                     testcase.ast,
                     values.inspect(testcase.value)


### PR DESCRIPTION
Implement `values.toAST` and `values.fromAST` functions which convert Juttle values from/to their AST representations. These functions replace ad-hoc, ugly, bug-ridden implementations of this functionality that we already had in the codebase.

The original motivation for this was getting rid of two lists of type display names ([in `values.js`](https://github.com/juttle/juttle/blob/612a8713a204ecb58255e1ed876e445613c86369/lib/runtime/values.js#L10-L21) and [in `filter-checker.js`](https://github.com/juttle/juttle/blob/master/lib/compiler/filters/filter-checker.js#L20-L33)). This will actually be done in a follow-up PR.

Vaguely related to #57.