### PR TITLE
ESLint move cleanups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Be sure to update documentation when you make user-facing changes. Small reposit
 
 ### Style
 
-When developing you may run into failures during linting where jscs complains about your Javascript coding style. An easy way to fix those files is to simply run `jscs --fix test` or `jscs --fix lib` from the root directory of the project. After jscs fixes things you should proceed to check that those changes are reasonable, as auto-fixing may not produce the nicest looking code.
+When developing you may run into failures during linting where eslint complains about your Javascript coding style. An easy way to fix those files is to simply run `eslint --fix test` or `eslint --fix lib` from the root directory of the project. After eslint fixes things you should proceed to check that those changes are reasonable, as auto-fixing may not produce the nicest looking code.
 
 When adding Juttle code, follow the [Juttle Style Guide](docs/references/style_guide.md). If you add *.juttle programs under docs/examples, or embedded anywhere in the docs markdown articles as a code block with `juttle` language marker, they will be automatically syntax-checked when tests are run.
 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ npm test
 
 Both are run automatically by Travis.
 
-When developing you may run into failures during linting where jscs complains
+When developing you may run into failures during linting where eslint complains
 about your coding style and an easy way to fix those files is to simply run
-`jscs --fix test` or `jscs --fix lib` from the root directory of the project.
-After jscs fixes things you should proceed to check that those changes are
+`eslint --fix test` or `eslint --fix lib` from the root directory of the project.
+After eslint fixes things you should proceed to check that those changes are
 reasonable as auto-fixing may not produce the nicest of looking code.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,6 @@ var path = require('path');
 var peg = require('gulp-peg');
 var rename = require('gulp-rename');
 var through = require('through2');
-// jshint ignore:line
 var Promise = require('bluebird');
 var marked = require('marked');
 var FileResolver = require('./lib/module-resolvers/file-resolver');

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -609,7 +609,7 @@ var GraphCompiler = CodeGenerator.extend({
                 } else {
                     return 'juttle.ops.pget(pt,' + expr + ')';
                 }
-                break;   // silence JSHint
+                break;   // silence ESLint
 
             case '++':
             case '--':

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* jshint evil:true */
-
 var events = require('backbone').Events;
 var Scheduler = require('../runtime/scheduler').Scheduler;
 var Graph = require('../graph');
@@ -13,7 +11,7 @@ var GraphBuilder = require('./graph-builder').GraphBuilder;
 var GraphCompiler = require('./graph-compiler');
 var Build = require('./build');
 
-var _ = require('underscore'); // jshint ignore:line
+var _ = require('underscore');
 var JuttleMoment = require('../moment').JuttleMoment;
 var juttle = require('../runtime').runtime;
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -1,7 +1,6 @@
 'use strict';
 
 
-/* jshint evil:true */
 var _ = require('underscore');
 var Base = require('extendable-base');
 var Promise = require('bluebird');

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -3,7 +3,6 @@
 //
 // Simple table of registered adapters
 //
-/* jshint node: true */
 var _ = require('underscore');
 var path = require('path');
 var errors = require('../errors');

--- a/lib/runtime/ops.js
+++ b/lib/runtime/ops.js
@@ -100,9 +100,7 @@ var ops = {
 
     band: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left & right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('&', left, right);
         }
@@ -110,9 +108,7 @@ var ops = {
 
     bor: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left | right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('|', left, right);
         }
@@ -120,9 +116,7 @@ var ops = {
 
     bxor: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left ^ right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('^', left, right);
         }
@@ -130,9 +124,7 @@ var ops = {
 
     bnot: function(value) {
         if (values.isNumber(value)) {
-            /* jshint bitwise: false */
             return ~value;
-            /* jshint bitwise: true */
         } else  {
             throw errors.typeErrorUnary('~', value);
         }
@@ -140,9 +132,7 @@ var ops = {
 
     shl: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left << right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('<<', left, right);
         }
@@ -150,9 +140,7 @@ var ops = {
 
     shr: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left >> right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('>>', left, right);
         }
@@ -160,9 +148,7 @@ var ops = {
 
     shrz: function(left, right) {
         if (values.isNumber(left) && values.isNumber(right)) {
-            /* jshint bitwise: false */
             return left >>> right;
-            /* jshint bitwise: true */
         } else {
             throw errors.typeErrorBinary('>>>', left, right);
         }

--- a/lib/runtime/procs/stoke/util.js
+++ b/lib/runtime/procs/stoke/util.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/*jshint -W061 */
 var _ =  require('underscore');
 var dur = require('../../../moment').JuttleMoment.duration;
 var gex = require('gex');

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -114,7 +114,7 @@ var values = {
                                     if (value.duration) {
                                         return 'Duration';
                                     }
-                                    break;   // silence JSHint
+                                    break;   // silence ESLint
 
                                 case Filter:
                                     return 'Filter';

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
     "gulp-eslint": "^1.1.1",
     "gulp-if": "2.0.0",
     "gulp-istanbul": "^0.10.2",
-    "gulp-jscs": "^3.0.2",
-    "gulp-jshint": "^1.12.0",
     "gulp-mocha": "^2.1.3",
     "gulp-peg": "^0.2.0",
     "gulp-rename": "^1.2.2",

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* jshint: node */
-
 var fs = require('fs');
 var util = require('util');
 var path = require('path');


### PR DESCRIPTION
After [moving to ESLint](https://github.com/juttle/juttle/pull/203) there still remained few places where JSHint and JSCS were referenced. Let’s eliminate them.