### PR TITLE
expose the list of adapters to the runtime

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -48,8 +48,9 @@ var implicit_views = require('../lib/compiler/flowgraph/implicit_views');
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
 
 function usage() {
-    console.log('usage: juttle [--version] [--mode <mode>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]');
+    console.log('usage: juttle [--version] [--adapters] [--mode <mode>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]');
     console.log('     --version show juttle CLI version');
+    console.log('     --adapters show versions and paths to all configured adapters');
     console.log('     --mode <mode>: one of ' + modes.map(JSON.stringify).join(', '));
     console.log('     --config <config>: path to the juttle interpreter configuration file');
     console.log('     --optimize runs optimization');
@@ -120,6 +121,12 @@ var view_classes = {
 var Juttle = require('../lib/runtime').Juttle;
 Juttle.adapters.configure(config.adapters);
 
+if (opts.adapters) {
+    Juttle.adapters.list().forEach(function(info) {
+        console.log(info.adapter, info.version, info.path);
+    });
+    process.exit(0);
+}
 
 if (process.env.JUTTLE_LOAD_TEST_ADAPTERS) {
     Juttle.adapters.register('test', require('../test/runtime/test-adapter')());

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -9,6 +9,7 @@ Juttle comes with built-in modules that provide functions for different data typ
    * [Array](../modules/array.md)
    * [Date](../modules/date.md)
    * [Duration](../modules/duration.md)
+   * [Juttle](../modules/juttle.md)
    * [Math](../modules/math.md)
    * [Number](../modules/number.md)
    * [Object](../modules/object.md)

--- a/docs/modules/juttle.md
+++ b/docs/modules/juttle.md
@@ -1,0 +1,61 @@
+---
+title: Juttle Module | Juttle Language Reference
+---
+
+# Juttle
+
+Juttle is a simple module that exposes some aspects of the Juttle runtime for debugging purposes.
+
+[TOC]
+
+***
+
+## Juttle.version
+
+Constant that contains the version of the Juttle runtime.
+
+For example:
+
+```juttle
+emit -points [{version: Juttle.version}]
+```
+
+```
+┌───────────┐
+│ version   │
+├───────────┤
+│ 0.4.0     │
+└───────────┘
+```
+
+***
+
+## Juttle.adapters
+
+Function that returns an array with the type, version, and filesystem path for all configured adapters. This can be useful when debugging a juttle installation to ensure that all the expected modules are being loaded properly.
+
+For example:
+
+```juttle
+emit -points Juttle.adapters()
+```
+
+```
+┌─────────────┬───────────────────────────────────────────┬─────────┐
+│ adapter     │ path                                      │ version │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ influx      │ /root/juttle-influx-adapter/index.js      │ 0.3.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ elastic     │ /root/juttle-elastic-adapter/lib/index.js │ 0.4.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ file        │ /root/juttle/lib/adapters/file/index.js   │ 0.4.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ http        │ /root/juttle/lib/adapters/http/index.js   │ 0.4.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ stdio       │ /root/juttle/lib/adapters/stdio/index.js  │ 0.4.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ stochastic  │ /root/juttle/lib/adapters/stochastic.js   │ 0.4.0   │
+├─────────────┼───────────────────────────────────────────┼─────────┤
+│ http_server │ /root/juttle/lib/adapters/http_server.js  │ 0.4.0   │
+└─────────────┴───────────────────────────────────────────┴─────────┘
+```

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -236,7 +236,8 @@ var SemanticPass = Base.extend({
             type: 'import',
             exported: false,
             exports: {
-                version: { type: 'const', exported: true, name: 'juttle.modules.juttle.version' }
+                version: { type: 'const', exported: true, name: 'juttle.modules.juttle.version' },
+                adapters: { type: 'function', exported: true, name: 'juttle.modules.juttle.adapters' }
             }
         });
     },

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -3,6 +3,7 @@
 //
 // Simple table of registered adapters
 //
+var juttleVersion = require('../../package').version;
 var _ = require('underscore');
 var path = require('path');
 var errors = require('../errors');
@@ -94,24 +95,30 @@ function stopModuleLoadOverride() {
     Module._load = moduleLoad;
 }
 
+function adapterModulePath(type, options) {
+    // If the path isn't specified in the config, assume there is a global
+    // installation of the module named `juttle-xyz-adapter`.
+    var modulePath = options.path || 'juttle-' + type + '-adapter';
+
+    // Any relative module paths should be resolved in the context of the
+    // process cwd, not relative to this module
+    if (modulePath[0] === '.') {
+        modulePath = path.resolve(process.cwd(), modulePath);
+    }
+
+    return modulePath;
+}
+
 // Load the adapter of the given type.
 function loadAdapter(type) {
     var options = adapterConfig[type];
     try {
-        // If the path isn't specified in the config, assume there is a global
-        // installation of the module named `juttle-xyz-adapter`.
-        var module_path = options.path || 'juttle-' + type + '-adapter';
-
-        // Any relative module paths should be resolved in the context of the
-        // process cwd, not relative to this module
-        if (module_path[0] === '.') {
-            module_path = path.resolve(process.cwd(), module_path);
-        }
+        var modulePath = adapterModulePath(type, options);
 
         startModuleLoadOverride();
 
         var start = new Date();
-        var init = require(module_path);
+        var init = require(modulePath);
 
         var loaded = new Date();
         var adapter = init(options);
@@ -150,9 +157,34 @@ function configure(config) {
     });
 }
 
+// Return a list of all configured adapters and their versions.
+function list() {
+    var adapters = [];
+    _.each(adapterConfig, function(config, adapter) {
+        var modulePath = adapterModulePath(adapter, config);
+        var version, installPath;
+
+        if (BUILTIN_ADAPTERS.indexOf(adapter) !== -1) {
+            version = juttleVersion;
+            installPath = Module._resolveFilename(modulePath, module);
+        } else {
+            try {
+                var pkg = require(path.join(modulePath, 'package'));
+                installPath = Module._resolveFilename(modulePath, module);
+                version = pkg.version || '(unknown)';
+            } catch (err) {
+                installPath = '(unable to load adapter)';
+                version = '(unknown)';
+            }
+        }
+        adapters.push({adapter: adapter, version: version, path: installPath});
+    });
+    return adapters;
+}
 module.exports = {
     register: register,
     get: get,
+    list: list,
     isValid: isValid,
     configure: configure
 };

--- a/lib/runtime/modules/juttle.js
+++ b/lib/runtime/modules/juttle.js
@@ -3,9 +3,14 @@
 /* Implementation of Juttle built-in Juttle module. */
 
 var pkg = require('../../../package.json');
+var adapters = require('../adapters');
 
 var Juttle = {
-    version: pkg.version
+    version: pkg.version,
+
+    adapters: function() {
+        return adapters.list();
+    }
 };
 
 module.exports = Juttle;

--- a/test/runtime/juttle-module.spec.js
+++ b/test/runtime/juttle-module.spec.js
@@ -1,10 +1,15 @@
 'use strict';
 
+var path = require('path');
 var expect = require('chai').expect;
 var juttle_test_utils = require('./specs/juttle-test-utils');
 var check_juttle = juttle_test_utils.check_juttle;
 
 var version = require('../../package.json').version;
+var adapters = require('../../lib/runtime/adapters');
+
+// Register a bogus adapter to make sure the list still works.
+adapters.configure({invalid: {}});
 
 describe('Juttle Module Tests', function() {
     it('exports the current version of the runtime', function() {
@@ -13,6 +18,18 @@ describe('Juttle Module Tests', function() {
         })
         .then(function(result) {
             expect(result.sinks.result[0].version).to.equal(version);
+        });
+    });
+
+    it('exports the current version of all configured adapters', function() {
+        return check_juttle({
+            program: 'emit -points Juttle.adapters() | view result'
+        })
+        .then(function(result) {
+            var adapterList = adapters.list();
+            expect(adapterList).to.contain({adapter: 'file', version: version, path: path.resolve(__dirname, '../../lib/adapters/file/index.js')});
+            expect(adapterList).to.contain({adapter: 'invalid', version: '(unknown)', path: '(unable to load adapter)'});
+            expect(result.sinks.result).to.deep.equal(adapterList);
         });
     });
 });


### PR DESCRIPTION
Add an `adapters.list()` API function that exposes the list of configured adapters with their versions and paths on disk.

Expose this as a constant array in the `Juttle` module so it can be printed by a simple program like:

```
emit -points Juttle.adapters
┌─────────────┬───────────────────────────────────────────┬─────────┐
│ adapter     │ path                                      │ version │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ influx      │ /root/juttle-influx-adapter/index.js      │ 0.3.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ elastic     │ /root/juttle-elastic-adapter/lib/index.js │ 0.4.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ file        │ /root/juttle/lib/adapters/file/index.js   │ 0.4.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ http        │ /root/juttle/lib/adapters/http/index.js   │ 0.4.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ stdio       │ /root/juttle/lib/adapters/stdio/index.js  │ 0.4.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ stochastic  │ /root/juttle/lib/adapters/stochastic.js   │ 0.4.0   │
├─────────────┼───────────────────────────────────────────┼─────────┤
│ http_server │ /root/juttle/lib/adapters/http_server.js  │ 0.4.0   │
└─────────────┴───────────────────────────────────────────┴─────────┘
```

Also add missing documentation for the Juttle module.

Fixes #313 