### PR TITLE
remove node-grok from the default juttle installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ node_js:
 
 before_script:
     - npm install -g gulp
+      # grok parser tests need node-grok
+    - npm install rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe
 
 script:
     - gulp lint examples-check test-coverage

--- a/lib/adapters/parsers/grok.js
+++ b/lib/adapters/parsers/grok.js
@@ -2,7 +2,7 @@
 
 var base = require('./base');
 var errors = require('../../errors');
-var grok = require('node-grok');
+var grok; // initialized in constructor
 var Promise = require('bluebird');
 var readline = require('readline');
 
@@ -10,6 +10,19 @@ module.exports = base.extend({
 
     initialize: function(options) {
         this.pattern = options.pattern || '%{GREEDYDATA:message}';
+
+        try {
+            grok = require('node-grok');
+        } catch(err) {
+            if (err.toString().match(/Cannot find module 'node-grok'/)) {
+                // we're doing this to avoid installing a more heavy weight dependency
+                // as part of the regular juttle dependencies.
+                throw Error('Grok parser requires a manual installation of node-grok like so:\n' +
+                            ' > npm install rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe\n');
+            } else {
+                throw err;
+            }
+        }
     },
 
     parseStream: function(stream, emit) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "moment-duration-format": "^1.3.0",
     "moment-parser": "^0.3.0",
     "moment-timezone": "^0.4.0",
-    "node-grok": "github:rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe",
     "oboe": "^2.1.2",
     "pegjs": "^0.9.0",
     "request": "^2.67.0",

--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -7,6 +7,7 @@ var path = require('path');
 var tmp = require('tmp');
 var fs = require('fs');
 var juttle_test_utils = require('../../runtime/specs/juttle-test-utils');
+var withModuleIt = juttle_test_utils.withModuleIt;
 var check_juttle = juttle_test_utils.check_juttle;
 var expect_to_fail = juttle_test_utils.expect_to_fail;
 
@@ -199,7 +200,7 @@ describe('file adapter tests', function () {
             return expect_to_fail(failing_read, message);
         });
 
-        it('can read syslog file using -format "grok"' , function() {
+        withModuleIt('can read syslog file using -format "grok"' , function() {
             return check_juttle({
                 program: 'read file -file "' +  syslog + '" -format "grok" -pattern "%{SYSLOGLINE}" | keep program, pid'
             })
@@ -213,7 +214,7 @@ describe('file adapter tests', function () {
                     { program: 'CRON', pid: '17218' }
                 ]);
             });
-        });
+        }, 'node-grok');
 
     });
 
@@ -362,7 +363,7 @@ describe('file adapter tests', function () {
             });
         });
 
-        it('fails to optimized tail followed by head with -format "grok"', function() {
+        withModuleIt('fails to optimized tail followed by head with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             return check_juttle({
@@ -375,9 +376,9 @@ describe('file adapter tests', function () {
                 expect(result.prog.graph.parser.stopAt).to.equal(Number.POSITIVE_INFINITY);
                 expect(result.prog.graph.parser.totalParsed).to.equal(6);
             });
-        });
+        }, 'node-grok');
 
-        it('can optimize "| head 1" with -format "grok"', function() {
+        withModuleIt('can optimize "| head 1" with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             return check_juttle({
@@ -390,9 +391,9 @@ describe('file adapter tests', function () {
                 expect(result.prog.graph.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.parser.totalParsed).to.equal(2);
             });
-        });
+        }, 'node-grok');
 
-        it('can optimize nested "| head 2 | head 1" with -format "grok"', function() {
+        withModuleIt('can optimize nested "| head 2 | head 1" with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             return check_juttle({
@@ -405,7 +406,7 @@ describe('file adapter tests', function () {
                 expect(result.prog.graph.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.parser.totalParsed).to.equal(2);
             });
-        });
+        }, 'node-grok');
 
     });
 });

--- a/test/adapters/parsers/grok.spec.js
+++ b/test/adapters/parsers/grok.spec.js
@@ -5,18 +5,23 @@ var fs = require('fs');
 var parsers = require('../../../lib/adapters/parsers');
 var path = require('path');
 var tmp = require('tmp');
