### PR TITLE
add -format to `read http`

### DIFF
--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -20,6 +20,7 @@ read http -url url
           -timeField timeField
           -rootPath rootPath
           -includeHeaders true/false
+          -format csv/json/jsonl
 ```
 
 Parameter         |             Description          | Required?
@@ -31,6 +32,8 @@ Parameter         |             Description          | Required?
 `-timeField`      | The name of the field to use as the time field <br><br>The specified field will be renamed to `time` in the body of the HTTP request. If the points already contain a field called `time`, that field is overwritten. This is useful when the source data contains a time field whose values are not valid time stamps.  | No; defaults to keeping the `time` field as is
 `-rootPath`       | When the incoming data is JSON, use the specified path into the incoming object (expressed as `field1.field2`) to emit points | No
 `-includeHeaders` | When set to true the headers from the response are appended to each of the points in the response | No; default: `false`
+`-timeField`      | Name of the field in the data which contains a valid timestamp  | No; defaults to `time`
+`-format`         | HTTP data format, supports: `csv`, `json` and `jsonl` | No; defaults to HTTP response header `Content-Type`
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var contentType = require('content-type');
 var Juttle = require('../../runtime').Juttle;
 var parsers = require('../parsers');
+var Promise = require('bluebird');
 var request = require('request');
 
 var Read = Juttle.proc.source.extend({
@@ -17,7 +18,8 @@ var Read = Juttle.proc.source.extend({
             'body',
             'timeField',
             'includeHeaders',
-            'rootPath'
+            'rootPath',
+            'format'
         ];
 
         var unknown = _.difference(_.keys(options), allowed_options);
@@ -47,6 +49,7 @@ var Read = Juttle.proc.source.extend({
         this.timeField = options.timeField;
         this.includeHeaders = options.includeHeaders;
         this.rootPath = options.rootPath;
+        this.format = options.format;
 
         if (params.filter_ast) {
             throw this.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER', {
@@ -63,7 +66,6 @@ var Read = Juttle.proc.source.extend({
             error: message
         });
         this.trigger('error', runtime_error);
-        this.emit_eof();
     },
 
     start: function() {
@@ -77,6 +79,7 @@ var Read = Juttle.proc.source.extend({
         })
         .on('error', function(err) {
             self.triggerFailure(err.toString());
+            self.emit_eof();
         })
         .on('response', function(res) {
             if (!('' + res.statusCode).match(/2\d\d/)) {
@@ -88,16 +91,21 @@ var Read = Juttle.proc.source.extend({
                 res.on('end', function() {
                     self.triggerFailure('StatusCodeError: ' + res.statusCode +
                                         ' - ' + body.join(''));
+                    self.emit_eof();
                 });
             } else {
                 var format;
-                try {
-                    format  = contentType.parse(res).type.split('/')[1];
-                } catch(err) {
-                    // type is undefined
+                if (self.format) {
+                    format = self.format;
+                } else {
+                    try {
+                        format  = contentType.parse(res).type.split('/')[1];
+                    } catch(err) {
+                        // type is undefined
+                    }
                 }
 
-                try {
+                Promise.try(function () {
                     self.parser = parsers.getParser(format, {
                         rootPath: self.rootPath,
                         optimization: self.optimization_info
@@ -110,7 +118,7 @@ var Read = Juttle.proc.source.extend({
                         }));
                     });
 
-                    self.parser.parseStream(req, function(points) {
+                    return self.parser.parseStream(req, function(points) {
                         if (self.includeHeaders) {
                             _.each(points, function(point) {
                                 _.each(res.headers, function(value, key) {
@@ -125,13 +133,14 @@ var Read = Juttle.proc.source.extend({
 
                         self.parseTime(points, self.timeField);
                         self.emit(points);
-                        self.emit_eof();
-                    }).catch(function(err) {
-                        self.triggerFailure(err.toString());
                     });
-                } catch(err) {
+                })
+                .catch(function(err) {
                     self.triggerFailure(err.toString());
-                }
+                })
+                .finally(function() {
+                    self.emit_eof();
+                });
             }
         });
     }


### PR DESCRIPTION
fixes #287

by adding the `-format` option you can now overcome some of the
difficulties of dealing with services that don't always return the
right `content-type`.