### PR TITLE
Do not call JuttleMoment.duration with "new"

### DIFF
--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -58,7 +58,7 @@ var CodeGenerator = Base.extend({
             : '[' + this.gen_expr(ast.key) + ', ' + this.gen_expr(ast.value) + ']';
     },
     gen_DurationLiteral: function(ast) {
-        return 'new juttle.types.JuttleMoment.duration("' + ast.value + '")';
+        return 'juttle.types.JuttleMoment.duration("' + ast.value + '")';
     },
     gen_MomentLiteral: function(ast) {
         return 'new juttle.types.JuttleMoment("' + ast.value + '")';

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -16,7 +16,7 @@ var Read = source.extend({
         this.options = options;
         this.params = params;
 
-        this.lag = _.has(options, 'lag') ? options.lag : new JuttleMoment.duration(0, 's');
+        this.lag = _.has(options, 'lag') ? options.lag : JuttleMoment.duration(0, 's');
         if (! this.lag.duration) {
             throw this.compile_error('RT-DURATION-ERROR', {
                 option: 'lag',
@@ -24,7 +24,7 @@ var Read = source.extend({
             });
         }
 
-        this.readEvery = options.every || new JuttleMoment.duration(1, 's');
+        this.readEvery = options.every || JuttleMoment.duration(1, 's');
         if (! this.readEvery.duration) {
             throw this.compile_error('RT-DURATION-ERROR', {
                 option: 'every',

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -26,7 +26,7 @@ var source = base.extend({
         this.queueSize = options.queueSize || 100000;
 
         this.lastEmit = new JuttleMoment(0);
-        this.tickEvery = new JuttleMoment.duration(1, 's');
+        this.tickEvery = JuttleMoment.duration(1, 's');
         this.nextTick = this.program.now.add(this.tickEvery);
     },
 

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -59,7 +59,7 @@ var ValueBuilder = ASTVisitor.extend({
     },
 
     visitDurationLiteral: function(node) {
-        return new JuttleMoment.duration(node.value);
+        return JuttleMoment.duration(node.value);
     },
 
     visitFilterLiteral: function(node) {

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -149,7 +149,7 @@ describe('FilterJSCompiler', function() {
     it('compiles DurationLiteral correctly', function() {
         expect('a == :00:00:05.000:').to.filter(
             POINTS_VALUES,
-            [ { a: new JuttleMoment.duration('00:00:05.000') } ]
+            [ { a: JuttleMoment.duration('00:00:05.000') } ]
         );
     });
 

--- a/test/compiler/views_sourceinfo.spec.js
+++ b/test/compiler/views_sourceinfo.spec.js
@@ -42,7 +42,7 @@ describe('Views get info on source time bounds', function() {
 
     var from = new JuttleMoment({ raw: '2015-01-01T00:00:00.000Z' });
     var to = new JuttleMoment({ raw: '2015-02-02T00:00:00.000Z' });
-    var last = new JuttleMoment.duration(1, 'hour');
+    var last = JuttleMoment.duration(1, 'hour');
 
     test('read stochastic -source "cdn" -from :' + from.valueOf() + ': | view view ', [[{from: from, to: null, last: null}]]);
     test('read stochastic -source "cdn" -from :' + from.valueOf() + ': -to :' + to.valueOf() + ': | view view ', [[{from: from, to: to, last: null}]]);

--- a/test/runtime/test-adapter-timeseries.js
+++ b/test/runtime/test-adapter-timeseries.js
@@ -26,7 +26,7 @@ class TestTimeseriesRead extends AdapterRead {
             throw errors.compileError('RT-MISSING-TIME-RANGE-ERROR');
         }
 
-        this.every = options.every || new JuttleMoment.duration(1, 's');
+        this.every = options.every || JuttleMoment.duration(1, 's');
         this.count = 0;
     }
 

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -254,7 +254,7 @@ describe('Values tests', function () {
                     expected: '/abcd/'
                 },
                 {
-                    value: new JuttleMoment.duration('5', 'seconds'),
+                    value: JuttleMoment.duration('5', 'seconds'),
                     expected: '00:00:05.000'
                 },
                 {
@@ -274,7 +274,7 @@ describe('Values tests', function () {
                     expected: '[ 1, 2, 3 ]'
                 },
                 {
-                    value: ['abcd', new JuttleMoment.duration('5', 'seconds') ],
+                    value: ['abcd', JuttleMoment.duration('5', 'seconds') ],
                     expected: '[ "abcd", :00:00:05.000: ]'
                 },
                 {
@@ -286,7 +286,7 @@ describe('Values tests', function () {
                     expected: '{ a: 1, b: 2, c: 3 }'
                 },
                 {
-                    value: { a: 'abcd', b: new JuttleMoment.duration('5', 'seconds') },
+                    value: { a: 'abcd', b: JuttleMoment.duration('5', 'seconds') },
                     expected: '{ a: "abcd", b: :00:00:05.000: }'
                 },
             ];
@@ -342,7 +342,7 @@ describe('Values tests', function () {
                     expected: '/abcd/'
                 },
                 {
-                    value: new JuttleMoment.duration('5', 'seconds'),
+                    value: JuttleMoment.duration('5', 'seconds'),
                     expected: ':00:00:05.000:'
                 },
                 {
@@ -362,7 +362,7 @@ describe('Values tests', function () {
                     expected: '[ 1, 2, 3 ]'
                 },
                 {
-                    value: ['abcd', new JuttleMoment.duration('5', 'seconds') ],
+                    value: ['abcd', JuttleMoment.duration('5', 'seconds') ],
                     expected: '[ "abcd", :00:00:05.000: ]'
                 },
                 {
@@ -374,7 +374,7 @@ describe('Values tests', function () {
                     expected: '{ a: 1, b: 2, c: 3 }'
                 },
                 {
-                    value: { a: 'abcd', b: new JuttleMoment.duration('5', 'seconds') },
+                    value: { a: 'abcd', b: JuttleMoment.duration('5', 'seconds') },
                     expected: '{ a: "abcd", b: :00:00:05.000: }'
                 },
             ];
@@ -530,7 +530,7 @@ describe('Values tests', function () {
             ast: { type: 'MomentLiteral', value: '2015-01-01T00:00:05.000Z' }
         },
         {
-            value: new JuttleMoment.duration('00:00:05.000'),
+            value: JuttleMoment.duration('00:00:05.000'),
             ast: { type: 'DurationLiteral', value: '00:00:05.000' }
         },
         {

--- a/test/spec/input-default-functions.js
+++ b/test/spec/input-default-functions.js
@@ -31,7 +31,7 @@ module.exports = {
     },
 
     duration: function() {
-        return new JuttleMoment.duration('1h');
+        return JuttleMoment.duration('1h');
     },
 
     filter: function() {


### PR DESCRIPTION
`JuttleMoment.duration` is not a constructor (just a factory function), so it should not be called using the `new` operator. This PR removes `new` from any such calls.