### PR TITLE
update vim syntax file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ var mocha = require('gulp-mocha');
 var path = require('path');
 var peg = require('gulp-peg');
 var rename = require('gulp-rename');
+var shell = require('gulp-shell');
 var through = require('through2');
 var Promise = require('bluebird');
 var marked = require('marked');
@@ -44,6 +45,15 @@ gulp.task('juttle-spec-clean', function() {
 gulp.task('juttle-spec', ['juttle-spec-clean'], function() {
     return gulp.src('test/runtime/specs/juttle-spec/**/*.md')
         .pipe(jspec());
+});
+
+gulp.task('misc', function() {
+    return gulp.src([
+        'misc/vim/syntax/update.sh'
+    ], {read: false})
+    .pipe(shell([
+        '<%= file.path %>'
+    ]));
 });
 
 gulp.task('lint-test', function() {
@@ -103,11 +113,11 @@ function gulp_test() {
         }));
 }
 
-gulp.task('test', ['peg', 'juttle-spec'], function() {
+gulp.task('test', ['misc', 'peg', 'juttle-spec'], function() {
     return gulp_test();
 });
 
-gulp.task('test-coverage', ['peg', 'juttle-spec', 'instrument'], function() {
+gulp.task('test-coverage', ['misc', 'peg', 'juttle-spec', 'instrument'], function() {
     return gulp_test()
         .pipe(istanbul.writeReports())
         .pipe(istanbul.enforceThresholds({

--- a/misc/vim/README.md
+++ b/misc/vim/README.md
@@ -8,6 +8,6 @@ To install automatic syntax highlighting for Juttle programs:
 
 ## Updating the rules
 
-There's a simple ash script in syntax directory that can be called like so
+There's a simple bash script in syntax directory that can be called like so
 `./update.sh` to simply update the syntax.vim based off the
 `lib/parser/parser.pegjs` grammar directly and update the proc rules.

--- a/misc/vim/README.md
+++ b/misc/vim/README.md
@@ -1,8 +1,13 @@
 # Vim plugins for Juttle
 
 ## Vim syntax highlighting
+
 To install automatic syntax highlighting for Juttle programs:
 1. Copy or link the filetype detection script to the ftdetect directory underneath your vim runtime directory (normally $HOME/.vim/ftdetect)
 2. Copy or link syntax/juttle.vim to the syntax directory underneath your vim runtime directory (normally $HOME/.vim/syntax).
 
+## Updating the rules
 
+There's a simple ash script in syntax directory that can be called like so
+`./update.sh` to simply update the syntax.vim based off the
+`lib/parser/parser.pegjs` grammar directly and update the proc rules.

--- a/misc/vim/syntax/juttle.vim.tmpl
+++ b/misc/vim/syntax/juttle.vim.tmpl
@@ -21,7 +21,7 @@ syn keyword juttleConditional       if else
 syn keyword juttleFunctions         function reducer sub
 
 syn keyword juttleSinks             view
-syn keyword juttleProcs             $(grep "'processor' =" ../../../lib/parser/parser.pegjs  | awk '{print $4}' | xargs)
+syn keyword juttleProcs             $(grep "'processor' =" $CWD/../../../lib/parser/parser.pegjs  | awk '{print $4}' | xargs)
 syn keyword juttleConst             false null true
 
 syn region  juttleLineComment       start=+\/\/+ end=/$/ oneline

--- a/misc/vim/syntax/juttle.vim.tmpl
+++ b/misc/vim/syntax/juttle.vim.tmpl
@@ -21,7 +21,7 @@ syn keyword juttleConditional       if else
 syn keyword juttleFunctions         function reducer sub
 
 syn keyword juttleSinks             view
-syn keyword juttleProcs             batch emit export filter head import input join keep pace pass sequence put read reduce remove skip sort split tail unbatch uniq view write
+syn keyword juttleProcs             $(grep "'processor' =" ../../../lib/parser/parser.pegjs  | awk '{print $4}' | xargs)
 syn keyword juttleConst             false null true
 
 syn region  juttleLineComment       start=+\/\/+ end=/$/ oneline

--- a/misc/vim/syntax/update.sh
+++ b/misc/vim/syntax/update.sh
@@ -1,5 +1,6 @@
+export CWD=`dirname "$0"`
 echo 'cat <<END_OF_TEXT' >  temp.sh
-cat juttle.vim.tmpl      >> temp.sh
+cat $CWD/juttle.vim.tmpl >> temp.sh
 echo 'END_OF_TEXT'       >> temp.sh
-bash temp.sh > juttle.vim
+bash temp.sh > $CWD/juttle.vim
 rm temp.sh

--- a/misc/vim/syntax/update.sh
+++ b/misc/vim/syntax/update.sh
@@ -1,0 +1,5 @@
+echo 'cat <<END_OF_TEXT' >  temp.sh
+cat juttle.vim.tmpl      >> temp.sh
+echo 'END_OF_TEXT'       >> temp.sh
+bash temp.sh > juttle.vim
+rm temp.sh

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "gulp-mocha": "^2.1.3",
     "gulp-peg": "^0.2.0",
     "gulp-rename": "^1.2.2",
+    "gulp-shell": "^0.5.2",
     "json2csv": "^3.0.1",
     "memory-streams": "^0.1.0",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
fixes #43

with this change I've also included an easy to use `update.sh` script
that can be used to update the proc list with minimal effort and could
be expanded to handle a few other mappings between our pegjs grammar
file and the resulting `juttle.vim` file.