### PR TITLE
Improve FilterJSCompiler tests

### DIFF
--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var expect = require('chai').expect;
+var chai = require('chai');
+var expect = chai.expect;
 
 var FilterJSCompiler = require('../../../lib/compiler/filters/filter-js-compiler.js');
 var JuttleMoment = require('../../../lib/moment').JuttleMoment;
@@ -9,6 +10,32 @@ var SemanticPass = require('../../../lib/compiler/semantic');
 
 // Needed to evaluate compiled Juttle code.
 var juttle = require('../../../lib/runtime/runtime');   // eslint-disable-line
+
+chai.use(function(chai, utils) {
+    chai.Assertion.addMethod('filter', function(points, result) {
+        /* jshint evil:true */
+
+        var ast = parser.parseFilter(this._obj).ast;
+
+        // We need to run the semantic pass to convert Variable nodes to field
+        // references.
+        var semantic = new SemanticPass();
+        ast = semantic.sa_expr(ast);
+
+        var compiler = new FilterJSCompiler();
+        var fn = eval(compiler.compile(ast));
+        var filtered = points.filter(fn);
+
+        this.assert(
+            utils.eql(filtered, result),
+            'expected #{this} to filter points to #{exp} but it filtered it to #{act}',
+            'expected #{this} to not filter points to #{exp} but it did',
+            result,
+            filtered,
+            true
+        );
+    });
+});
 
 var POINTS_MISC = [
     { v: null                                         },
@@ -35,53 +62,35 @@ var POINTS_STRINGS = [
 ];
 
 describe('FilterJSCompiler', function() {
-    function testFilter(filter, points, expected) {
-        /* jshint evil:true */
-
-        var ast = parser.parseFilter(filter).ast;
-
-        // We need to run the semantic pass to convert Variable nodes to field
-        // references.
-        var semantic = new SemanticPass();
-        ast = semantic.sa_expr(ast);
-
-        var compiler = new FilterJSCompiler();
-        var fn = eval(compiler.compile(ast));
-
-        expect(points.filter(fn)).to.deep.equal(expected);
-    }
-
     describe('literals', function() {
         it('handles null', function() {
-            testFilter('v == null', POINTS_MISC, [{ v: null }]);
+            expect('v == null').to.filter(POINTS_MISC, [{ v: null }]);
         });
 
         it('handles booleans', function() {
-            testFilter('v == true', POINTS_MISC, [{ v: true }]);
+            expect('v == true').to.filter(POINTS_MISC, [{ v: true }]);
         });
 
         it('handles numbers', function() {
-            testFilter('v == 5', POINTS_MISC, [{ v: 5 }]);
-            testFilter('v == Infinity', POINTS_MISC, [{ v: Infinity }]);
+            expect('v == 5').to.filter(POINTS_MISC, [{ v: 5 }]);
+            expect('v == Infinity').to.filter(POINTS_MISC, [{ v: Infinity }]);
             // No value equals NaN, not even NaN.
-            testFilter('v == NaN', POINTS_MISC, []);
+            expect('v == NaN').to.filter(POINTS_MISC, []);
         });
 
         it('handles strings', function() {
-            testFilter( 'v == "abcd"', POINTS_MISC, [{ v: 'abcd' }]);
+            expect( 'v == "abcd"').to.filter(POINTS_MISC, [{ v: 'abcd' }]);
         });
 
         it('handles dates', function() {
-            testFilter(
-                'v == :2015-01-01T00:00:00.000Z:',
+            expect('v == :2015-01-01T00:00:00.000Z:').to.filter(
                 POINTS_MISC,
                 [{ v: new JuttleMoment('2015-01-01T00:00:00.000Z') }]
             );
         });
 
         it('handles durations', function() {
-            testFilter(
-                'v == :00:00:05.000:',
+            expect('v == :00:00:05.000:').to.filter(
                 POINTS_MISC,
                 [{ v: JuttleMoment.duration('00:00:05.000') }]
             );
@@ -91,19 +100,19 @@ describe('FilterJSCompiler', function() {
     describe('filter expressions', function() {
         describe('NOT', function() {
             it('finds correct points', function() {
-                testFilter('NOT v == 2', POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
+                expect('NOT v == 2').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
             });
         });
 
         describe('AND', function() {
             it('finds correct points', function() {
-                testFilter('v <= 2 AND v >= 2', POINTS_NUMBERS, [{ v: 2 }]);
+                expect('v <= 2 AND v >= 2').to.filter(POINTS_NUMBERS, [{ v: 2 }]);
             });
         });
 
         describe('OR', function() {
             it('finds correct points', function() {
-                testFilter('v <= 2 OR v >= 2', POINTS_NUMBERS, [{ v: 1 }, { v: 2 }, { v: 3 }]);
+                expect('v <= 2 OR v >= 2').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 2 }, { v: 3 }]);
             });
         });
     });
@@ -111,88 +120,88 @@ describe('FilterJSCompiler', function() {
     describe('expression terms', function() {
         describe('missing fields', function() {
             it('treats them as null', function() {
-                testFilter('m == null', POINTS_NUMBERS, [{ v: 1 }, { v: 2 }, { v: 3 }]);
+                expect('m == null').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 2 }, { v: 3 }]);
             });
         });
 
         describe('==', function() {
             it('finds correct points (field == expression)', function() {
-                testFilter('v == 2', POINTS_NUMBERS, [{ v: 2 }]);
+                expect('v == 2').to.filter(POINTS_NUMBERS, [{ v: 2 }]);
             });
 
             it('finds correct points (expression == field)', function() {
-                testFilter('v == 2', POINTS_NUMBERS, [{ v: 2 }]);
+                expect('v == 2').to.filter(POINTS_NUMBERS, [{ v: 2 }]);
             });
         });
 
         describe('!=', function() {
             it('finds correct points (field != expression)', function() {
-                testFilter('v != 2', POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
+                expect('v != 2').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
             });
 
             it('finds correct points (expression != field)', function() {
-                testFilter('2 != v', POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
+                expect('2 != v').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
             });
         });
 
         describe('=~', function() {
             it('finds correct points (field =~ expression)', function() {
-                testFilter('v =~ "e*h"', POINTS_STRINGS, [{ v: 'efgh' }]);
-                testFilter('v =~ /e.*h/', POINTS_STRINGS, [{ v: 'efgh' }]);
+                expect('v =~ "e*h"').to.filter(POINTS_STRINGS, [{ v: 'efgh' }]);
+                expect('v =~ /e.*h/').to.filter(POINTS_STRINGS, [{ v: 'efgh' }]);
             });
         });
 
         describe('!~', function() {
             it('finds correct points (field !~ expression)', function() {
-                testFilter('v !~ "e*h"', POINTS_STRINGS, [{ v: 'abcd' }, { v: 'ijkl' }]);
-                testFilter('v !~ /e.*h/', POINTS_STRINGS, [{ v: 'abcd' }, { v: 'ijkl' }]);
+                expect('v !~ "e*h"').to.filter(POINTS_STRINGS, [{ v: 'abcd' }, { v: 'ijkl' }]);
+                expect('v !~ /e.*h/').to.filter(POINTS_STRINGS, [{ v: 'abcd' }, { v: 'ijkl' }]);
             });
         });
 
         describe('<', function() {
             it('finds correct points (field < expression)', function() {
-                testFilter('v < 2', POINTS_NUMBERS, [{ v: 1 }]);
+                expect('v < 2').to.filter(POINTS_NUMBERS, [{ v: 1 }]);
             });
 
             it('finds correct points (expression < field)', function() {
-                testFilter('2 < v', POINTS_NUMBERS, [{ v: 3 }]);
+                expect('2 < v').to.filter(POINTS_NUMBERS, [{ v: 3 }]);
             });
         });
 
         describe('>', function() {
             it('finds correct points (field > expression)', function() {
-                testFilter('v > 2', POINTS_NUMBERS, [{ v: 3 }]);
+                expect('v > 2').to.filter(POINTS_NUMBERS, [{ v: 3 }]);
             });
 
             it('finds correct points (expression > field)', function() {
-                testFilter('2 > v', POINTS_NUMBERS, [{ v: 1 }]);
+                expect('2 > v').to.filter(POINTS_NUMBERS, [{ v: 1 }]);
             });
         });
 
         describe('<=', function() {
             it('finds correct points (field <= expression)', function() {
-                testFilter('v <= 2', POINTS_NUMBERS, [{ v: 1 }, { v: 2 }]);
+                expect('v <= 2').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 2 }]);
             });
 
             it('finds correct points (expression <= field)', function() {
-                testFilter('2 <= v', POINTS_NUMBERS, [{ v: 2 }, { v: 3 }]);
+                expect('2 <= v').to.filter(POINTS_NUMBERS, [{ v: 2 }, { v: 3 }]);
             });
         });
 
         describe('>=', function() {
             it('finds correct points (field >= expression)', function() {
-                testFilter('v >= 2', POINTS_NUMBERS, [{ v: 2 }, { v: 3 }]
+                expect('v >= 2').to.filter(POINTS_NUMBERS, [{ v: 2 }, { v: 3 }]
                 );
             });
 
             it('finds correct points (expression >= field)', function() {
-                testFilter('2 >= v', POINTS_NUMBERS, [{ v: 1 }, { v: 2 }]);
+                expect('2 >= v').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 2 }]);
             });
         });
 
         describe('in', function() {
             it('finds correct points (field in expression)', function() {
-                testFilter('v in [1, 3]', POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
+                expect('v in [1, 3]').to.filter(POINTS_NUMBERS, [{ v: 1 }, { v: 3 }]);
             });
         });
     });

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -3,19 +3,19 @@
 var chai = require('chai');
 var expect = chai.expect;
 
-var FilterJSCompiler = require('../../../lib/compiler/filters/filter-js-compiler.js');
-var JuttleMoment = require('../../../lib/moment').JuttleMoment;
 var Filter = require('../../../lib/runtime/filter');
-var parser = require('../../../lib/parser');
-var errors = require('../../../lib/errors');
+var JuttleMoment = require('../../../lib/moment').JuttleMoment;
 var SemanticPass = require('../../../lib/compiler/semantic');
+var _ = require('underscore');
+var errors = require('../../../lib/errors');
+var parser = require('../../../lib/parser');
 
-// Needed to evaluate compiled Juttle code.
+var FilterJSCompiler = require('../../../lib/compiler/filters/filter-js-compiler.js');
+
+// Needed to evaluate compiled filters.
 var juttle = require('../../../lib/runtime/runtime');   // eslint-disable-line
 
 function filterPoints(filter, points) {
-    /* jshint evil:true */
-
     var ast = parser.parseFilter(filter).ast;
 
     // We need to run the semantic pass to convert Variable nodes to field
@@ -26,7 +26,7 @@ function filterPoints(filter, points) {
     var compiler = new FilterJSCompiler();
     var fn = eval(compiler.compile(ast));
 
-    return points.filter(fn);
+    return _.filter(points, fn);
 }
 
 chai.use(function(chai, utils) {


### PR DESCRIPTION
Rewrite the `FilterJSCompiler` tests so that they don’t use ASTs, match structure of tested code better, and are more idiomatic. See individual commit messages for details.

Overall, these changes will make work with tests easier as capabilities of `FilterJSCompiler` are extended. 

Part of work on #57.