+var juttleTestUtils = require('../../runtime/specs/juttle-test-utils');
+
+var withGrokIt = function(describe, fn) {
+    return juttleTestUtils.withModuleIt(describe, fn,  'node-grok');
+};
 
 describe('parsers/grok', function() {
     var empty = path.resolve(__dirname, 'input/logs/empty.log');
     var syslog = path.resolve(__dirname, 'input/logs/syslog');
     var badSyslog = path.resolve(__dirname, 'input/logs/bad-syslog');
 
-    it('can instantiate a grok parser', function() {
+    withGrokIt('can instantiate a grok parser', function() {
         var parser = parsers.getParser('grok');
         expect(parser).to.not.be.undefined();
     });
 
-    it('can read an empty file', function() {
+    withGrokIt('can read an empty file', function() {
         var parser = parsers.getParser('grok');
         var results = [];
         return parser.parseStream(fs.createReadStream(empty), function(result) {
@@ -27,7 +32,7 @@ describe('parsers/grok', function() {
         });
     });
 
-    it('can parse syslog file', function() {
+    withGrokIt('can parse syslog file', function() {
         var parser = parsers.getParser('grok', {
             pattern: '%{SYSLOGLINE}'
         });
@@ -45,7 +50,7 @@ describe('parsers/grok', function() {
         });
     });
 
-    it('can parse a file with invalid syslog lines', function() {
+    withGrokIt('can parse a file with invalid syslog lines', function() {
         var parser = parsers.getParser('grok', {
             pattern: '%{SYSLOGLINE}'
         });
@@ -71,7 +76,7 @@ describe('parsers/grok', function() {
         });
     });
 
-    it('calls emit multiple times with payload limit specified', function() {
+    withGrokIt('calls emit multiple times with payload limit specified', function() {
         var csv = parsers.getParser('grok', {
             limit: 1,
             pattern: '%{SYSLOGLINE}'
@@ -92,7 +97,7 @@ describe('parsers/grok', function() {
         });
     });
 
-    it('stops emitting values after the optimization.limit', function() {
+    withGrokIt('stops emitting values after the optimization.limit', function() {
         // the read ahead buffer of the parser will always read more points
         // that we actually want to parse but lets make sure this does not // read the whole file by writing out enough data
         var tmpFilename = tmp.tmpNameSync();

--- a/test/adapters/stdio/read.stdio.spec.js
+++ b/test/adapters/stdio/read.stdio.spec.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var expect = require('chai').expect;
 var fs = require('fs');
 var juttle_test_utils = require('../../runtime/specs/juttle-test-utils');
+var withModuleIt = juttle_test_utils.withModuleIt;
 var check_juttle = juttle_test_utils.check_juttle;
 var path = require('path');
 
@@ -118,7 +119,7 @@ describe('read stdio adapter tests', function() {
         });
     });
 
-    it('can read syslog data from stdin using -format "grok"' , function() {
+    withModuleIt('can read syslog data from stdin using -format "grok"' , function() {
         juttle_test_utils.set_stdin(fs.createReadStream(syslog));
 
         return check_juttle({
@@ -134,7 +135,7 @@ describe('read stdio adapter tests', function() {
                 { program: 'CRON', pid: '17218' }
             ]);
         });
-    });
+    }, 'node-grok');
 
     describe('optimizations', function() {
         _.each(symmetricalFormats, function(details, format) {
@@ -193,7 +194,7 @@ describe('read stdio adapter tests', function() {
             });
         });
 
-        it('fails to optimized tail followed by head with -format "grok"', function() {
+        withModuleIt('fails to optimized tail followed by head with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             juttle_test_utils.set_stdin(fs.createReadStream(badSyslog));
@@ -208,9 +209,9 @@ describe('read stdio adapter tests', function() {
                 expect(result.prog.graph.parser.stopAt).to.equal(Number.POSITIVE_INFINITY);
                 expect(result.prog.graph.parser.totalParsed).to.equal(6);
             });
-        });
+        }, 'node-grok');
 
-        it('can optimize "| head 1" with -format "grok"', function() {
+        withModuleIt('can optimize "| head 1" with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             juttle_test_utils.set_stdin(fs.createReadStream(badSyslog));
@@ -225,9 +226,9 @@ describe('read stdio adapter tests', function() {
                 expect(result.prog.graph.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.parser.totalParsed).to.equal(2);
             });
-        });
+        }, 'node-grok');
 
-        it('can optimize nested "| head 2 | head 1" with -format "grok"', function() {
+        withModuleIt('can optimize nested "| head 2 | head 1" with -format "grok"', function() {
             // the bad syslog file will emit an error if we hit the 3rd entry when
             // parsing and the parsers currently read 1 point ahead
             juttle_test_utils.set_stdin(fs.createReadStream(badSyslog));
@@ -242,7 +243,7 @@ describe('read stdio adapter tests', function() {
                 expect(result.prog.graph.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.parser.totalParsed).to.equal(2);
             });
-        });
+        }, 'node-grok');
 
     });
 

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -326,6 +326,50 @@ function expect_to_fail(promise, message) {
         });
 }
 
+// mocha utils
+
+function checkForModule(name) {
+    /*
+     * check for required module dependency
+     */
+    try {
+        require(name);
+    } catch(err) {
+        logger.warn('WARNING: skipping test due to unmet dependency on module "' +
+                    name + '"');
+        return false;
+    }
+
+    return true;
+}
+
+var mochaIt = global.it;
+
+function withModuleIt(description, fn, module) {
+    /*
+     * wrapper function for mocha it() so you can skip a test based on module
+     * availability.
+     *
+     *  module: the name of a module that must be require'able for a specific
+     *          test to be executed or skipped if the module can not be
+     *          required
+     *  
+     * if you have the need to set the same requirements for all tests in a 
+     * single test suite then use the following approach and redefine it() 
+     * locally to that one file like so:
+     *
+     *  var withGrokIt = function(describe, function) {
+     *      return require('../../runtime/specs/juttle-test-utils').it(describe, function, 'node-grok');
+     *  };
+     *
+     */
+    if (checkForModule(module)) {
+        mochaIt(description, fn);
+    } else {
+        mochaIt.skip(description, fn);
+    }
+}
+
 module.exports = {
     wait_for_event: wait_for_event,
     get_times: get_times,
@@ -336,5 +380,6 @@ module.exports = {
     options_from_object: options_from_object,
     expect_to_fail: expect_to_fail,
     set_stdin: set_stdin,
-    set_stdout: set_stdout
+    set_stdout: set_stdout,
+    withModuleIt 
 };


### PR DESCRIPTION
fixes #289

now node-grok will not be installed by npm and the user that has any
interest in using the grok parser will be prompted to install it
themselves (currently off our own fork).