### PR TITLE
Consolidate Juttle runtime: Don’t set Juttle.FilterJSCompiler

### DIFF
--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -27,11 +27,6 @@ var Juttle = module.exports = {
 Juttle.reducers = reducers;
 Juttle.adapters = adapters;
 
-// stash the filter compiler in the runtime to enable adapters to
-// leverage the filters in their implementation.
-var FilterJSCompiler = require('../../compiler/filters/filter-js-compiler.js');
-Juttle.FilterJSCompiler = FilterJSCompiler;
-
 var base = require('./base');
 var fanin = require('./fanin');
 


### PR DESCRIPTION
Anyone who needs to use `FilterJSCompiler` should require it directly.

Can be merged only after juttle/juttle-opentsdb-adapter#7 and juttle/juttle-sql-adapter-common#19 get merged.

Part of work on #97.