### PR TITLE
test: fix checks for no errors / warnings

### DIFF
--- a/test/adapters/file/file.spec.js
+++ b/test/adapters/file/file.spec.js
@@ -126,8 +126,8 @@ describe('file adapter tests', function () {
             var options = {from: '1970-01-01T00:00:03.000Z'};
             return run_read_file_juttle(json_file, options, ' | keep time, rate')
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { 'time': '1970-01-01T00:00:03.000Z', 'rate': 2},
                     { 'time': '1970-01-01T00:00:04.000Z', 'rate': 7},
@@ -141,8 +141,8 @@ describe('file adapter tests', function () {
             var options = {to: '1970-01-01T00:00:03.000Z'};
             return run_read_file_juttle(json_file, options, ' | keep time, rate')
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { 'time': '1970-01-01T00:00:01.000Z', 'rate': 1},
                     { 'time': '1970-01-01T00:00:02.000Z', 'rate': 5},
@@ -158,8 +158,8 @@ describe('file adapter tests', function () {
 
             return run_read_file_juttle(json_file, options, '| keep time, rate')
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { 'time': '1970-01-01T00:00:03.000Z', 'rate': 2},
                     { 'time': '1970-01-01T00:00:04.000Z', 'rate': 7},
@@ -205,8 +205,8 @@ describe('file adapter tests', function () {
                 program: 'read file -file "' +  syslog + '" -format "grok" -pattern "%{SYSLOGLINE}" | keep program, pid'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { program: 'anacron', pid: '15134' },
                     { program: 'anacron', pid: '15134' },
@@ -250,7 +250,7 @@ describe('file adapter tests', function () {
                          '| write file -file "' + tmp_file + '" -format "csv"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
+                expect(result.errors).deep.equals([]);
                 expect(result.warnings.length).equal(1);
                 expect(result.warnings[0]).to.contain('Invalid CSV data: Found new or missing fields: fizz');
             });
@@ -264,12 +264,12 @@ describe('file adapter tests', function () {
                              '| write file -file "' + tmp_file + '" -format "' + format + '"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
+                    expect(result.errors).deep.equals([]);
 
                     return run_read_file_juttle(tmp_file, { format: format });
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
+                    expect(result.errors).deep.equals([]);
                     expect(result.sinks.table.length).equal(1);
                     expect(result.sinks.table[0].message).equal('hello test');
                 });
@@ -285,8 +285,8 @@ describe('file adapter tests', function () {
                     return run_read_file_juttle(tmp_file, { format: format });
                 })
                 .then(function(result) {
-                    expect(result.errors.length).to.equal(0);
-                    expect(result.warnings.length).to.equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).to.equal(0);
                 });
             });
@@ -298,11 +298,11 @@ describe('file adapter tests', function () {
                              '| write file -file "' + tmp_file + '" -format "' + format + '"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
+                    expect(result.errors).deep.equals([]);
                     return run_read_file_juttle(tmp_file, { format: format });
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
+                    expect(result.errors).deep.equals([]);
                     expect(result.sinks.table.length).equal(10);
                     for(var index = 0; index < 10; index++) {
                         expect(result.sinks.table[index].message).equal('hello test ' + (index + 1));
@@ -371,7 +371,7 @@ describe('file adapter tests', function () {
             })
             .then(function(result) {
                 expect(result.errors.length).to.equal(2);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(Number.POSITIVE_INFINITY);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(6);
@@ -385,8 +385,8 @@ describe('file adapter tests', function () {
                 program: 'read file -file "' +  badSyslog + '" -format "grok" -pattern "%{SYSLOGLINE}" | head 1'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(2);
@@ -400,8 +400,8 @@ describe('file adapter tests', function () {
                 program: 'read file -file "' +  badSyslog + '" -format "grok" -pattern "%{SYSLOGLINE}" | head 2 | head 1'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(2);

--- a/test/adapters/http.spec.js
+++ b/test/adapters/http.spec.js
@@ -369,7 +369,7 @@ describe('HTTP adapter tests', function() {
             })
             .then(function(result) {
                 expect(result.errors.length).equal(1);
-                expect(result.warnings.length).equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.errors[0]).to.contain('connect ECONNREFUSED');
             });
         });
@@ -380,7 +380,7 @@ describe('HTTP adapter tests', function() {
             })
             .then(function(result) {
                 expect(result.errors.length).equal(1);
-                expect(result.warnings.length).equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.errors[0]).to.contain('getaddrinfo ENOTFOUND');
             });
         });
@@ -416,7 +416,7 @@ describe('HTTP adapter tests', function() {
             })
             .then(function(result) {
                 expect(result.errors.length).equal(1);
-                expect(result.warnings.length).equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.errors[0]).to.contain('Invalid format option value, must be one of the following: csv, json, jsonl');
             });
         });
@@ -428,8 +428,8 @@ describe('HTTP adapter tests', function() {
                     program: 'read http -method "' + method + '" -url "' + self.url + '/status/200"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                 });
             });
         });
@@ -441,8 +441,8 @@ describe('HTTP adapter tests', function() {
                     '               -url "' + self.url + '/headers?foo=bar&fizz=buzz"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -452,8 +452,8 @@ describe('HTTP adapter tests', function() {
                     '-url "' + this.url + '/points?count=1&timeField=created_on"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).equal(1);
                 expect(result.sinks.table[0].time).to.not.be.undefined();
             });
@@ -464,8 +464,8 @@ describe('HTTP adapter tests', function() {
                 program: 'read http -includeHeaders true -url "' + this.url + '/fake-data"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).equal(2);
                 expect(result.sinks.table[0].etag).to.equal('12345');
                 expect(result.sinks.table[0]['user-agent']).to.equal('fake-data');
@@ -493,7 +493,7 @@ describe('HTTP adapter tests', function() {
                 })
                 .then(function(result) {
                     expect(result.errors.length).equal(1);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.errors[0]).to.contain('Invalid ' + name.toUpperCase() + ' data');
                 });
             });
@@ -506,7 +506,7 @@ describe('HTTP adapter tests', function() {
                 })
                 .then(function(result) {
                     expect(result.errors.length).equal(1);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.errors[0]).to.contain('internal error StatusCodeError: ' + status);
                 });
             });
