### PR TITLE
Remove pubsub

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -56,24 +56,6 @@ var Program = Base.extend({
 
         this.scheduler.start();
     },
-    // connect a publish/subscribe channel that is inside the flowgraph closure to the
-    // sink object (e.g., a view) that is outside the flowgraph
-    // XXX actually this is a hack right now and relies on the Juttle global
-    // table... publish/subscribe needs to be scoped in an intelligent way and the
-    // Juttle namespace objects needs to be refactored into separate pieces
-    // for proc/fn namespace and per-graph runtime state... better runtime
-    // state should be its own class and should be created in main and
-    // passed to all the procs etc created inside the closure
-    bind_sink: function(sink, channel) {
-        //XXX hack
-        // this relies on there be different channel names for different
-        // flowgraph running at the same time
-        var sub = new Juttle.proc.subscribe({channel:channel}, {}, null, this);
-        // sub will call emit which will call consume, which is part of
-        // the sink API
-        sub.connect(sink);
-        this.graph.head[0].combine(sub);
-    },
     _validate_sources: function() {
         var sources = this.get_sources();
 

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -116,48 +116,6 @@ Juttle.proc.publish = Juttle.proc.sink.extend({
     info: PUBLISH_INFO
 });
 
-var SUBSCRIBE_INFO = {
-    type: 'source',
-    options: {}   // documented, non-deprecated options only
-};
-
-Juttle.proc.subscribe = Juttle.proc.source.extend({
-    // sub is special, it is not stitched to its upstream pub
-    // by connect(), but pub will be calling its consume().
-    // stick with the old gods here.
-    initialize: function(options) {
-        this.channel = this.channelName(options);
-        var targets = Juttle.hub[this.channel];
-        if (targets === undefined) {
-            targets = Juttle.hub[this.channel] = [];
-        }
-        targets.push(this);
-    },
-    channelName: function(options) {
-        return options.channel || '__DEFAULT';
-    },
-    procName: 'subscribe',
-    process: function(points) {
-        this.emit(points);
-    },
-    teardown: function() {
-        var k;
-        var targets = Juttle.hub[this.channel];
-        for (k = 0; k < targets.length; ++k) {
-            if (targets[k] === this) {
-                targets.splice(k, 1);
-                if (targets.length === 0) {
-                    delete Juttle.hub[this.channel];
-                }
-                return;
-            }
-        }
-        this.logger.warn('subscribe could not find self in Juttle.hub');
-    }
-}, {
-    info: SUBSCRIBE_INFO
-});
-
 var nchannels = 0;
 function alloc_channel(prefix) {
     prefix = prefix || 'chan';

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -73,49 +73,6 @@ Juttle.proc = {
     fanin: fanin
 };
 
-var PUBLISH_INFO = {
-    type: 'sink',
-    options: {}   // documented, non-deprecated options only
-};
-
-//XXX make sure mark works right between flowgraphs
-Juttle.proc.publish = Juttle.proc.sink.extend({
-    initialize: function(options) {
-        this.channel = options.channel || '__DEFAULT';
-    },
-    procName: 'publish',
-    mark: function(time) {
-        var targets = Juttle.hub[this.channel];
-        var self = this;
-        _(targets).each(function(target) {
-            target.consume_mark(time, self);
-        });
-    },
-    tick: function(time) {
-        var targets = Juttle.hub[this.channel];
-        var self = this;
-        _(targets).each(function(target) {
-            target.consume_tick(time, self);
-        });
-    },
-    eof: function() {
-        var targets = Juttle.hub[this.channel];
-        var self = this;
-        _(targets).each(function(target) {
-            target.consume_eof(self);
-        });
-    },
-    process: function(points) {
-        var targets = Juttle.hub[this.channel];
-        var self = this;
-        _(targets).each(function(target) {
-            target.consume(points.slice(0), self);
-        });
-    }
-}, {
-    info: PUBLISH_INFO
-});
-
 var nchannels = 0;
 function alloc_channel(prefix) {
     prefix = prefix || 'chan';

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -73,9 +73,8 @@ Juttle.proc = {
     fanin: fanin
 };
 
-
-var SINK_INFO = {
-    type: 'sink',
+var VIEW_INFO = {
+    type: 'view',
     options: {}   // documented, non-deprecated options only
 };
 
@@ -111,7 +110,7 @@ Juttle.proc.view = Juttle.proc.sink.extend({
     }
 
 }, {
-    info: SINK_INFO
+    info: VIEW_INFO
 });
 
 // Additional Functions

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -11,7 +11,7 @@ var adapters = require('../adapters');
 // Assign Juttle to module.exports early to satisfy/break a circular dependency
 // from base.js
 var Juttle = module.exports = {
-    hub: {},
+    channels:0,
     visitGen:0,
     teardown: function(entryNode) {
         var k;
@@ -73,20 +73,6 @@ Juttle.proc = {
     fanin: fanin
 };
 
-var nchannels = 0;
-function alloc_channel(prefix) {
-    prefix = prefix || 'chan';
-    while (true) {
-        var name = prefix + (nchannels++);
-        if (!Juttle.hub.hasOwnProperty(name)) {
-            // insert an empty list to "claim" this channel
-            Juttle.hub[name] = [];
-            return name;
-        }
-    }
-}
-
-Juttle.alloc_channel = alloc_channel;
 
 var SINK_INFO = {
     type: 'sink',
@@ -97,8 +83,7 @@ Juttle.proc.view = Juttle.proc.sink.extend({
     initialize: function(options, params) {
         this.name = params.name;
         this.options = options;
-        var chan = alloc_channel('sink');
-        this.channel = chan;
+        this.channel = 'view' + (Juttle.channels++);
     },
 
     procName: 'view',

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -136,9 +136,7 @@ var SINK_INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-// XXX/demmer this should not inherit from publish but until we convert the
-// clients
-Juttle.proc.view = Juttle.proc.publish.extend({
+Juttle.proc.view = Juttle.proc.sink.extend({
     initialize: function(options, params) {
         this.name = params.name;
         this.options = options;
@@ -157,20 +155,16 @@ Juttle.proc.view = Juttle.proc.publish.extend({
     // include proc names including the error/warning.
 
     mark: function(time) {
-        Juttle.proc.publish.prototype.mark.call(this, time);
         this.program.trigger('view:mark', {channel: this.channel, time: time});
     },
     tick: function(time) {
-        Juttle.proc.publish.prototype.tick.call(this, time);
         this.program.trigger('view:tick', {channel: this.channel, time: time});
     },
     eof: function() {
-        Juttle.proc.publish.prototype.eof.call(this);
         this.program.trigger('view:eof', {channel: this.channel});
         this.done();
     },
     process: function(points) {
-        Juttle.proc.publish.prototype.process.call(this, points);
         this.program.trigger('view:points', {channel: this.channel, points: points});
     }
 

--- a/lib/runtime/procs/sink.js
+++ b/lib/runtime/procs/sink.js
@@ -3,6 +3,11 @@
 var fanin = require('./fanin');
 var Promise = require('bluebird');
 
+var SINK_INFO = {
+    type: 'sink',
+    options: {}   // documented, non-deprecated options only
+};
+
 // base class for all sinks (both client-side views and adapter write procs)
 var sink = fanin.extend({
     initialize: function(options, params) {
@@ -16,6 +21,8 @@ var sink = fanin.extend({
             self.done = resolve;
         });
     },
+}, {
+    info: SINK_INFO
 });
 
 module.exports = sink;


### PR DESCRIPTION
As the `TestView` was the last view depending on the pub sub system, modify it so it uses `program.events`. Then gradually remove dependencies on the `publish` and `subscribe` procs from the inheritance chains and from the code.