### PR TITLE
accept date object as valid value

### DIFF
--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -105,6 +105,9 @@ var values = {
                         case '[object Array]':
                             return 'Array';
 
+                        case '[object Date]':
+                            return 'Date';
+
                         case '[object Object]':
                             switch (value.constructor) {
                                 case JuttleMoment:


### PR DESCRIPTION
Accept Date Object as valid value.

@davidvgalbraith @demmer 

(postgres adapter contains date value when value is not under time field.)