@@ -517,8 +517,8 @@ describe('HTTP adapter tests', function() {
                 program: 'read http -url "' + this.url + '/points?count=0"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).equal(0);
             });
         });
@@ -530,8 +530,8 @@ describe('HTTP adapter tests', function() {
                                     '   -url "' + this.url + '/object?foo=bar"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(1);
                     expect(result.sinks.table[0].foo).to.be.equal('bar');
                 });
@@ -543,8 +543,8 @@ describe('HTTP adapter tests', function() {
                                     '   -url "' + this.url + '/object?time=2014-01-01T00:00:00.000Z"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(1);
                     expect(result.sinks.table[0].time).to.be.equal('2014-01-01T00:00:00.000Z');
                 });
@@ -556,8 +556,8 @@ describe('HTTP adapter tests', function() {
                                     '   -url "' + this.url + '/points?count=100&timeField=time&fizz=buzz"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(100);
                     expect(result.sinks.table[0].time).to.not.be.undefined();
                     expect(result.sinks.table[0].fizz).to.be.equal('buzz');
@@ -571,8 +571,8 @@ describe('HTTP adapter tests', function() {
                              '          -url "' + this.url + '/points?count=100&timeField=time&fizz=buzz"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(100);
                     expect(result.sinks.table[0].time).to.not.be.undefined();
                     expect(result.sinks.table[0].fizz).to.be.equal('buzz');
@@ -632,8 +632,8 @@ describe('HTTP adapter tests', function() {
                         '              -url "' + self.url + '/status/200"'
                 })
                 .then(function(result) {
-                    expect(result.errors.length).equal(0);
-                    expect(result.warnings.length).equal(0);
+                    expect(result.errors).deep.equals([]);
+                    expect(result.warnings).deep.equals([]);
                 });
             });
         });
@@ -646,8 +646,8 @@ describe('HTTP adapter tests', function() {
                     '              -url "' + self.url + '/headers?foo=bar&fizz=buzz"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -656,7 +656,7 @@ describe('HTTP adapter tests', function() {
                 program: 'emit -limit 1 | write http -url "' + this.url + '/status/500"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
+                expect(result.errors).deep.equals([]);
                 expect(result.warnings.length).equal(1);
                 expect(result.warnings[0]).to.contain('internal error StatusCodeError: 500');
             });
@@ -669,7 +669,7 @@ describe('HTTP adapter tests', function() {
                     '| write http -url "' + this.url + '/flakey"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
+                expect(result.errors).deep.equals([]);
                 expect(result.warnings.length).equal(5);
             });
         });
@@ -680,8 +680,8 @@ describe('HTTP adapter tests', function() {
                 program: 'emit -limit 1 | filter banana=true | write http -url "' + this.url + '/status/500"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.be.undefined();
             });
         });
@@ -694,8 +694,8 @@ describe('HTTP adapter tests', function() {
                     '| write http -method "PUT" -url "' + this.url + '/body?value=1&name=field-1"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -706,8 +706,8 @@ describe('HTTP adapter tests', function() {
                     '| write http -method "PUT" -url "' + this.url + '/body?time=2015-01-01T00:00:00.000Z&value=1&name=field-1"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -719,8 +719,8 @@ describe('HTTP adapter tests', function() {
                     '| write http -method "PUT" -url "' + this.url + '/points?expect=1"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -731,8 +731,8 @@ describe('HTTP adapter tests', function() {
                     '| write http -method "PUT" -url "' + this.url + '/accept-object"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
 
@@ -745,8 +745,8 @@ describe('HTTP adapter tests', function() {
                     '| write http -maxLength 10 -method "PUT" -url "' + this.url + '/points?expect=10"'
             })
             .then(function(result) {
-                expect(result.errors.length).equal(0);
-                expect(result.warnings.length).equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             });
         });
     });

