### PR TITLE
ASTVisitor: Move FilterLiteral to other literals

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -29,6 +29,7 @@ var NODE_CHILDREN = {
     RegularExpressionLiteral: [],
     MomentLiteral:            [],
     DurationLiteral:          [],
+    FilterLiteral:            ['ast'],
     ArrayLiteral:             ['elements'],
     ObjectLiteral:            ['properties'],
     ObjectProperty:           ['key', 'value'],
@@ -48,7 +49,6 @@ var NODE_CHILDREN = {
     /* Filter expressions */
     ExpressionFilterTerm:     ['expression'],
     SimpleFilterTerm:         ['expression'],
-    FilterLiteral:            ['ast'],
 
     /* Procs (sorted alphabetically) */
     FieldListArgProc:         ['options', 'columns', 'groupby'],


### PR DESCRIPTION
The new place makes more sense and better corresponds to ordering used e.g. in `values.js` or `FilterJSCompiler`.