### PR TITLE
expose -format for `write file`

### DIFF
--- a/docs/adapters/file.md
+++ b/docs/adapters/file.md
@@ -75,7 +75,7 @@ The above examples produce the same output table:
 
 ## write file
 
-Data is written out to a file as a JSON array; no other output formats are supported.
+Data is written out to the filename specified in the format you specify.
 
 ```text
 write file -file <path>
@@ -84,11 +84,9 @@ write file -file <path>
 Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
 `-file`           | File path on the local filesystem, absolute or relative to the current working directory  | Yes
-`-bufferLimit`    | Maximum number of points that will be written to the file. | No; defaults to 100
-`-maxFilesize`    | Maximum size of the file being written to, limited since the entire JSON needs to fit in memory | No; defaults to 200MB
-`-limit` | Maximum number of points in a file before we'd stop writing points to the file to avoid running out of memory | No; defaults to 100000
+`-format`         | Input input format: `csv` for [CSV](https://tools.ietf.org/html/rfc4180) data, `json` for [JSON](https://tools.ietf.org/html/rfc7159) data, or `jsonl` for [JSON lines](http://jsonlines.org/) data | No; defaults to `json`
 
-If the file already exists and contains a valid JSON array, the write will append new data rather than overwrite.
+If the file already exists it will be truncated and overwritten.
 
 _Example: writing data to a file_
 

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -4,11 +4,12 @@ var _ = require('underscore');
 var Juttle = require('../../runtime/index').Juttle;
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
+var serializers = require('../serializers');
 
 var Write = Juttle.proc.sink.extend({
     procName: 'write-file',
     initialize: function(options, params) {
-        var allowed_options = ['file', 'limit', 'maxFilesize', 'bufferLimit'];
+        var allowed_options = ['file', 'format'];
         var unknown = _.difference(_.keys(options), allowed_options);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
@@ -24,121 +25,27 @@ var Write = Juttle.proc.sink.extend({
             });
         }
 
-        this.limit = options.limit || 100000;
-        if (!_.isNumber(this.limit) || this.limit < 0 ) {
-            throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: 'limit'
-            });
-        }
-
-        // 200MB limit on file
-        this.maxFilesize = options.maxFilesize || 200*1024*1024;
-        if (!_.isNumber(this.maxFilesize) || this.maxFilesize < 0 ) {
-            throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: 'maxFilesize'
-            });
-        }
-
-        // flush every 100 points
-        this.bufferLimit = options.bufferLimit ? options.bufferLimit : 100;
-        if (!_.isNumber(this.bufferLimit) || this.bufferLimit < 0 ) {
-            throw this.compile_error('RT-OPTION-SHOULD-BE-POSITIVE-INTEGER', {
-                option: 'bufferLimit'
-            });
-        }
-
         this.filename = options.file;
-        this.queue = [];
+        this.format = options.format ? options.format : 'json'; // default to json
+        var stream = fs.createWriteStream(this.filename);
+        this.serializer = serializers.getSerializer(this.format, stream, {});
+
+        var self = this;
+        this.serializer
+        .on('error', function(err) {
+            // during write no fatal errors
+            self.trigger('warning', err);
+        });
     },
 
     process: function(points) {
-        this.logger.debug('process', points);
-        this.queue = this.queue.concat(points);
-        // if we're due for a flush and don't have a flush in course then
-        // fire off another flush
-        if (this.queue.length > this.bufferLimit && !this.flushPromise) {
-            this.flush();
-        }
-    },
-
-    flush: function() {
-        var self = this;
-        var points = [];
-
-        this.flushPromise = fs.statAsync(this.filename)
-        .then(function(stats) {
-            if (stats.size > self.maxFilesize) {
-                throw self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                    option: 'maxFilesize',
-                    value: self.maxFilesize + ' bytes'
-                });
-            }
-            // we can only read the file if it exists which would be here
-            // and only after verifying the maxFileSize has not been
-            // exceeded
-            return fs.readFileAsync(self.filename, 'utf8')
-            .then(function(data) {
-                points = JSON.parse(data);
-            });
-        })
-        .catch(function(err) {
-            // ignore the ENOENT since that means we don't have an output
-            // file to begin with
-            if (err.code !== 'ENOENT') {
-                throw err;
-            }
-        })
-        .then(function() {
-            if (points.length > self.limit) {
-                self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                    option: 'limit',
-                    value: self.limit,
-                    extra: ', dropping points.'
-                }));
-                return Promise.resolve();
-            } else {
-                var space_left = self.limit - points.length;
-                if (space_left < self.queue.length) {
-                    points = points.concat(self.queue.slice(0, space_left));
-                    // error since we really can't take any more points after this and
-                    // should stop the whole pipeline
-                    self.trigger('error', self.runtime_error('RT-OPTION-VALUE-EXCEEDED', {
-                        option: 'limit',
-                        value: self.limit,
-                        extra: ', dropping points.'
-                    }));
-                } else {
-                    // lets write out some more points
-                    points = points.concat(self.queue);
-                }
-                var data = JSON.stringify(points, null, 4);
-                self.queue = [];
-                return fs.writeFileAsync(self.filename, data);
-            }
-        })
-        .catch(function(err) {
-            self.trigger('error', err);
-        }).finally(function() {
-            self.flushPromise = null;
-        });
-
-        return this.flushPromise;
+        this.serializer.write(points);
     },
 
     eof: function() {
         this.logger.debug('eof');
-        var self = this;
-        var currentFlush = this.flushPromise || Promise.resolve();
-        currentFlush.then(function() {
-            // after the current flush is done lets make sure to fire off
-            // another one as the previous one could have been somewhere
-            // in the middle of the async write and without another flush we
-            // would leave points on the self.queue
-            return self.flush();
-        })
-        .then(function() {
-            self.done();
-        });
+        this.serializer.done();
+        this.done();
     }
 });
 

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -43,9 +43,10 @@ var Write = Juttle.proc.sink.extend({
     },
 
     eof: function() {
-        this.logger.debug('eof');
-        this.serializer.done();
-        this.done();
+        return this.serializer.done()
+        .then(() => {
+            this.done();
+        });
     }
 });
 

--- a/lib/adapters/serializers/base.js
+++ b/lib/adapters/serializers/base.js
@@ -17,7 +17,9 @@ module.exports = Base.inherits(events.EventEmitter, {
         // implement me
     },
 
-    done: function(points) {
+    done: function() {
         // implement me
+        // this method should return a promise that resolves when the
+        // serializer is done flushing the data to the unerlying stream
     }
 });

--- a/lib/adapters/serializers/csv.js
+++ b/lib/adapters/serializers/csv.js
@@ -34,15 +34,21 @@ module.exports = base.extend({
                 self.emit('error', errors.runtimeError('RT-INVALID-CSV-ERROR',{
                     detail: 'Found new or missing fields: ' + diff
                 }));
+            } else {
+                self.csvWriter.write(point);
             }
-
-            self.csvWriter.write(point);
         });
     },
 
     done: function() {
-        if (this.csvWriter) {
-            this.csvWriter.end();
-        }
+        return new Promise((resolve) => {
+            if (this.csvWriter) {
+                this.csvWriter.end(() => {
+                    resolve();
+                });
+            } else {
+                resolve();
+            }
+        });
     }
 });

--- a/lib/adapters/serializers/json.js
+++ b/lib/adapters/serializers/json.js
@@ -28,8 +28,12 @@ module.exports = base.extend({
     },
 
     done: function() {
-        if (this.pointBefore) {
-            this.stream.write('\n]');
-        }
+        return new Promise((resolve) => {
+            if (this.pointBefore) {
+                this.stream.write('\n]', resolve);
+            } else {
+                resolve();
+            }
+        });
     }
 });

--- a/lib/adapters/serializers/jsonl.js
+++ b/lib/adapters/serializers/jsonl.js
@@ -10,4 +10,8 @@ module.exports = base.extend({
             self.stream.write(JSON.stringify(point) + '\n');
         });
     },
+
+    done: function() { 
+        return Promise.resolve();
+    }
 });

--- a/lib/adapters/stdio/write.js
+++ b/lib/adapters/stdio/write.js
@@ -38,8 +38,10 @@ var Write = Juttle.proc.sink.extend({
     },
 
     eof: function() {
-        this.serializer.done();
-        this.done();
+        return this.serializer.done()
+        .then(() => {
+            this.done();
+        });
     }
 });
 

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -242,6 +242,19 @@ describe('file adapter tests', function () {
             return expect_to_fail(failing_write, message);
         });
 
+        it('warns when the underlying serializer emits errors', function() {
+            return check_juttle({
+                program: '( emit -limit 1 -from :2014-01-01:-:1s: | put foo = "bar"; ' +
+                         '  emit -limit 1 -from :2014-01-01: | put fizz = "buzz" )' +
+                         '| write file -file "' + tmp_file + '" -format "csv"'
+            })
+            .then(function(result) {
+                expect(result.errors.length).equal(0);
+                expect(result.warnings.length).equal(1);
+                expect(result.warnings[0]).to.contain('Invalid CSV data: Found new or missing fields: fizz');
+            });
+        });
+
         _.each(symmetricalFormats, function(format) {
             it('can write a point and read it back with ' + format + ' format', function() {
                 return check_juttle({

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -242,153 +242,60 @@ describe('file adapter tests', function () {
             return expect_to_fail(failing_write, message);
         });
 
-        _.each(['limit', 'maxFilesize', 'bufferLimit'], function(option) {
-            it('fails when you provide an invalid ' + option, function() {
-                var message = util.format('option %s should be a positive integer', option);
-                var failing_write = check_juttle({
-                    program: 'emit -limit 1 | write file -file "' + tmp_file + '" -' + option + ' -1'
-                });
-
-                return expect_to_fail(failing_write, message);
-            });
-        });
-
-        it('can write a point and read it back', function() {
-            return check_juttle({
-                program: 'emit -limit 1 | put message = "hello test" | write file -file "' + tmp_file + '"'
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(0);
-
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.sinks.table.length).equal(1);
-                expect(result.sinks.table[0].message).equal('hello test');
-            });
-        });
-
-        it('fails when you attempt to write to a file larger than -maxFilesize', function() {
-            return check_juttle({
-                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + tmp_file + '"'
-            })
-            .then(function() {
+        _.each(symmetricalFormats, function(format) {
+            it('can write a point and read it back with ' + format + ' format', function() {
                 return check_juttle({
-                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + tmp_file + '" -maxFilesize 2'
+                    program: 'emit -limit 1 ' +
+                             '| put message = "hello test" ' +
+                             '| write file -file "' + tmp_file + '" -format "' + format + '"'
+                })
+                .then(function(result) {
+                    expect(result.errors.length).equal(0);
+
+                    return run_read_file_juttle(tmp_file, { format: format });
+                })
+                .then(function(result) {
+                    expect(result.errors.length).equal(0);
+                    expect(result.sinks.table.length).equal(1);
+                    expect(result.sinks.table[0].message).equal('hello test');
                 });
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(1);
-                expect(result.errors[0]).to.contain('option maxFilesize exceeded limit of 2 bytes');
             });
-        });
 
-        it('fails when you exceed the -limit value', function() {
-            return check_juttle({
-                program: 'emit -limit 2 -from :2014-01-01: | write file -file "' + tmp_file + '" -limit 1'
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(1);
-                expect(result.errors[0]).to.equal('option limit exceeded limit of 1, dropping points.');
-
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.sinks.table.length).equal(1);
-            });
-        });
-
-        it('can handle writing no points out', function() {
-            return check_juttle({
-                program: 'emit -limit 3 -every :1s: | filter foo="bar" | write file -file "' + tmp_file + '"'
-            })
-            .then(function() {
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.sinks.table.length).to.equal(0);
-            });
-        });
-
-        it('can write all expected data with a high -bufferLimit', function() {
-            return check_juttle({
-                program: 'emit -limit 10 | write file -file "' + tmp_file + '" -bufferLimit 1000'
-            })
-            .then(function() {
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.sinks.table.length).to.equal(10);
-            });
-        });
-
-        it('can write all expected data with a low -bufferLimit', function() {
-            return check_juttle({
-                program: 'emit -limit 10 | write file -file "' + tmp_file + '" -bufferLimit 1'
-            })
-            .then(function() {
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.sinks.table.length).to.equal(10);
-            });
-        });
-
-        it('fails when you attempt to write to a file with more points than than -limit allows', function() {
-            return check_juttle({
-                program: 'emit -limit 3 -from :2014-01-01: | write file -file "' + tmp_file + '"'
-            })
-            .then(function() {
+            it('can handle writing no points out with ' + format + ' format ', function() {
                 return check_juttle({
-                    program: 'emit -limit 1 -from :2014-01-01: | write file -file "' + tmp_file + '" -limit 2'
+                    program: 'emit -limit 3 -every :1s: ' +
+                             '| filter foo="bar" ' +
+                             '| write file -file "' + tmp_file + '" -format "' + format + '"'
+                })
+                .then(function() {
+                    return run_read_file_juttle(tmp_file, { format: format });
+                })
+                .then(function(result) {
+                    expect(result.errors.length).to.equal(0);
+                    expect(result.warnings.length).to.equal(0);
+                    expect(result.sinks.table.length).to.equal(0);
                 });
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(1);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.errors[0]).to.contain('option limit exceeded limit of 2, dropping points.');
-
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
-                expect(result.sinks.table.length).to.equal(3);
             });
-        });
 
-        it('can write two points and read them back again', function() {
-            return check_juttle({
-                program: 'emit -limit 1 | put message = "hello test 2" | write file -file "' + tmp_file + '"'
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(0);
-            })
-            .then(function() {
+            it('can write multiple points and read them back again with ' + format + ' format', function() {
                 return check_juttle({
-                    program: 'emit -limit 1 | put message = "hello test 3" | write file -file "' + tmp_file + '"'
+                    program: 'emit -limit 10 -every :100ms: ' +
+                             '| put value=count(), message="hello test ${value}" ' +
+                             '| write file -file "' + tmp_file + '" -format "' + format + '"'
+                })
+                .then(function(result) {
+                    expect(result.errors.length).equal(0);
+                    return run_read_file_juttle(tmp_file, { format: format });
+                })
+                .then(function(result) {
+                    expect(result.errors.length).equal(0);
+                    expect(result.sinks.table.length).equal(10);
+                    for(var index = 0; index < 10; index++) {
+                        expect(result.sinks.table[index].message).equal('hello test ' + (index + 1));
+                    }
                 });
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(0);
-
-                return run_read_file_juttle(tmp_file);
-            })
-            .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.sinks.table.length).equal(2);
-                expect(result.sinks.table[0].message).equal('hello test 2');
-                expect(result.sinks.table[1].message).equal('hello test 3');
             });
         });
-
     });
 
     describe('optimizations', function() {
@@ -488,5 +395,4 @@ describe('file adapter tests', function () {
         });
 
     });
-
 });

--- a/test/adapters/serializers/csv.spec.js
+++ b/test/adapters/serializers/csv.spec.js
@@ -20,14 +20,15 @@ describe('serializers/csv', function() {
         var stream = fs.createWriteStream(tmpFilename);
         stream.on('open', function() {
             var serializer = serializers.getSerializer('csv', stream);
-            serializer.done();
-
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
-                expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
-                done();
+            serializer.done()
+            .then(() => {
+                stream.end(function(err) {
+                    if (err) {
+                        done(err);
+                    }
+                    expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
+                    done();
+                });
             });
         });
     });
@@ -57,13 +58,8 @@ describe('serializers/csv', function() {
                 { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
             ];
             serializer.write(data);
-            serializer.done();
-
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
-
+            serializer.done()
+            .then(() => {
                 var parser = parsers.getParser('csv');
                 var results = [];
                 parser.parseStream(fs.createReadStream(tmpFilename), function(result) {

--- a/test/adapters/serializers/json.spec.js
+++ b/test/adapters/serializers/json.spec.js
@@ -20,11 +20,8 @@ describe('serializers/json', function() {
         var stream = fs.createWriteStream(tmpFilename);
         stream.on('open', function() {
             var serializer = serializers.getSerializer('json', stream);
-            serializer.done();
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
+            serializer.done()
+            .then(() => {
                 expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
                 done();
             });
@@ -42,11 +39,8 @@ describe('serializers/json', function() {
                 { time: '2014-03-01T00:00:00.000Z', foo: 'bizz' }
             ];
             serializer.write(data);
-            serializer.done();
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
+            serializer.done()
+            .then(() => {
                 var results = [];
                 var parser = parsers.getParser('json');
                 parser.parseStream(fs.createReadStream(tmpFilename), function(result) {

--- a/test/adapters/serializers/jsonl.spec.js
+++ b/test/adapters/serializers/jsonl.spec.js
@@ -20,13 +20,15 @@ describe('serializers/jsonl', function() {
         var stream = fs.createWriteStream(tmpFilename);
         stream.on('open', function() {
             var serializer = serializers.getSerializer('jsonl', stream);
-            serializer.done();
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
-                expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
-                done();
+            serializer.done()
+            .then(() => {
+                stream.end(function(err) {
+                    if (err) {
+                        done(err);
+                    }
+                    expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
+                    done();
+                });
             });
         });
     });
@@ -42,13 +44,8 @@ describe('serializers/jsonl', function() {
                 { time: '2014-03-01T00:00:00.000Z', fuzz: 'bizz' }
             ];
             serializer.write(data);
-            serializer.done();
-
-            stream.end(function(err) {
-                if (err) {
-                    done(err);
-                }
-
+            serializer.done()
+            .then(() => {
                 var parser = parsers.getParser('jsonl');
                 var results = [];
                 return parser.parseStream(fs.createReadStream(tmpFilename), function(result) {

--- a/test/adapters/stdio/write.stdio.spec.js
+++ b/test/adapters/stdio/write.stdio.spec.js
@@ -36,6 +36,22 @@ describe('write stdio adapter tests', function() {
         });
     });
 
+    it('warns when the underlying serializer emits errors', function() {
+        var tmpFilename = tmp.tmpNameSync();
+        juttle_test_utils.set_stdout(fs.createWriteStream(tmpFilename));
+
+        return check_juttle({
+            program: '( emit -limit 1 -from :2014-01-01:-:1s: | put foo = "bar"; ' +
+                     '  emit -limit 1 -from :2014-01-01: | put fizz = "buzz" )' +
+                     '| write stdio -format "csv"'
+        })
+        .then(function(result) {
+            expect(result.errors.length).equal(0);
+            expect(result.warnings.length).equal(1);
+            expect(result.warnings[0]).to.contain('Invalid CSV data: Found new or missing fields: fizz');
+        });
+    });
+
     _.each(validFormats, function(details, format) {
         function handle(input) {
             if (details.typed) {


### PR DESCRIPTION
fixes #125

remove the ability to append to a file when writing and simply rely on the
serializers to write out data in the various supported serializer formats.

we can revisit adding a `-append` option to the file adapter when it
becomes a requirement.