### PR TITLE
Split FilterChecker and enable dynamic filters

### DIFF
--- a/lib/compiler/filters/dynamic-filter-checker.js
+++ b/lib/compiler/filters/dynamic-filter-checker.js
@@ -120,7 +120,7 @@ var ALLOWED_OP_FORMS_FIELD_COMPARISON = _(ALLOWED_OP_FORMS).mapObject(function(f
     );
 });
 
-var FilterChecker = ASTVisitor.extend({
+var DynamicFilterChecker = ASTVisitor.extend({
     check: function(node, options) {
         this.options = options;
 
@@ -171,4 +171,4 @@ var FilterChecker = ASTVisitor.extend({
     }
 });
 
-module.exports = FilterChecker;
+module.exports = DynamicFilterChecker;

--- a/lib/compiler/filters/dynamic-filter-checker.js
+++ b/lib/compiler/filters/dynamic-filter-checker.js
@@ -1,10 +1,9 @@
 'use strict';
 
-// Inspects filter expression AST and throws an error if it is invalid.
-//
-// For normal expressions, these checks are done in runtime, but for filter
-// expressions at least some basic checks need to be done sooner so that the
-// various compilers (mostly in adapters) can assume some level of sanity.
+// Checks whether a filter expression AST represents a valid *dynamic filter*.
+// Dynamic filters allow straming expressions such as function calls on point
+// fields and don't restrict forms of comparison expression, but they don't
+// support FTS. They are intended to be compiled into JavaScript.
 
 var ASTVisitor = require('../ast-visitor');
 var errors = require('../../errors');

--- a/lib/compiler/filters/dynamic-filter-checker.js
+++ b/lib/compiler/filters/dynamic-filter-checker.js
@@ -6,167 +6,19 @@
 // expressions at least some basic checks need to be done sooner so that the
 // various compilers (mostly in adapters) can assume some level of sanity.
 
-var _ = require('underscore');
 var ASTVisitor = require('../ast-visitor');
 var errors = require('../../errors');
-var values = require('../../runtime/values');
-
-// For ExpressionFilterTerms, we use a table of allowed forms for each operator.
-// Descriptions of these forms use the following checks to test their operands.
-
-var checks = {
-    isSimpleFieldReference: {
-        displayName: 'field',
-
-        test: function(node) {
-            return node.type === 'UnaryExpression'
-                && node.operator === '*'
-                && node.expression.type === 'StringLiteral';
-        }
-    },
-
-    isStringLiteral: {
-        displayName: 'string',
-
-        test: function(node) {
-            return node.type === 'StringLiteral';
-        }
-    },
-
-    isRegularExpressionLiteral: {
-        displayName: 'regexp',
-
-        test: function(node) {
-            return node.type === 'RegularExpressionLiteral';
-        }
-    },
-
-    isSimpleLiteral: {
-        displayName: 'value',
-
-        test: function(node) {
-            return node.type === 'NullLiteral'
-                || node.type === 'BooleanLiteral'
-                || node.type === 'NumericLiteral'
-                || node.type === 'InfinityLiteral'
-                || node.type === 'NaNLiteral'
-                || node.type === 'StringLiteral'
-                || node.type === 'MomentLiteral'
-                || node.type === 'DurationLiteral';
-        }
-    },
-
-    isSimpleArrayLiteral: {
-        displayName: 'array',
-
-        test: function(node) {
-            return node.type === 'ArrayLiteral'
-                && _.every(node.elements, checks.isSimpleLiteral.test);
-        }
-    }
-};
-
-// And here comes the description of allowed operator forms.
-
-var ALLOWED_OP_FORMS = {
-    '==': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    '!=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    '=~': [
-        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
-        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
-    ],
-
-    '!~': [
-        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
-        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
-    ],
-
-    '<': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    '>': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    '<=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    '>=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
-    ],
-
-    'in': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleArrayLiteral },
-    ]
-};
-
-var ALLOWED_OP_FORMS_FIELD_COMPARISON = _(ALLOWED_OP_FORMS).mapObject(function(forms, operator) {
-    return _.clone(forms).concat(
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleFieldReference }
-    );
-});
 
 var DynamicFilterChecker = ASTVisitor.extend({
-    check: function(node, options) {
-        this.options = options;
-
+    check: function(node) {
         this.visit(node);
     },
 
-    visitExpressionFilterTerm: function(node) {
-        var forms = this.options.allowFieldComparisons
-            ? ALLOWED_OP_FORMS_FIELD_COMPARISON[node.expression.operator]
-            : ALLOWED_OP_FORMS[node.expression.operator];
-
-        var valid = _.any(forms, function(form) {
-            return form.left.test(node.expression.left)
-                && form.right.test(node.expression.right);
-        });
-
-        if (!valid) {
-            var formsDescription = _.map(forms, function(form) {
-                return JSON.stringify(form.left.displayName
-                    + ' '
-                    + node.expression.operator
-                    + ' '
-                    + form.right.displayName);
-            }).join(', ');
-
-            throw errors.compileError('RT-INVALID-EXPRESSION-FILTER-TERM', {
-                forms: formsDescription,
+    visitSimpleFilterTerm: function(node) {
+        if (node.expression.type !== 'FilterLiteral') {
+            throw errors.compileError('RT-NO-FREE-TEXT', {
                 location: node.location
             });
-        }
-    },
-
-    visitSimpleFilterTerm: function(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-                break;
-
-            case 'FilterLiteral':
-                this.visit(node.expression);
-                break;
-
-            default:
-                throw errors.compileError('RT-INVALID-TERM-TYPE', {
-                    type: values.typeDisplayName(values.typeOf(values.fromAST(node.expression))),
-                    location: node.location
-                });
         }
     }
 });

--- a/lib/compiler/filters/index.js
+++ b/lib/compiler/filters/index.js
@@ -2,10 +2,12 @@
 
 var FilterJSCompiler = require('./filter-js-compiler');
 var PartialFilterJSCompiler = require('./partial-filter-js-compiler');
-var FilterChecker = require('./filter-checker');
+var StaticFilterChecker = require('./static-filter-checker');
+var DynamicFilterChecker = require('./dynamic-filter-checker');
 
 module.exports = {
     FilterJSCompiler: FilterJSCompiler,
     PartialFilterJSCompiler: PartialFilterJSCompiler,
-    FilterChecker: FilterChecker
+    StaticFilterChecker: StaticFilterChecker,
+    DynamicFilterChecker: DynamicFilterChecker
 };

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -114,23 +114,13 @@ var ALLOWED_OP_FORMS = {
     ]
 };
 
-var ALLOWED_OP_FORMS_FIELD_COMPARISON = _(ALLOWED_OP_FORMS).mapObject(function(forms, operator) {
-    return _.clone(forms).concat(
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleFieldReference }
-    );
-});
-
 var StaticFilterChecker = ASTVisitor.extend({
-    check: function(node, options) {
-        this.options = options;
-
+    check: function(node) {
         this.visit(node);
     },
 
     visitExpressionFilterTerm: function(node) {
-        var forms = this.options.allowFieldComparisons
-            ? ALLOWED_OP_FORMS_FIELD_COMPARISON[node.expression.operator]
-            : ALLOWED_OP_FORMS[node.expression.operator];
+        var forms = ALLOWED_OP_FORMS[node.expression.operator];
 
         var valid = _.any(forms, function(form) {
             return form.left.test(node.expression.left)

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -1,10 +1,9 @@
 'use strict';
 
-// Inspects filter expression AST and throws an error if it is invalid.
-//
-// For normal expressions, these checks are done in runtime, but for filter
-// expressions at least some basic checks need to be done sooner so that the
-// various compilers (mostly in adapters) can assume some level of sanity.
+// Checks whether a filter expression AST represents a valid *static filter*.
+// Static filters don't allow straming expressions such as function calls on
+// point fields and restrict forms of comparison expression. This ensures they
+// can be compiled into native queries by adapters.
 
 var _ = require('underscore');
 var ASTVisitor = require('../ast-visitor');

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -1,0 +1,174 @@
+'use strict';
+
+// Inspects filter expression AST and throws an error if it is invalid.
+//
+// For normal expressions, these checks are done in runtime, but for filter
+// expressions at least some basic checks need to be done sooner so that the
+// various compilers (mostly in adapters) can assume some level of sanity.
+
+var _ = require('underscore');
+var ASTVisitor = require('../ast-visitor');
+var errors = require('../../errors');
+var values = require('../../runtime/values');
+
+// For ExpressionFilterTerms, we use a table of allowed forms for each operator.
+// Descriptions of these forms use the following checks to test their operands.
+
+var checks = {
+    isSimpleFieldReference: {
+        displayName: 'field',
+
+        test: function(node) {
+            return node.type === 'UnaryExpression'
+                && node.operator === '*'
+                && node.expression.type === 'StringLiteral';
+        }
+    },
+
+    isStringLiteral: {
+        displayName: 'string',
+
+        test: function(node) {
+            return node.type === 'StringLiteral';
+        }
+    },
+
+    isRegularExpressionLiteral: {
+        displayName: 'regexp',
+
+        test: function(node) {
+            return node.type === 'RegularExpressionLiteral';
+        }
+    },
+
+    isSimpleLiteral: {
+        displayName: 'value',
+
+        test: function(node) {
+            return node.type === 'NullLiteral'
+                || node.type === 'BooleanLiteral'
+                || node.type === 'NumericLiteral'
+                || node.type === 'InfinityLiteral'
+                || node.type === 'NaNLiteral'
+                || node.type === 'StringLiteral'
+                || node.type === 'MomentLiteral'
+                || node.type === 'DurationLiteral';
+        }
+    },
+
+    isSimpleArrayLiteral: {
+        displayName: 'array',
+
+        test: function(node) {
+            return node.type === 'ArrayLiteral'
+                && _.every(node.elements, checks.isSimpleLiteral.test);
+        }
+    }
+};
+
+// And here comes the description of allowed operator forms.
+
+var ALLOWED_OP_FORMS = {
+    '==': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '!=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '=~': [
+        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
+        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+    ],
+
+    '!~': [
+        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
+        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+    ],
+
+    '<': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '>': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '<=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    '>=': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+    ],
+
+    'in': [
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleArrayLiteral },
+    ]
+};
+
+var ALLOWED_OP_FORMS_FIELD_COMPARISON = _(ALLOWED_OP_FORMS).mapObject(function(forms, operator) {
+    return _.clone(forms).concat(
+        { left: checks.isSimpleFieldReference, right: checks.isSimpleFieldReference }
+    );
+});
+
+var StaticFilterChecker = ASTVisitor.extend({
+    check: function(node, options) {
+        this.options = options;
+
+        this.visit(node);
+    },
+
+    visitExpressionFilterTerm: function(node) {
+        var forms = this.options.allowFieldComparisons
+            ? ALLOWED_OP_FORMS_FIELD_COMPARISON[node.expression.operator]
+            : ALLOWED_OP_FORMS[node.expression.operator];
+
+        var valid = _.any(forms, function(form) {
+            return form.left.test(node.expression.left)
+                && form.right.test(node.expression.right);
+        });
+
+        if (!valid) {
+            var formsDescription = _.map(forms, function(form) {
+                return JSON.stringify(form.left.displayName
+                    + ' '
+                    + node.expression.operator
+                    + ' '
+                    + form.right.displayName);
+            }).join(', ');
+
+            throw errors.compileError('RT-INVALID-EXPRESSION-FILTER-TERM', {
+                forms: formsDescription,
+                location: node.location
+            });
+        }
+    },
+
+    visitSimpleFilterTerm: function(node) {
+        switch (node.expression.type) {
+            case 'StringLiteral':
+                break;
+
+            case 'FilterLiteral':
+                this.visit(node.expression);
+                break;
+
+            default:
+                throw errors.compileError('RT-INVALID-TERM-TYPE', {
+                    type: values.typeDisplayName(values.typeOf(values.fromAST(node.expression))),
+                    location: node.location
+                });
+        }
+    }
+});
+
+module.exports = StaticFilterChecker;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -399,7 +399,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_ReadProc: function(ast) {
         if (ast.filter) {
             var checker = new StaticFilterChecker();
-            checker.check(ast.filter, { now: this.now, allowFieldComparisons: false });
+            checker.check(ast.filter);
         }
 
         var params = {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -436,7 +436,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_FilterProc: function(ast) {
         var checker = new DynamicFilterChecker();
-        checker.check(ast.filter, { now: this.now, allowFieldComparisons: true });
+        checker.check(ast.filter);
 
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);
@@ -445,7 +445,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_SequenceProc: function(ast) {
         var checker = new DynamicFilterChecker();
-        _.each (ast.filters, (filter) => { checker.check(filter, { now: this.now, allowFieldComparisons: true });});
+        _.each (ast.filters, (filter) => { checker.check(filter);});
 
 
         var filters = _.map(ast.filters, function(filter) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -3,7 +3,8 @@
 var _ = require('underscore');
 var CodeGenerator = require('./code-generator');
 var filters = require('./filters');
-var FilterChecker = filters.FilterChecker;
+var StaticFilterChecker = filters.StaticFilterChecker;
+var DynamicFilterChecker = filters.DynamicFilterChecker;
 var FilterJSCompiler = filters.FilterJSCompiler;
 var errors = require('../errors');
 
@@ -397,7 +398,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_ReadProc: function(ast) {
         if (ast.filter) {
-            var checker = new FilterChecker();
+            var checker = new StaticFilterChecker();
             checker.check(ast.filter, { now: this.now, allowFieldComparisons: false });
         }
 
@@ -434,7 +435,7 @@ var GraphCompiler = CodeGenerator.extend({
         return pname;
     },
     gen_FilterProc: function(ast) {
-        var checker = new FilterChecker();
+        var checker = new DynamicFilterChecker();
         checker.check(ast.filter, { now: this.now, allowFieldComparisons: true });
 
         var compiler = new FilterJSCompiler();
@@ -443,7 +444,7 @@ var GraphCompiler = CodeGenerator.extend({
         return this.gen_proc(ast, 'filter', '{predicate: ' + code + '}');
     },
     gen_SequenceProc: function(ast) {
-        var checker = new FilterChecker();
+        var checker = new DynamicFilterChecker();
         _.each (ast.filters, (filter) => { checker.check(filter, { now: this.now, allowFieldComparisons: true });});
 
 

--- a/test/compiler/inputs.spec.js
+++ b/test/compiler/inputs.spec.js
@@ -116,22 +116,20 @@ describe('Juttle inputs', function() {
                                  inputs: {
                                      f: new Filter(
                                          {
-                                             type: 'ExpressionFilterTerm',
+                                             type: 'SimpleFilterTerm',
                                              expression: {
-                                                 type: 'BinaryExpression',
-                                                 operator: '<',
-                                                 left: { type: 'NumericLiteral', value: 1 },
-                                                 right: { type: 'NumericLiteral', value: 2 }
+                                                 type: 'StringLiteral',
+                                                 value: 'abcd'
                                              }
                                          },
-                                         '1 < 2'
+                                         '"abcd"'
                                      )
                                  }})
                 .then(function() {
                     throw new Error('this should fail');
                 })
                 .catch(function(err) {
-                    expect(err.message).to.eq('Invalid filter term. Valid forms are: "field < value", "value < field", "field < field".');
+                    expect(err.message).to.eq('Free text search is not implemented in this context.');
                 });
         });
     });

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -40,17 +40,6 @@ Regression test for PROD-6797.
 
     { time: "1970-01-01T00:00:00.000Z", a: 5 }
 
-The `*` operator: Produces an error when the expression has an invalid type
----------------------------------------------------------------------------
-
-### Juttle
-
-    emit -from Date.new(0) -limit 1 | put a = 5 | filter *null == 5 | view result
-
-### Errors
-
-  * Invalid filter term. Valid forms are: "field == value", "value == field", "field == field".
-
 The `=~` operator: Produces an error for `non-field @ *`
 --------------------------------------------------------
 


### PR DESCRIPTION
Split `FilterChecker` into `StaticFilterChecker` and `DynamicFilterChecker`, which are then tweaked and used in appropriate places in order to support dynamic filters in `filter`.

Final step of #57.