### PR TITLE
add head optimization to `read http`

### DIFF
--- a/lib/adapters/http/index.js
+++ b/lib/adapters/http/index.js
@@ -4,7 +4,8 @@ function HTTPAdapter(config, Juttle) {
     return {
         name: 'http',
         read: require('./read'),
-        write: require('./write')
+        write: require('./write'),
+        optimizer: require('./optimize')
     };
 }
 

--- a/lib/adapters/http/optimize.js
+++ b/lib/adapters/http/optimize.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var optimizer = {
+    optimize_head: function(read, head, graph, optimization_info) {
+        var limit = graph.node_get_option(head, 'arg');
+
+        if (optimization_info.hasOwnProperty('limit')) {
+            limit = Math.min(limit, optimization_info.limit);
+        }
+
+        optimization_info.type = 'head';
+        optimization_info.limit = limit;
+        return true;
+    }
+};
+
+module.exports = optimizer;

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -54,6 +54,8 @@ var Read = Juttle.proc.source.extend({
                 filter: 'filtering'
             });
         }
+
+        this.optimization_info = params && params.optimization_info || {};
     },
 
     triggerFailure: function(message) {
@@ -96,16 +98,19 @@ var Read = Juttle.proc.source.extend({
                 }
 
                 try {
-                    var parser =  parsers.getParser(format, {rootPath: self.rootPath});
+                    self.parser = parsers.getParser(format, {
+                        rootPath: self.rootPath,
+                        optimization: self.optimization_info
+                    });
 
-                    parser
+                    self.parser
                     .on('error', (err) => {
                         this.trigger('error', this.runtime_error('RT-INTERNAL-ERROR', {
                             error: err.toString()
                         }));
                     });
 
-                    parser.parseStream(req, function(points) {
+                    self.parser.parseStream(req, function(points) {
                         if (self.includeHeaders) {
                             _.each(points, function(point) {
                                 _.each(res.headers, function(value, key) {


### PR DESCRIPTION
fixes #276

expose the limit optimization that the `adapters/parsers` supports to
correctly optimize head when used with `read http`