### PR TITLE
Small FilterChecker cleanup

### DIFF
--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -16,21 +16,7 @@
 var _ = require('underscore');
 var ASTVisitor = require('../ast-visitor');
 var errors = require('../../errors');
-
-var NODE_TYPE_DISPLAY_NAMES = {
-    NullLiteral:              'null',
-    BooleanLiteral:           'boolean',
-    NumericLiteral:           'number',
-    InfinityLiteral:          'number',
-    NaNLiteral:               'number',
-    StringLiteral:            'string',
-    RegularExpressionLiteral: 'regular expression',
-    MomentLiteral:            'date',
-    DurationLiteral:          'duration',
-    FilterLiteral:            'filter expression',
-    ArrayLiteral:             'array',
-    ObjectLiteral:            'object'
-};
+var values = require('../../runtime/values');
 
 // For ExpressionFilterTerms, we use a table of allowed forms for each operator.
 // Descriptions of these forms use the following checks to test their operands.
@@ -185,14 +171,10 @@ var FilterChecker = ASTVisitor.extend({
 
             default:
                 throw errors.compileError('RT-INVALID-TERM-TYPE', {
-                    type: this._nodeTypeDisplayName(node.expression.type),
+                    type: values.typeDisplayName(values.typeOf(values.fromAST(node.expression))),
                     location: node.location
                 });
         }
-    },
-
-    _nodeTypeDisplayName: function (type) {
-        return NODE_TYPE_DISPLAY_NAMES[type];
     }
 });
 

--- a/lib/compiler/filters/filter-checker.js
+++ b/lib/compiler/filters/filter-checker.js
@@ -1,17 +1,10 @@
 'use strict';
 
-// Inspects filter expression AST and throws an error if it contains values of
-// invalid types.
+// Inspects filter expression AST and throws an error if it is invalid.
 //
 // For normal expressions, these checks are done in runtime, but for filter
-// expressions at least some basic checks need to be done sooner so that the ES
-// and JS compilers can assume some level of sanity. Note we already have all
-// the values computed when the checker is invoked in the graph compilation
-// stage because we don't allow straming expressions inside filter expressions.
-//
-// Some structural checks on filter expressions are done in the semantic pass
-// already (the idea is to do them as soon as possible in the compiler
-// pipeline).
+// expressions at least some basic checks need to be done sooner so that the
+// various compilers (mostly in adapters) can assume some level of sanity.
 
 var _ = require('underscore');
 var ASTVisitor = require('../ast-visitor');


### PR DESCRIPTION
Let’s clean up `FilterChecker` a bit before it is split up.

Part of the work on #57.