### PR TITLE
do not multiply any number by 1000

### DIFF
--- a/lib/runtime/juttle-utils.js
+++ b/lib/runtime/juttle-utils.js
@@ -8,11 +8,6 @@ var JuttleMoment = require('../moment').JuttleMoment;
 function makeDate(time) {
     if (time instanceof Date) { return time; }
 
-    var number = Number(time);
-    if (number === number) { // check for NaN
-        time = number * 1000; // convert seconds to milliseconds for Date constructor
-    }
-
     return new Date(time);
 }
 


### PR DESCRIPTION
I know I missed the ball here on the conversation before but:

Why are we assuming that any number in the time field is in seconds? Wouldn't it be better to not make this assumption?

The contract would then be that any valid param passed into JS `Date` is ok. I think that makes more sense than multiplying any number by 1000 no?

@demmer @davidvgalbraith @go-oleg @dmajda 