### PR TITLE
Don’t set Juttle.reducers

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -143,7 +143,7 @@ var Scope = Base.extend({
             type: 'reducer',
             exported: false,
             arg_count: builtin_reducers[name].arg_count,
-            name: 'Juttle.reducers.' + name + '.fn'
+            name: 'juttle.reducers.' + name + '.fn'
         };
     },
 

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -3,7 +3,6 @@
 var _ = require('underscore');
 var errors = require('../../errors');
 
-var reducers = require('../reducers').reducers;
 var adapters = require('../adapters');
 
 // Juttle namespace
@@ -24,7 +23,6 @@ var Juttle = module.exports = {
     }
 };
 
-Juttle.reducers = reducers;
 Juttle.adapters = adapters;
 
 // stash the filter compiler in the runtime to enable adapters to

--- a/lib/runtime/runtime.js
+++ b/lib/runtime/runtime.js
@@ -7,6 +7,7 @@ var ops = require('./ops');
 var partialOps = require('./partial-ops');
 var values = require('./values');
 var types = require('./types');
+var reducers = require('./reducers').reducers;
 var errors = require('../errors');
 
 var runtime = {
@@ -15,6 +16,7 @@ var runtime = {
     partialOps: partialOps,
     values: values,
     types: types,
+    reducers: reducers,
     errors: errors
 };
 


### PR DESCRIPTION
Don't set `Juttle.reducers`. Instead, add reducers to the runtime and let compiled Juttle programs use them as `juttle.reducers.*`. This makes the programs less dependent on the `Juttle` variable.

Part of work on #97.