### PR TITLE
Consolidate Juttle runtime: Don’t set Juttle.proc

### DIFF
--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -4,11 +4,11 @@ var http = require('http');
 var _ = require('underscore');
 var contentType = require('content-type');
 
-var Juttle = require('../runtime/index').Juttle;
+var source = require('../runtime/procs/source');
 var Promise = require('bluebird');
 var parsers = require('./parsers');
 
-var Read = Juttle.proc.source.extend({
+var Read = source.extend({
     procName: 'read-http_server',
 
     initialize: function(options, params, location, program) {

--- a/lib/compiler/autocompleter.js
+++ b/lib/compiler/autocompleter.js
@@ -5,28 +5,28 @@
 var _ = require('underscore');
 var Base = require('extendable-base');
 var parser = require('../parser');
-var Juttle = require('../runtime/procs/procs');
+var procs = require('../runtime/procs');
 
 // List of documented, non-deprecated procs with their options.
 var PROCS = {
-    batch: Juttle.proc.batch.info,
-    emit: Juttle.proc.emit.info,
-    filter: Juttle.proc.filter.info,
-    head: Juttle.proc.head.info,
-    join: Juttle.proc.join.info,
-    keep: Juttle.proc.keep.info,
-    pace: Juttle.proc.pace.info,
-    put: Juttle.proc.put.info,
-    read: Juttle.proc.read.info,
-    reduce: Juttle.proc.reduce.info,
-    remove: Juttle.proc.remove.info,
-    skip: Juttle.proc.skip.info,
-    sort: Juttle.proc.sort.info,
-    split: Juttle.proc.split.info,
-    tail: Juttle.proc.tail.info,
-    unbatch: Juttle.proc.unbatch.info,
-    uniq: Juttle.proc.uniq.info,
-    write: Juttle.proc.write.info
+    batch: procs.batch.info,
+    emit: procs.emit.info,
+    filter: procs.filter.info,
+    head: procs.head.info,
+    join: procs.join.info,
+    keep: procs.keep.info,
+    pace: procs.pace.info,
+    put: procs.put.info,
+    read: procs.read.info,
+    reduce: procs.reduce.info,
+    remove: procs.remove.info,
+    skip: procs.skip.info,
+    sort: procs.sort.info,
+    split: procs.split.info,
+    tail: procs.tail.info,
+    unbatch: procs.unbatch.info,
+    uniq: procs.uniq.info,
+    write: procs.write.info
 };
 
 // Describes which proc types are suggested for each proc placement.

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -3,7 +3,7 @@
 var Base = require('extendable-base');
 var _ = require('underscore');
 var values = require('../runtime/values');
-var Juttle = require('../runtime/procs/procs');
+var procs = require('../runtime/procs');
 var errors = require('../errors');
 var SemanticPass = require('./semantic');
 
@@ -12,11 +12,11 @@ function proc_name(node) {
 }
 
 function is_source(node) {
-    return node.type !== 'View' && Juttle.proc[proc_name(node)].info.type === 'source';
+    return node.type !== 'View' && procs[proc_name(node)].info.type === 'source';
 }
 
 function is_sink(node) {
-    return node.type === 'View' || Juttle.proc[proc_name(node)].info.type === 'sink';
+    return node.type === 'View' || procs[proc_name(node)].info.type === 'sink';
 }
 
 function build_pname(index) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -182,7 +182,7 @@ var GraphCompiler = CodeGenerator.extend({
                                         ast.location,
                                         params);
         var code = 'var ' + pname + ' = ';
-        code += 'new Juttle.proc.' + procName + '('
+        code += 'new juttle.procs.' + procName + '('
             + soptions + ', '
             + JSON.stringify(ast.location) + ', '
             + 'program'

--- a/lib/program.js
+++ b/lib/program.js
@@ -8,6 +8,9 @@ var Promise = require('bluebird');
 var juttle = require('./runtime').runtime;
 
 var Juttle = require('./runtime').Juttle;
+var source = require('./runtime/procs/source');
+var sink = require('./runtime/procs/sink');
+var view = require('./runtime/procs/view');
 var errors = require('./errors');
 
 
@@ -56,7 +59,7 @@ var Program = Base.extend({
 
         // Check that all heads are sources.
         for (var i = 0; i < this.graph.head.length; i++) {
-            if (!(this.graph.head[i] instanceof Juttle.proc.source)) {
+            if (!(this.graph.head[i] instanceof source)) {
                 throw errors.compileError('RT-PROC-CANNOT-START-FLOWGRAPH', {
                     proc: this.graph.head[i].procName,
                     location: this.graph.head[i].location
@@ -81,7 +84,7 @@ var Program = Base.extend({
 
         // Check that all terminal nodes are valid sinks.
         for (var i = 0; i < terminalNodes.length; i++) {
-            if (!(terminalNodes[i] instanceof Juttle.proc.sink)) {
+            if (!(terminalNodes[i] instanceof sink)) {
                 throw errors.compileError('RT-PROC-CANNOT-END-FLOWGRAPH', {
                     proc: terminalNodes[i].procName,
                     location: terminalNodes[i].location
@@ -102,7 +105,7 @@ var Program = Base.extend({
 
     get_sources: function() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
-            return (proc instanceof Juttle.proc.source);
+            return (proc instanceof source);
         });
     },
 
@@ -110,7 +113,7 @@ var Program = Base.extend({
     get_views: function() {
         var allSinks = this.get_sinks();
         return _.filter(allSinks, function(sink) {
-            return (sink instanceof Juttle.proc.view);
+            return (sink instanceof view);
         })
         .map(function(view) {
             return {name: view.name, channel: view.channel, options: view.options, location: view.location};
@@ -119,7 +122,7 @@ var Program = Base.extend({
 
     get_sinks: function() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
-            return (proc instanceof Juttle.proc.sink);
+            return (proc instanceof sink);
         });
     },
 

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -6,7 +6,6 @@ var Base = require('extendable-base');
 var errors = require('../../errors');
 
 var DEFAULT_OUT_NAME = 'default';
-var Juttle = require('./procs');
 
 var base = Base.extend({
     //
@@ -77,11 +76,7 @@ var base = Base.extend({
     },
     //XXX need a disconnect method
     connect: function(proc) {
-        var out;
-        if (this instanceof Juttle.proc.sink) {
-            throw new Error ('connecting an output to a sink shouldn\'t happen!');
-        }
-        out = this.out();
+        var out = this.out();
         // add proc as a downstream consumer of our points.
         out.push({proc: proc, from: this});
         proc.connect_input(this);
@@ -92,11 +87,7 @@ var base = Base.extend({
     // `logical_from_proc` is the proc that points sent over this
     // shortcut should appear to come from (for eof/mark fanin accounting purposes).
     shortcut: function(target, logical_from, name) {
-        var out;
-        if (this instanceof Juttle.proc.sink) {
-            throw new Error ('connecting an output to a sink shouldn\'t happen!');
-        }
-        out = this.out(name);
+        var out = this.out(name);
         // add proc as a downstream consumer of our points.
         out.push({proc: target, from:logical_from});
         target.shortcut_input(logical_from);

--- a/lib/runtime/procs/index.js
+++ b/lib/runtime/procs/index.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Classes implementing Juttle procs.
+
+var base = require('./base');
+var batch = require('./batch');
+var emit = require('./emit');
+var fanin = require('./fanin');
+var filter = require('./filter');
+var head = require('./head');
+var join = require('./join');
+var keep = require('./keep');
+var pace = require('./pace');
+var pass = require('./pass');
+var put = require('./put');
+var read = require('./read');
+var reduce = require('./reduce');
+var remove = require('./remove');
+var sequence = require('./sequence');
+var sink = require('./sink');
+var skip = require('./skip');
+var sort = require('./sort');
+var source = require('./source');
+var split = require('./split');
+var tail = require('./tail');
+var unbatch = require('./unbatch');
+var uniq = require('./uniq');
+var view = require('./view');
+var write = require('./write');
+
+module.exports = {
+    base: base,
+    batch: batch,
+    emit: emit,
+    fanin: fanin,
+    filter: filter,
+    head: head,
+    join: join,
+    keep: keep,
+    pace: pace,
+    pass: pass,
+    put: put,
+    read: read,
+    reduce: reduce,
+    remove: remove,
+    sequence: sequence,
+    sink: sink,
+    skip: skip,
+    sort: sort,
+    source: source,
+    split: split,
+    tail: tail,
+    unbatch: unbatch,
+    uniq: uniq,
+    view: view,
+    write: write
+};

--- a/lib/runtime/procs/pass.js
+++ b/lib/runtime/procs/pass.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var fanin = require('./fanin');
+
+var INFO = {
+    type: 'proc',
+    options: {}   // documented, non-deprecated options only
+};
+
+var pass = fanin.extend({
+    procName: 'pass'
+}, {
+    info: INFO
+});
+
+module.exports = pass;

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -6,10 +6,8 @@ var errors = require('../../errors');
 var adapters = require('../adapters');
 
 // Juttle namespace
-//
-// Assign Juttle to module.exports early to satisfy/break a circular dependency
-// from base.js
-var Juttle = module.exports = {
+
+var Juttle = {
     channels:0,
     visitGen:0,
     teardown: function(entryNode) {
@@ -23,12 +21,7 @@ var Juttle = module.exports = {
     }
 };
 
-// Needs to be below the module.exports assignment becasue of the circular
-// dependency mentioned above.
-var procs = require('../procs');
-
 Juttle.adapters = adapters;
-Juttle.proc = procs;
 
 // Additional Functions
 
@@ -73,3 +66,5 @@ Juttle.extend_options = function(opts, location) {
 
     return options;
 };
+
+module.exports = Juttle;

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -52,48 +52,9 @@ Juttle.proc = {
     sequence: require('./sequence'),
     uniq: require('./uniq'),
     reduce: require('./reduce'),
-    fanin: fanin
+    fanin: fanin,
+    view: require('./view')
 };
-
-var VIEW_INFO = {
-    type: 'view',
-    options: {}   // documented, non-deprecated options only
-};
-
-Juttle.proc.view = Juttle.proc.sink.extend({
-    initialize: function(options, params) {
-        this.name = params.name;
-        this.options = options;
-        this.channel = 'view' + (Juttle.channels++);
-    },
-
-    procName: 'view',
-
-    // When views get points/marks/ticks, they emit events on
-    // the related program object. Program users will subscribe for
-    // these events to receive the information from the views.
-    //
-    // Note: not using base.js::trigger as that's used for triggering
-    // error/warning events and has special handling of arguments to
-    // include proc names including the error/warning.
-
-    mark: function(time) {
-        this.program.trigger('view:mark', {channel: this.channel, time: time});
-    },
-    tick: function(time) {
-        this.program.trigger('view:tick', {channel: this.channel, time: time});
-    },
-    eof: function() {
-        this.program.trigger('view:eof', {channel: this.channel});
-        this.done();
-    },
-    process: function(points) {
-        this.program.trigger('view:points', {channel: this.channel, points: points});
-    }
-
-}, {
-    info: VIEW_INFO
-});
 
 // Additional Functions
 

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -28,17 +28,6 @@ Juttle.adapters = adapters;
 var base = require('./base');
 var fanin = require('./fanin');
 
-var PASS_INFO = {
-    type: 'proc',
-    options: {}   // documented, non-deprecated options only
-};
-
-var pass = fanin.extend({
-    procName: 'pass'
-}, {
-    info: PASS_INFO
-});
-
 Juttle.proc = {
     base: base,
     read: require('./read'),
@@ -59,7 +48,7 @@ Juttle.proc = {
     keep: require('./keep'),
     emit: require('./emit'),
     pace: require('./pace'),
-    pass: pass,
+    pass: require('./pass'),
     sequence: require('./sequence'),
     uniq: require('./uniq'),
     reduce: require('./reduce'),

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -23,38 +23,12 @@ var Juttle = module.exports = {
     }
 };
 
+// Needs to be below the module.exports assignment becasue of the circular
+// dependency mentioned above.
+var procs = require('../procs');
+
 Juttle.adapters = adapters;
-
-var base = require('./base');
-var fanin = require('./fanin');
-
-Juttle.proc = {
-    base: base,
-    read: require('./read'),
-    write: require('./write'),
-    join: require('./join'),
-    filter: require('./filter'),
-    tail: require('./tail'),
-    head: require('./head'),
-    skip: require('./skip'),
-    sort: require('./sort'),
-    source: require('./source'),
-    sink: require('./sink'),
-    split: require('./split'),
-    batch: require('./batch'),
-    unbatch: require('./unbatch'),
-    put: require('./put'),
-    remove: require('./remove'),
-    keep: require('./keep'),
-    emit: require('./emit'),
-    pace: require('./pace'),
-    pass: require('./pass'),
-    sequence: require('./sequence'),
-    uniq: require('./uniq'),
-    reduce: require('./reduce'),
-    fanin: fanin,
-    view: require('./view')
-};
+Juttle.proc = procs;
 
 // Additional Functions
 

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var sink = require('./sink');
+var Juttle = require('./procs');
+
+var INFO = {
+    type: 'view',
+    options: {}   // documented, non-deprecated options only
+};
+
+var view = sink.extend({
+    initialize: function(options, params) {
+        this.name = params.name;
+        this.options = options;
+        this.channel = 'view' + (Juttle.channels++);
+    },
+
+    procName: 'view',
+
+    // When views get points/marks/ticks, they emit events on
+    // the related program object. Program users will subscribe for
+    // these events to receive the information from the views.
+    //
+    // Note: not using base.js::trigger as that's used for triggering
+    // error/warning events and has special handling of arguments to
+    // include proc names including the error/warning.
+
+    mark: function(time) {
+        this.program.trigger('view:mark', {channel: this.channel, time: time});
+    },
+    tick: function(time) {
+        this.program.trigger('view:tick', {channel: this.channel, time: time});
+    },
+    eof: function() {
+        this.program.trigger('view:eof', {channel: this.channel});
+        this.done();
+    },
+    process: function(points) {
+        this.program.trigger('view:points', {channel: this.channel, points: points});
+    }
+
+}, {
+    info: INFO
+});
+
+
+module.exports = view;

--- a/lib/runtime/runtime.js
+++ b/lib/runtime/runtime.js
@@ -7,6 +7,7 @@ var ops = require('./ops');
 var partialOps = require('./partial-ops');
 var values = require('./values');
 var types = require('./types');
+var procs = require('./procs');
 var reducers = require('./reducers').reducers;
 var errors = require('../errors');
 
@@ -16,6 +17,7 @@ var runtime = {
     partialOps: partialOps,
     values: values,
     types: types,
+    procs: procs,
     reducers: reducers,
     errors: errors
 };


### PR DESCRIPTION
Kill `Juttle.proc` after some preparatory refactoring. See individual commits for details.

Note the change set leaves `lib/runtime/procs/procs.js` in a weird state where it builds the `Juttle` object and has otherwise nothing to do with procs. I plan to dismantle that file completely over time.

Part of work on #97.