### PR TITLE
add delete and rename for time

### DIFF
--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -28,7 +28,7 @@ var source = base.extend({
                 }
                 if (timeField !== 'time') {
                     if (pt.time) {
-                        pt._time = pt.time;
+                        self.trigger('warning', self.runtime_error('RT-OVERWRITING-TIME', {field: timeField}));
                     }
                     pt.time = pt[timeField];
                     delete pt[timeField];

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -22,17 +22,21 @@ var source = base.extend({
         var self = this;
 
         _.each(points, function(pt) {
-            if (timeField && !pt[timeField]) {
-                self.trigger('warning', self.runtime_error('RT-POINT-MISSING-TIME', {field: timeField}));
+            if (timeField) {
+                if (!pt[timeField]) {
+                    self.trigger('warning', self.runtime_error('RT-POINT-MISSING-TIME', {field: timeField}));
+                }
+                if (timeField !== 'time') {
+                    if (pt.time) {
+                        pt._time = pt.time;
+                    }
+                    pt.time = pt[timeField];
+                    delete pt[timeField];
+                }
             }
-
-            var time = pt[timeField || 'time'];
-            if (time) { pt.time = time; }
         });
 
-        juttle_utils.toNative(points);
-
-        return points;
+        return juttle_utils.toNative(points);
     }
 }, {
     info: INFO

--- a/lib/strings/juttle-error-strings-en-US.json
+++ b/lib/strings/juttle-error-strings-en-US.json
@@ -12,6 +12,7 @@
     "RT-TIME-OUT-OF-ORDER": "Warning: out-of-order assignment of time {{info.badTime}} after {{info.goodTime}}, point(s) dropped",
     "RT-TOO-MANY-LOGS-WARNING": "Warning: too many logs from {{info.host}}, throttling",
     "RT-POINT-MISSING-TIME": "Warning: point is missing a time in {{info.field}}",
+    "RT-OVERWRITING-TIME": "Warning: overwriting value of time field with {{info.field}} field",
     "RT-TIMELESS-POINTS": "Warning: encountered point(s) without the time field",
     "RT-TYPE-ERROR": "Error: {{info.message}}",
     "RT-NO-FREE-TEXT": "Error: Free text search is not implemented in this context.",


### PR DESCRIPTION
1. delete `pt[timeField]` after putting the value into `pt.time`. 
2. if there exists a `pt.time` with a separate `timeField`, avoid simply discarding by setting that value to key `pt._time`.  

(also note that I will have to do a little rework on this after https://github.com/juttle/juttle/pull/248 since the function moves to a new class - but the function does not change in logic in that pr)

This PR originated from @dmajda comment here: https://github.com/juttle/juttle-sql-adapter-common/pull/16

And has to do with bringing this back: https://github.com/juttle/juttle-sql-adapter-common/pull/14