--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -46,8 +46,8 @@ describe('read http_server', function() {
         })
         .then(function(result) {
             expect(result.sinks.table).to.deep.equal(body);
-            expect(result.errors.length).equal(0);
-            expect(result.warnings.length).equal(0);
+            expect(result.errors).deep.equals([]);
+            expect(result.warnings).deep.equals([]);
         });
     });
 

--- a/test/adapters/stdio/read.stdio.spec.js
+++ b/test/adapters/stdio/read.stdio.spec.js
@@ -72,7 +72,7 @@ describe('read stdio adapter tests', function() {
             })
             .then(function(result) {
                 expect(result.errors.length).to.equal(1);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.errors[0]).to.contain('Error: Invalid ' + format.toUpperCase() + ' data');
             });
         });
@@ -84,8 +84,8 @@ describe('read stdio adapter tests', function() {
                 program: 'read stdio'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.equal(0);
             });
         });
@@ -105,8 +105,8 @@ describe('read stdio adapter tests', function() {
                 program: 'read stdio -format "' + format + '" | keep time, rate'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { 'time': '1970-01-01T00:00:01.000Z', 'rate': handle(1) },
                     { 'time': '1970-01-01T00:00:02.000Z', 'rate': handle(5) },
@@ -126,8 +126,8 @@ describe('read stdio adapter tests', function() {
             program: 'read stdio -format "grok" -pattern "%{SYSLOGLINE}" | keep program, pid'
         })
         .then(function(result) {
-            expect(result.errors.length).to.equal(0);
-            expect(result.warnings.length).to.equal(0);
+            expect(result.errors).deep.equals([]);
+            expect(result.warnings).deep.equals([]);
             expect(result.sinks.table).to.deep.equal([
                 { program: 'anacron', pid: '15134' },
                 { program: 'anacron', pid: '15134' },
@@ -204,7 +204,7 @@ describe('read stdio adapter tests', function() {
             })
             .then(function(result) {
                 expect(result.errors.length).to.equal(2);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(Number.POSITIVE_INFINITY);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(6);
@@ -220,8 +220,8 @@ describe('read stdio adapter tests', function() {
                 program: 'read stdio -format "grok" -pattern "%{SYSLOGLINE}" | head 1'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(2);
@@ -237,8 +237,8 @@ describe('read stdio adapter tests', function() {
                 program: 'read stdio -format "grok" -pattern "%{SYSLOGLINE}" | head 2 | head 1'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).to.be.equal(1);
                 expect(result.prog.graph.adapter.parser.stopAt).to.equal(1);
                 expect(result.prog.graph.adapter.parser.totalParsed).to.equal(2);

--- a/test/adapters/stdio/write.stdio.spec.js
+++ b/test/adapters/stdio/write.stdio.spec.js
@@ -46,7 +46,7 @@ describe('write stdio adapter tests', function() {
                      '| write stdio -format "csv"'
         })
         .then(function(result) {
-            expect(result.errors.length).equal(0);
+            expect(result.errors).deep.equals([]);
             expect(result.warnings.length).equal(1);
             expect(result.warnings[0]).to.contain('Invalid CSV data: Found new or missing fields: fizz');
         });
@@ -69,8 +69,8 @@ describe('write stdio adapter tests', function() {
                 program: 'emit -limit 3 | filter foo="bar" | write stdio -format "' + format + '"'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(fs.readFileSync(tmpFilename).toString()).to.equal('');
             });
         });
@@ -83,8 +83,8 @@ describe('write stdio adapter tests', function() {
                 program: 'emit -limit 3 | put foo="bar", index=count() | write stdio -format "' + format + '"'
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
             })
             .then(function() {
                 juttle_test_utils.set_stdin(fs.createReadStream(tmpFilename));
@@ -93,8 +93,8 @@ describe('write stdio adapter tests', function() {
                 });
             })
             .then(function(result) {
-                expect(result.errors.length).to.equal(0);
-                expect(result.warnings.length).to.equal(0);
+                expect(result.errors).deep.equals([]);
+                expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table).to.deep.equal([
                     { foo: 'bar', index: handle(1) },
                     { foo: 'bar', index: handle(2) },

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -70,7 +70,7 @@ describe('adapter API tests', function () {
             program: 'emit -limit 1 | put message = "hello test 2" | write test -key "test3"'
         })
         .then(function(result) {
-            expect(result.errors.length).equal(0);
+            expect(result.errors).deep.equals([]);
         })
         .then(function() {
             return check_juttle({
@@ -150,7 +150,7 @@ describe('adapter API tests', function () {
         })
         .then(function(result) {
             expect(TestAdapterClone.initialized).is.true;
-            expect(result.errors.length).equal(0);
+            expect(result.errors).deep.equals([]);
             expect(result.sinks.table.length).equal(0);
         });
     });


### PR DESCRIPTION
When testing that a juttle program ran with no errors or warnings,
use `expect(result.errors).deep.equals([])` instead of checking for
a zero-length array since in the event of a failure, it will actually
print what the errors are instead of uselessly reporting that some
error happened but not indicating what error it was.