### PR TITLE
Extend FilterJSCompiler

### DIFF
--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -123,6 +123,18 @@ var FilterJSCompiler = ASTVisitor.extend({
         return 'juttle.ops.str(' + this.visit(node.expression) + ')';
     },
 
+    visitPropertyAccess: function(node) {
+        if (!node.computed) {
+            return node.uname;
+        } else {
+            return 'juttle.ops.get('
+                + this.visit(node.base)
+                + ', '
+                + this.visit(node.name)
+                + ')';
+        }
+    },
+
     visitUnaryExpression: function(node) {
         switch (node.operator) {
             case '*':

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -10,6 +10,13 @@ var ASTVisitor = require('../ast-visitor');
 var _ = require('underscore');
 var errors = require('../../errors');
 
+var UNARY_OPS_TO_FUNCTIONS = {
+    '+':   'pos',
+    '-':   'neg',
+    '~':   'bnot',
+    'NOT': 'lnot'
+};
+
 var BINARY_OPS_TO_FUNCTIONS = {
     '==':  'eql',
     '!=':  'neq',
@@ -75,14 +82,20 @@ var FilterJSCompiler = ASTVisitor.extend({
 
     visitUnaryExpression: function(node) {
         switch (node.operator) {
-            case 'NOT':
-                return 'juttle.ops.lnot(' + this.visit(node.expression) + ')';
-
             case '*':
                 return 'juttle.ops.pget(pt, ' + this.visit(node.expression) + ')';
 
+            case '!':
+                return '!juttle.values.ensureBoolean('
+                    + this.visit(node.expression)
+                    + ', '
+                    + '\'"!" operator: Invalid operand type (<type>).\''
+                    + ')';
+
             default:
-                throw new Error('Invalid operator: ' + node.operator + '.');
+                return 'juttle.ops.' + UNARY_OPS_TO_FUNCTIONS[node.operator] + '('
+                    + this.visit(node.expression)
+                    + ')';
         }
     },
 

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -72,6 +72,10 @@ var FilterJSCompiler = ASTVisitor.extend({
         return JSON.stringify(node.value);
     },
 
+    visitMultipartStringLiteral: function(node) {
+        return '(' + _.map(node.parts, this.visit, this).join(' + ') + ')';
+    },
+
     visitRegularExpressionLiteral: function(node) {
         return 'new RegExp(' + JSON.stringify(node.value) + ', ' + JSON.stringify(node.flags) + ')';
     },
@@ -90,6 +94,10 @@ var FilterJSCompiler = ASTVisitor.extend({
 
     visitArrayLiteral: function(node) {
         return '[ ' + _.map(node.elements, this.visit, this).join(', ') + ' ]';
+    },
+
+    visitToString: function(node) {
+        return 'juttle.ops.str(' + this.visit(node.expression) + ')';
     },
 
     visitUnaryExpression: function(node) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -18,6 +18,17 @@ var UNARY_OPS_TO_FUNCTIONS = {
 };
 
 var BINARY_OPS_TO_FUNCTIONS = {
+    '+':   'add',
+    '-':   'sub',
+    '*':   'mul',
+    '/':   'div',
+    '%':   'mod',
+    '&':   'band',
+    '|':   'bor',
+    '^':   'bxor',
+    '<<':  'shl',
+    '>>':  'shr',
+    '>>>': 'shrz',
     '==':  'eql',
     '!=':  'neq',
     '=~':  'match',
@@ -28,7 +39,8 @@ var BINARY_OPS_TO_FUNCTIONS = {
     '>=':  'gte',
     'in':  'in',
     'AND': 'land',
-    'OR':  'lor'
+    'OR':  'lor',
+    '??':  'coal'
 };
 
 var FilterJSCompiler = ASTVisitor.extend({
@@ -100,11 +112,28 @@ var FilterJSCompiler = ASTVisitor.extend({
     },
 
     visitBinaryExpression: function(node) {
-        return 'juttle.ops.' + BINARY_OPS_TO_FUNCTIONS[node.operator] + '('
-            + this.visit(node.left)
-            + ', '
-            + this.visit(node.right)
-            + ')';
+        switch (node.operator) {
+            case '&&':
+            case '||':
+                return 'juttle.values.ensureBoolean('
+                    + this.visit(node.left)
+                    + ', '
+                    + '\'"' + node.operator + '" operator: Invalid operand type (<type>).\''
+                    + ')'
+                    + ' ' + node.operator + ' '
+                    + 'juttle.values.ensureBoolean('
+                    + this.visit(node.right)
+                    + ', '
+                    + '\'"' + node.operator + '" operator: Invalid operand type (<type>).\''
+                    + ')';
+
+            default:
+                return 'juttle.ops.' + BINARY_OPS_TO_FUNCTIONS[node.operator] + '('
+                    + this.visit(node.left)
+                    + ', '
+                    + this.visit(node.right)
+                    + ')';
+        }
     },
 
     visitExpressionFilterTerm: function(node) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -187,6 +187,18 @@ var FilterJSCompiler = ASTVisitor.extend({
         }
     },
 
+    visitConditionalExpression: function(node) {
+        return 'juttle.values.ensureBoolean('
+            + this.visit(node.condition)
+            + ', '
+            + '\'Ternary operator: Invalid operand type (<type>).\''
+            + ')'
+            + ' ? '
+            + this.visit(node.trueExpression)
+            + ' : '
+            + this.visit(node.falseExpression);
+    },
+
     visitExpressionFilterTerm: function(node) {
         return this.visit(node.expression);
     },

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -135,6 +135,14 @@ var FilterJSCompiler = ASTVisitor.extend({
         }
     },
 
+    visitFunctionCall: function(node) {
+        return  'juttle.ops.call('
+            + node.fname
+            + ', '
+            + _.map(node.arguments, this.visit, this).join(', ')
+            + ')';
+    },
+
     visitUnaryExpression: function(node) {
         switch (node.operator) {
             case '*':

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -7,6 +7,7 @@
 // The compiler doesn't modify the AST.
 
 var ASTVisitor = require('../ast-visitor');
+var _ = require('underscore');
 var errors = require('../../errors');
 
 var BINARY_OPS_TO_FUNCTIONS = {
@@ -69,9 +70,7 @@ var FilterJSCompiler = ASTVisitor.extend({
     },
 
     visitArrayLiteral: function(node) {
-        var self = this;
-
-        return '[' + node.elements.map(function(e) { return self.visit(e); }).join(', ') + ']';
+        return '[ ' + _.map(node.elements, this.visit, this).join(', ') + ' ]';
     },
 
     visitUnaryExpression: function(node) {
@@ -89,7 +88,8 @@ var FilterJSCompiler = ASTVisitor.extend({
 
     visitBinaryExpression: function(node) {
         return 'juttle.ops.' + BINARY_OPS_TO_FUNCTIONS[node.operator] + '('
-            + this.visit(node.left) + ', '
+            + this.visit(node.left)
+            + ', '
             + this.visit(node.right)
             + ')';
     },

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -96,6 +96,29 @@ var FilterJSCompiler = ASTVisitor.extend({
         return '[ ' + _.map(node.elements, this.visit, this).join(', ') + ' ]';
     },
 
+    visitObjectLiteral: function(node) {
+        var self = this;
+
+        var hasSimpleKeys = _.every(node.properties, function(property) {
+            return property.key.type === 'StringLiteral'
+                || property.key.type === 'NumericLiteral';
+        });
+
+        var propertiesCode = _.map(node.properties, function(property) {
+            return self.visit(property, hasSimpleKeys);
+        }).join(', ');
+
+        return hasSimpleKeys
+            ? '{ ' + propertiesCode + ' }'
+            : 'juttle.values.buildObject([ ' + propertiesCode + ' ])';
+    },
+
+    visitObjectProperty: function(node, hasSimpleKeys) {
+        return hasSimpleKeys
+            ? this.visit(node.key) + ': ' + this.visit(node.value)
+            : '[' + this.visit(node.key) + ', ' + this.visit(node.value) + ']';
+    },
+
     visitToString: function(node) {
         return 'juttle.ops.str(' + this.visit(node.expression) + ')';
     },

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -221,6 +221,10 @@ describe('FilterJSCompiler', function() {
         expect('a == (null ?? 2)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
     });
 
+    it('compiles ConditionalExpression correctly', function() {
+        expect('a == (true ? 2 : 3)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+    });
+
     it('compiles ExpressionFilterTerm correctly', function() {
         expect('a == 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
     });

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -153,6 +153,19 @@ describe('FilterJSCompiler', function() {
     });
 
     it('compiles BinaryExpression correctly', function() {
+        expect('a == (true && true)').to.filter(POINTS_BOOLEANS, [ { a: true } ]);
+        expect('a == (true || true)').to.filter(POINTS_BOOLEANS, [ { a: true } ]);
+        expect('a == 1 + 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 3 - 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 2 * 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 4 / 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 2 % 3').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == (2 & 2)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == (2 | 2)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == (2 ^ 0)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 1 << 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 4 >> 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == 4 >>> 1').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
         expect('a == 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
         expect('a != 2').to.filter(POINTS_NUMBERS, [ { a: 1 }, { a: 3 } ]);
         expect('a =~ "efgh"').to.filter(POINTS_STRINGS, [ { a: 'efgh' } ]);
@@ -164,6 +177,7 @@ describe('FilterJSCompiler', function() {
         expect('a in [ 1, 3 ]').to.filter(POINTS_NUMBERS, [ { a: 1 }, { a : 3 } ]);
         expect('a <= 2 AND a >= 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
         expect('a <= 2 OR a >= 2').to.filter(POINTS_NUMBERS, [ { a: 1 }, { a: 2 }, { a: 3 } ]);
+        expect('a == (null ?? 2)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
     });
 
     it('compiles ExpressionFilterTerm correctly', function() {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -118,6 +118,10 @@ describe('FilterJSCompiler', function() {
         expect('a == "abcd"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
     });
 
+    it('compiles MultipartStringLiteral correctly', function() {
+        expect('a == "${"ab" + "cd"}"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
+    });
+
     it('compiles RegularExpressionLiteral correctly', function() {
         expect('a == /abcd/').to.filter(POINTS_VALUES, [ { a: /abcd/ } ]);
         expect('a == /abcd/gim').to.filter(POINTS_VALUES, [ { a: /abcd/gim } ]);
@@ -141,6 +145,10 @@ describe('FilterJSCompiler', function() {
 
     it('compiles ArrayLiteral correctly', function() {
         expect('a == [ 1, 2, 3 ]').to.filter(POINTS_VALUES, [ { a: [ 1, 2, 3 ] } ]);
+    });
+
+    it('compiles ToString correctly', function() {
+        expect('a == "${"ab" + "cd"}"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
     });
 
     it('compiles UnaryExpression correctly', function() {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -89,6 +89,12 @@ describe('FilterJSCompiler', function() {
         { a: 'ijkl' }
     ];
 
+    var POINTS_OBJECTS = [
+        { a: { 'a': 1 } },
+        { a: { 5: 2 } },
+        { a: { 'abcd': 3 } },
+    ];
+
     it('compiles NullLiteral correctly', function() {
         expect('a == null').to.filter(POINTS_VALUES, [ { a: null } ]);
     });
@@ -145,6 +151,17 @@ describe('FilterJSCompiler', function() {
 
     it('compiles ArrayLiteral correctly', function() {
         expect('a == [ 1, 2, 3 ]').to.filter(POINTS_VALUES, [ { a: [ 1, 2, 3 ] } ]);
+    });
+
+    it('compiles ObjectLiteral correctly', function() {
+        expect('a == { a: 1 }').to.filter(POINTS_OBJECTS, [ { a: { a: 1 } } ]);
+        expect('a == { 5: 2 }').to.filter(POINTS_OBJECTS, [ { a: { 5: 2 } } ]);
+        expect('a == { "${"ab" + "cd"}": 3 }').to.filter(POINTS_OBJECTS, [ { a: { 'abcd': 3 } } ]);
+    });
+
+    it('compiles ObjectProperty correctly', function() {
+        expect('a == { a: 1 }').to.filter(POINTS_OBJECTS, [ { a: { a: 1 } } ]);
+        expect('a == { "${"ab" + "cd"}": 3 }').to.filter(POINTS_OBJECTS, [ { a: { 'abcd': 3 } } ]);
     });
 
     it('compiles ToString correctly', function() {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -89,6 +89,12 @@ describe('FilterJSCompiler', function() {
         { a: 'ijkl' }
     ];
 
+    var POINTS_ARRAYS = [
+        { a: [ 1, 2, 3 ] },
+        { a: [ 4, 5, 6 ] },
+        { a: [ 7, 8, 9 ] },
+    ];
+
     var POINTS_OBJECTS = [
         { a: { 'a': 1 } },
         { a: { 5: 2 } },
@@ -166,6 +172,13 @@ describe('FilterJSCompiler', function() {
 
     it('compiles ToString correctly', function() {
         expect('a == "${"ab" + "cd"}"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
+    });
+
+    it('compiles PropertyAccess correctly', function() {
+        // Non-computed PropertyAccess can't be tested because it refers to
+        // module exports and we can't load modules here.
+
+        expect('a[1] == 5').to.filter(POINTS_ARRAYS, [ { a: [ 4, 5, 6 ] } ]);
     });
 
     it('compiles UnaryExpression correctly', function() {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -72,6 +72,11 @@ describe('FilterJSCompiler', function() {
         { a: { a: 1, b: 2, c: 3 } }
     ];
 
+    var POINTS_BOOLEANS = [
+        { a: true },
+        { a: false }
+    ];
+
     var POINTS_NUMBERS = [
         { a: 1 },
         { a: 2 },
@@ -139,8 +144,12 @@ describe('FilterJSCompiler', function() {
     });
 
     it('compiles UnaryExpression correctly', function() {
-        expect('NOT a == 2').to.filter(POINTS_NUMBERS, [ { a: 1 }, { a: 3 } ]);
         expect('*"a" == 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == !false').to.filter(POINTS_BOOLEANS, [ { a: true } ]);
+        expect('a == +2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == -(-2)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('a == ~(-3)').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+        expect('NOT a == 2').to.filter(POINTS_NUMBERS, [ { a: 1 }, { a: 3 } ]);
     });
 
     it('compiles BinaryExpression correctly', function() {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -181,6 +181,9 @@ describe('FilterJSCompiler', function() {
         expect('a[1] == 5').to.filter(POINTS_ARRAYS, [ { a: [ 4, 5, 6 ] } ]);
     });
 
+    // FunctionCall can't be tested because it calls a function and we can't
+    // define functions here.
+
     it('compiles UnaryExpression correctly', function() {
         expect('*"a" == 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
         expect('a == !false').to.filter(POINTS_BOOLEANS, [ { a: true } ]);


### PR DESCRIPTION
Extend `FilterJSCompiler` to handle AST nodes that will be part of dynamic filters. It can now handle essentially all expressions. The code was mostly adapted from `code-generator.js`, `build.js` and `graph-compiler.js` (and yes, it would be good to unify these instead of duplication — but that has to wait as we need to do more high-priority work now).

Note the chosen method of testing didn’t allow to test some expressions (e.g. function calls). These were noted in the test file and tested manually (with lifted filter checks). One way to test them would be to rewrite the tests into JuttleSpec, but that would make them much bigger and more clumsy so I didn’t want to do that (at least not now).

Part of work on #57.