### PR TITLE
Values reducers

### DIFF
--- a/lib/runtime/reducers.js
+++ b/lib/runtime/reducers.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var JuttleMoment = require('../moment').JuttleMoment;
 var DEQueue = require('double-ended-queue');
 var Digest = require('tdigest').Digest;
 var values = require('./values');
@@ -48,13 +47,7 @@ reducers.min = {
     fn:function(field) {
         var val = Infinity;
         function _update(v) {
-            if (val === Infinity) {
-                val = v;
-            } else if (v instanceof JuttleMoment) {
-                if (v.lt(val)) {
-                    val = v;
-                }
-            } else if (v < val) {
+            if (val === Infinity || ops.lt(v, val)) {
                 val = v;
             }
         }
@@ -62,7 +55,6 @@ reducers.min = {
             result: function() {
                 return val;
             },
-
             update: function(pt) {
                 var v = pt[field];
 
@@ -85,13 +77,7 @@ reducers.max = {
     fn: function(field) {
         var val = -Infinity;
         function _update(v) {
-            if (val === -Infinity) {
-                val = v;
-            } else if (v instanceof JuttleMoment) {
-                if (v.gt(val)) {
-                    val = v;
-                }
-            } else if (v > val) {
+            if (val === -Infinity || ops.gt(v, val)) {
                 val = v;
             }
         }

--- a/lib/runtime/reducers.js
+++ b/lib/runtime/reducers.js
@@ -4,6 +4,7 @@ var DEQueue = require('double-ended-queue');
 var Digest = require('tdigest').Digest;
 var values = require('./values');
 var ops = require('./ops');
+var math = require('./modules/math');
 
 //XXX
 // scalar function
@@ -287,7 +288,7 @@ reducers.sigma = {
                 } else if (n === 1) {
                     return 0;
                 } else {
-                    return Math.sqrt(1/(n-1) * ops.sub(ssum, ops.div(ops.mul(sum, sum), n)));
+                    return math.sqrt(ops.mul(1/(n-1), ops.sub(ssum, ops.div(ops.mul(sum, sum), n))));
                 }
             },
             update: function(pt) {

--- a/lib/runtime/reducers.js
+++ b/lib/runtime/reducers.js
@@ -127,13 +127,12 @@ reducers.avg = {
         var n = 0;
         return {
             result: function() {
-                return n ? sum / n : null;
+                return n ? ops.div(sum, n) : null;
             },
             update: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    //XXX type check
-                    sum += v;
+                    sum = ops.add(sum, v);
                     n += 1;
                 }
             },
@@ -144,7 +143,7 @@ reducers.avg = {
             expire: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    sum -= v;
+                    sum = ops.sub(sum, v);
                     n -= 1;
                 }
             }
@@ -166,18 +165,16 @@ reducers.sum = {
             update: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    //XXX type check
-                    sum += v;
+                    sum = ops.add(sum, v);
                 }
             },
             combine: function(v) {
-                sum += v;
+                sum = ops.add(sum, v);
             },
             expire: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    //XXX type check
-                    sum -= v;
+                    sum = ops.sub(sum, v);
                 }
             }
         };
@@ -304,24 +301,22 @@ reducers.sigma = {
                 } else if (n === 1) {
                     return 0;
                 } else {
-                    return Math.sqrt(1/(n-1) * (ssum - sum*sum/n));
+                    return Math.sqrt(1/(n-1) * ops.sub(ssum, ops.div(ops.mul(sum, sum), n)));
                 }
             },
             update: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    //XXX type check
-                    sum += v;
-                    ssum += v*v;
+                    sum = ops.add(sum, v);
+                    ssum = ops.add(ssum, ops.mul(v, v));
                     n += 1;
                 }
             },
             expire: function(pt) {
                 var v = pt[fld];
                 if (v !== undefined) {
-                    //XXX type check
-                    sum -= v;
-                    ssum -= v*v;
+                    sum = ops.sub(sum, v);
+                    ssum = ops.sub(ssum, ops.mul(v, v));
                     n -= 1;
                 }
             }


### PR DESCRIPTION
Instead of native javascript arithmetic operators, use `ops.add` and `ops.sub` in reducers. This ensures that the operations are type-checked and that adding incompatible types or types for which the operation is not defined, throws an error, instead of being silently converted.