### PR TITLE
convert to es6 classes

### DIFF
--- a/lib/adapters/parsers/base.js
+++ b/lib/adapters/parsers/base.js
@@ -1,33 +1,33 @@
 'use strict';
 
-var Base = require('extendable-base');
 var EventEmitter = require('eventemitter3');
 
-var ParserBase = Base.inherits(EventEmitter, {
+class ParserBase extends EventEmitter {
     /*
      * A parser must implement the parseStream function below and should fire
      * errors by using the
      * `this.emit('error', ...)` EvenEmitter method.
      */
-    initialize: function(options) {
+    constructor(options) {
+        super(options);
         this.limit = (options && options.limit) ? options.limit : 1024;
         this.stopAt = Number.POSITIVE_INFINITY;
-        
+
         if (options.optimization && options.optimization.type === 'head') {
             this.stopAt = options.optimization.limit;
         }
-        
+
         // its responsibility of each subclass to maintain these numbers 
         // where the totalRead counts the total number of data points read
         // from a stream while the totalParsed counts the ones that were 
         // actually parsed out to be sent
         this.totalRead = 0;
         this.totalParsed = 0;
-    },
+    }
 
-    parseStream: function(stream, emit) {
+    parseStream(stream, emit) {
         throw new Error('parseStream must be implemented');
     }
-});
+}
 
 module.exports = ParserBase;

--- a/lib/adapters/parsers/csv.js
+++ b/lib/adapters/parsers/csv.js
@@ -5,13 +5,13 @@ var csvParser = require('csv-parser');
 var errors = require('../../errors');
 var Promise = require('bluebird');
 
-var CSVParser = base.extend({
-
-    initialize: function(options) {
+class CSVParser extends base {
+    constructor(options) {
+        super(options);
         this.separator = options.separator ? options.separator : ',';
-    },
+    }
 
-    parseStream: function(stream, emit) {
+    parseStream(stream, emit) {
         var self = this;
 
         return new Promise(function(resolve, reject) {
@@ -65,6 +65,6 @@ var CSVParser = base.extend({
             stream.pipe(csvStream);
         });
     }
-});
+}
 
 module.exports = CSVParser;

--- a/lib/adapters/parsers/grok.js
+++ b/lib/adapters/parsers/grok.js
@@ -2,13 +2,14 @@
 
 var base = require('./base');
 var errors = require('../../errors');
-var grok; // initialized in constructor
+// initialized in constructor
+var grok;
 var Promise = require('bluebird');
 var readline = require('readline');
 
-var GrokParser = base.extend({
-
-    initialize: function(options) {
+class GrokParser extends base {
+    constructor(options) {
+        super(options);
         this.pattern = options.pattern || '%{GREEDYDATA:message}';
 
         try {
@@ -23,9 +24,9 @@ var GrokParser = base.extend({
                 throw err;
             }
         }
-    },
+    }
 
-    parseStream: function(stream, emit) {
+    parseStream(stream, emit) {
         var self = this;
 
         return new Promise(function(resolve, reject) {
@@ -94,6 +95,6 @@ var GrokParser = base.extend({
             });
         });
     }
-});
+}
 
 module.exports = GrokParser;

--- a/lib/adapters/parsers/json.js
+++ b/lib/adapters/parsers/json.js
@@ -6,12 +6,13 @@ var errors = require('../../errors');
 var oboe = require('oboe');
 var Promise = require('bluebird');
 
-var JSONParser = base.extend({
-    initialize: function(options) {
+class JSONParser extends base {
+    constructor(options) {
+        super(options);
         this.rootPath = options.rootPath || undefined;
-    },
+    }
 
-    parseStream: function(stream, emit) {
+    parseStream(stream, emit) {
         var self = this;
         var rootPath = self.rootPath || '';
 
@@ -70,6 +71,6 @@ var JSONParser = base.extend({
             });
         });
     }
-});
+}
 
 module.exports = JSONParser;

--- a/lib/adapters/parsers/jsonl.js
+++ b/lib/adapters/parsers/jsonl.js
@@ -5,9 +5,8 @@ var errors = require('../../errors');
 var JSONStream = require('JSONStream');
 var Promise = require('bluebird');
 
-var JSONLParser = base.extend({
-
-    parseStream: function(stream, emit) {
+class JSONLParser extends base {
+    parseStream(stream, emit) {
         var self = this;
 
         return new Promise(function(resolve, reject) {
@@ -52,7 +51,6 @@ var JSONLParser = base.extend({
             stream.pipe(parser);
         });
     }
-
-});
+}
 
 module.exports = JSONLParser;

--- a/lib/adapters/serializers/base.js
+++ b/lib/adapters/serializers/base.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var Base = require('extendable-base');
 var EventEmitter = require('eventemitter3');
 
-var SerializerBase = Base.inherits(EventEmitter, {
+class SerializerBase extends EventEmitter {
     /*
      * A serializer can override the following methods in order to provide the
      * desired serialization method and should fire errors by using the
      * `this.emit('error', ...)` EvenEmitter method.
      */
-    initialize: function(stream, options) {
+    constructor(stream, options) {
+        super(stream, options);
         this.stream = stream;
-    },
+    }
 
-    write: function(points) {
+    write(points) {
         // implement me
-    },
+    }
 
-    done: function() {
+    done() {
         // implement me
         // this method should return a promise that resolves when the
         // serializer is done flushing the data to the unerlying stream
     }
-});
+}
 
 module.exports = SerializerBase;

--- a/lib/adapters/serializers/csv.js
+++ b/lib/adapters/serializers/csv.js
@@ -7,9 +7,9 @@ var errors = require('../../errors');
 var values = require('../../runtime/values');
 var readline = require('readline');
 
-var CSVSerializer = base.extend({
-
-    initialize: function(stream, options) {
+class CSVSerializer extends base {
+    constructor(stream, options) {
+        super(stream, options);
         options = options  || {};
 
         if (options.append && !options.input) {
@@ -49,9 +49,9 @@ var CSVSerializer = base.extend({
         } else {
             this.base = Promise.resolve();
         }
-    },
+    }
 
-    write: function(points) {
+    write(points) {
         this.base = this.base
         .then(() => {
             _.each(points, (point) => {
@@ -85,9 +85,9 @@ var CSVSerializer = base.extend({
                 }
             });
         });
-    },
+    }
 
-    done: function() {
+    done() {
         return this.base
         .then(() => {
             return new Promise((resolve) => {
@@ -101,6 +101,6 @@ var CSVSerializer = base.extend({
             });
         });
     }
-});
+}
 
 module.exports = CSVSerializer;

--- a/lib/adapters/serializers/json.js
+++ b/lib/adapters/serializers/json.js
@@ -3,14 +3,14 @@
 var _ = require('underscore');
 var base = require('./base');
 
-var JSONSeralizer = base.extend({
-
-    initialize: function(stream, options) {
+class JSONSeralizer extends base {
+    constructor(stream, options) {
+        super(stream, options);
         this.firstPoint = true;
         this.pointBefore = false;
-    },
+    }
 
-    write: function(points) {
+    write(points) {
         var self = this;
 
         if (this.firstPoint) {
@@ -25,9 +25,9 @@ var JSONSeralizer = base.extend({
             self.stream.write(JSON.stringify(point));
             self.pointBefore = true;
         });
-    },
+    }
 
-    done: function() {
+    done() {
         return new Promise((resolve) => {
             if (this.pointBefore) {
                 this.stream.write('\n]', resolve);
@@ -36,6 +36,6 @@ var JSONSeralizer = base.extend({
             }
         });
     }
-});
+}
 
 module.exports = JSONSeralizer;

--- a/lib/adapters/serializers/jsonl.js
+++ b/lib/adapters/serializers/jsonl.js
@@ -3,17 +3,17 @@
 var _ = require('underscore');
 var base = require('./base');
 
-var JSONLSerializer = base.extend({
-    write: function(points) {
+class JSONLSerializer extends base {
+    write(points) {
         var self = this;
         _.each(points, function(point) {
             self.stream.write(JSON.stringify(point) + '\n');
         });
-    },
+    }
 
-    done: function() { 
+    done() { 
         return Promise.resolve();
     }
-});
+}
 
 module.exports = JSONLSerializer;

--- a/lib/cli/location-stripper.js
+++ b/lib/cli/location-stripper.js
@@ -3,16 +3,16 @@
 var ASTVisitor = require('../compiler/ast-visitor');
 
 // Strips the "location" property from all AST nodes.
-var LocationStripper = ASTVisitor.extend({
-    strip: function(node) {
+class LocationStripper extends ASTVisitor {
+    strip(node) {
         this.visit(node);
-    },
+    }
 
-    visit: function(node) {
+    visit(node) {
         delete node.location;
 
         ASTVisitor.prototype.visit.call(this, node);
     }
-});
+}
 
 module.exports = LocationStripper;

--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 
 /*
  * Debug mode flag. Set to "true" if you want to enable AST structure checks in
@@ -107,11 +106,11 @@ var NODE_CHILDREN = {
  * implementation of visit* methods just traverses the AST and passes around
  * arguments.
  */
-var ASTVisitor = Base.extend({
-    visit: function(node) {
+class ASTVisitor {
+    visit(node) {
         return this['visit' + node.type].apply(this, arguments);
-    },
-});
+    }
+}
 
 // BEGIN DEBUGGING FUNCTIONS
 

--- a/lib/compiler/autocompleter.js
+++ b/lib/compiler/autocompleter.js
@@ -3,7 +3,6 @@
 // Juttle autocomplete backend.
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var parser = require('../parser');
 var procs = require('../runtime/procs');
 
@@ -35,15 +34,15 @@ var PLACEMENTS_TO_PROC_TYPES = {
     tail: ['proc', 'sink']
 };
 
-var Autocompleter = Base.extend({
-    initialize: function(options) {
+class Autocompleter {
+    constructor(options) {
         options = options || {};
 
         var views = options.views || {};
         this._procs = _.extend(_.clone(PROCS), views);
-    },
+    }
 
-    getCompletions: function(juttle, pos) {
+    getCompletions(juttle, pos) {
         var regions = this._computeRegions(juttle);
         var region = this._regionAtPos(regions, pos, juttle);
 
@@ -106,9 +105,9 @@ var Autocompleter = Base.extend({
         } else {
             return [];
         }
-    },
+    }
 
-    _computeRegions: function(juttle) {
+    _computeRegions(juttle) {
         var regions = [];
 
         try {
@@ -123,17 +122,17 @@ var Autocompleter = Base.extend({
         }
 
         return regions;
-    },
+    }
 
-    _validOptionsForRegion: function(region) {
+    _validOptionsForRegion(region) {
         return _.chain(this._procOptions(region.proc))
             .keys()
             .difference(_.pluck(region.prevOptions, 'name'))
             .map(function(opt) { return '-' + opt; })
             .value();
-    },
+    }
 
-    _regionAtPos: function(regions, pos, juttle) {
+    _regionAtPos(regions, pos, juttle) {
         var self = this;
 
         // We return the *last* of the regions containing pos. This is because
@@ -180,11 +179,11 @@ var Autocompleter = Base.extend({
             })
             .last()
             .value();
-    },
+    }
 
-    _procOptions: function(proc) {
+    _procOptions(proc) {
         return _.has(this._procs, proc) ? this._procs[proc].options : [];
     }
-});
+}
 
 module.exports = Autocompleter;

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -52,14 +52,15 @@ var SYMBOL_TYPE_NAMES = {
 // (which is currently limited to javascript running against the
 // juttle js runtime)
 //
-var Build = CodeGenerator.extend({
-    initialize: function() {
+class Build extends CodeGenerator {
+    constructor() {
+        super();
         // XXX/sm we can easily get rid of emit and just recursively return
         // the code strings, except we rely on returning the uname for the
         // proc when building the graph contruction code
         this.code = '';
-    },
-    gen: function(ast) {
+    }
+    gen(ast) {
         var code, body;
         var self = this;
 
@@ -81,22 +82,22 @@ var Build = CodeGenerator.extend({
         code += ast.uname + '();\n';
         code += '});\n';
         return code;
-    },
-    emit: function(s) {
+    }
+    emit(s) {
         this.code += s;
-    },
-    gen_var: function(uname) {
+    }
+    gen_var(uname) {
         return 'var ' + uname + ';\n';
-    },
-    gen_var_decl: function(decl) {
+    }
+    gen_var_decl(decl) {
         var code = this.gen_var(decl.uname);
         code += decl.uname;
         code += ' = ';
         code += decl.expr ? this.gen_expr(decl.expr) : 'null';
         code += ';\n';
         return code;
-    },
-    gen_const_decl: function(decl) {
+    }
+    gen_const_decl(decl) {
         var uname = decl.uname;
         var code = this.gen_var(uname);
         code += uname;
@@ -105,14 +106,14 @@ var Build = CodeGenerator.extend({
         code += ';\n';
         code += 'builder.set_const("' + uname + '",' + uname + ');\n';
         return code;
-    },
+    }
     //
     // this is like JSON.stringify except we walk the object and for
     // code nodes we output the code directly instead of a string rep
     // of the code
     // XXX generalize this (google a deepcopy routine)
     //
-    build_code_ast: function(ast) {
+    build_code_ast(ast) {
         var s;
         var self = this;
         if (ast === null || typeof(ast) !== 'object') {
@@ -138,11 +139,11 @@ var Build = CodeGenerator.extend({
                 '}';
         }
         return s;
-    },
-    gen_BuiltinProc: function(ast) {
+    }
+    gen_BuiltinProc(ast) {
         return this.gen_proc(ast);
-    },
-    gen_proc: function(ast) {
+    }
+    gen_proc(ast) {
         var code;
         ast.pname = {type:'Eval', expr:'builder.alloc_pname()' };
         code = 'var ' + ast.uname + ' = ';
@@ -151,8 +152,8 @@ var Build = CodeGenerator.extend({
         code += 'builder.add_node(' + ast.uname + ');\n';
         this.emit(code);
         return ast.uname;
-    },
-    gen_sub_call: function(ast) {
+    }
+    gen_sub_call(ast) {
         var code = '';
         var self = this;
         var subname = ast.op.type === 'Variable' ? ast.op.name : ast.op.object.name + '.' + ast.op.property.value;
@@ -168,8 +169,8 @@ var Build = CodeGenerator.extend({
         code += JSON.stringify(ast.location) + '));\n';
         this.emit(code);
         return ast.uname;
-    },
-    build_options: function(ast) {
+    }
+    build_options(ast) {
         var that = this;
         ast.options = _.map(ast.options, function(option) {
             // when we finally set 'd' bit everywhere properly, we should be
@@ -182,10 +183,10 @@ var Build = CodeGenerator.extend({
                 location: option.location
             };
         } );
-    },
+    }
 
     // statements that can appear inside subs or at the top level
-    gen_statement: function(ast, opts) {
+    gen_statement(ast, opts) {
         switch (ast.type) {
             case 'SubDef':
             case 'FunctionDef':
@@ -202,8 +203,8 @@ var Build = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized statement type ' + ast.type);
         }
-    },
-    gen_ModuleDef: function(ast) {
+    }
+    gen_ModuleDef(ast) {
         //
         // just spit out the module elements in the main scope since
         // the semantic pass flattened out all the module contents
@@ -213,8 +214,8 @@ var Build = CodeGenerator.extend({
         _.each(ast.elements, function(stmt) {
             self.gen_statement(stmt, {path_info: {mod: ast.name, sub: []}});
         } );
-    },
-    gen_SubDef: function(ast, opts) {
+    }
+    gen_SubDef(ast, opts) {
         opts = opts || {};
         opts.path_info = opts.path_info || {};
         var flowgraph, returnVal;
@@ -242,10 +243,10 @@ var Build = CodeGenerator.extend({
             this.emit('return ' + returnVal + ';\n');
         }
         this.emit('};\n');
-    },
+    }
 
     // statements that can appear inside functions or reducers
-    gen_function_statement: function(ast) {
+    gen_function_statement(ast) {
         switch (ast.type) {
             case 'StatementBlock':
             case 'FunctionDef':
@@ -261,8 +262,8 @@ var Build = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized function statement type ' + ast.type);
         }
-    },
-    gen_fill_args: function(args, define_consts) {
+    }
+    gen_fill_args(args, define_consts) {
         for (var k = 0; k < args.length; k++) {
             if (args[k].default) {
                 this.emit('if (' + args[k].uname + ' === undefined) {\n');
@@ -274,8 +275,8 @@ var Build = CodeGenerator.extend({
                 this.emit('builder.set_const("' + args[k].uname + '",' + args[k].uname + ');\n');
             }
         }
-    },
-    define_consts: function(elems) {
+    }
+    define_consts(elems) {
         var j, k, decls;
 
         for (k = 0; k < elems.length; ++k) {
@@ -288,8 +289,8 @@ var Build = CodeGenerator.extend({
                 }
             }
         }
-    },
-    gen_FunctionDef: function(ast) {
+    }
+    gen_FunctionDef(ast) {
         var k, elems = ast.elements;
         var args = _.pluck(ast.args, 'uname');
         this.emit('var ' + ast.uname + '= function(' + args.join(', ') + ') {\n');
@@ -311,8 +312,8 @@ var Build = CodeGenerator.extend({
         //from stream context, otherwise, they should just go away after
         // this pass because they aren't needed at runtime
         this.emit('builder.add_function(' + this.build_code_ast(ast) + ');\n');
-    },
-    build_reify: function(ast) {
+    }
+    build_reify(ast) {
         var self = this;
         if (ast === null || typeof(ast) !== 'object') {
             return ast;
@@ -324,8 +325,8 @@ var Build = CodeGenerator.extend({
             ast[name] = self.build_reify(val);
         });
         return ast;
-    },
-    gen_ReducerDef: function(ast) {
+    }
+    gen_ReducerDef(ast) {
         ast = this.build_reify(ast);
 
         // Define const statements outside of the reducer's scope so that they
@@ -333,13 +334,13 @@ var Build = CodeGenerator.extend({
         this.define_consts(ast.elements);
 
         this.emit('builder.add_reducer(' + this.build_code_ast(ast) + ');\n');
-    },
-    gen_StatementBlock: function(ast) {
+    }
+    gen_StatementBlock(ast) {
         for (var k = 0; k < ast.elements.length; ++k) {
             this.gen_function_statement(ast.elements[k]);
         }
-    },
-    stitch: function(flowgraph) {
+    }
+    stitch(flowgraph) {
         var k;
         var code = '';
         if (flowgraph.length <= 0) {
@@ -354,10 +355,10 @@ var Build = CodeGenerator.extend({
         }
         this.emit(code);
         return first;
-    },
+    }
 
     // elements of a flowgraph
-    gen_proc_element: function(ast) {
+    gen_proc_element(ast) {
         // XXX
         var methods = {
             ParallelGraph: this.gen_ParallelGraph,
@@ -378,9 +379,9 @@ var Build = CodeGenerator.extend({
         }
 
         throw new Error('unrecognized processor or sub: ' + ast.type);
-    },
+    }
 
-    gen_SequentialGraph: function(ast) {
+    gen_SequentialGraph(ast) {
         var k, next, first;
         var elements = ast.elements;
         var code = '';
@@ -397,9 +398,9 @@ var Build = CodeGenerator.extend({
         }
         this.emit(code);
         return first;
-    },
+    }
 
-    gen_ParallelGraph: function(ast) {
+    gen_ParallelGraph(ast) {
         var k;
         var elements = ast.elements;
         var flowgraph = [];
@@ -413,43 +414,43 @@ var Build = CodeGenerator.extend({
             flowgraph.push(this.gen_proc_element(elements[k]));
         }
         return this.stitch(flowgraph);
-    },
-    gen_EmptyStatement: function(ast) {
-    },
+    }
+    gen_EmptyStatement(ast) {
+    }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    gen_AssignmentStatement: function(ast) {
+    gen_AssignmentStatement(ast) {
         var code = this.gen_assignment_lhs(ast.left);
         //XXX need to handle op's other than "="
         code +=  ' = ' + this.gen_expr(ast.expr) + ';\n';
         this.emit(code);
-    },
+    }
     // this type of assignment lives in places where there can be
     // points or reducers
-    gen_AssignmentExpression: function(ast) {
+    gen_AssignmentExpression(ast) {
         var code = this.gen_assignment_lhs(ast.left);
         code += ' ' + ast.operator + ' ';
         code += this.gen_expr(ast.right);
         return code;
-    },
+    }
 
-    gen_VarStatement: function(ast) {
+    gen_VarStatement(ast) {
         var k, decls = ast.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_var_decl(decls[k]));
         }
-    },
-    gen_ConstStatement: function(ast) {
+    }
+    gen_ConstStatement(ast) {
         var k, decls = ast.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_const_decl(decls[k]));
         }
-    },
-    gen_ImportStatement: function(ast, functions) {
+    }
+    gen_ImportStatement(ast, functions) {
         // do nothing
-    },
+    }
 
-    gen_IfStatement: function(ast) {
+    gen_IfStatement(ast) {
         this.emit('if (');
         this.emit('juttle.values.ensureBoolean('
             + this.gen_expr(ast.condition)
@@ -462,48 +463,48 @@ var Build = CodeGenerator.extend({
             this.gen_function_statement(ast.elseStatement);
             this.emit('}\n');
         }
-    },
-    gen_ReturnStatement: function(ast) {
+    }
+    gen_ReturnStatement(ast) {
         this.emit('return (' + (ast.value ? this.gen_expr(ast.value) : 'null') + ');\n');
-    },
-    gen_ErrorStatement: function(ast) {
+    }
+    gen_ErrorStatement(ast) {
         this.emit('throw juttle.errors.runtimeError("CUSTOM-ERROR", {\n');
         this.emit('message: juttle.values.ensureString('
             + this.gen_expr(ast.message)
             + ', \'error statement: Invalid message type (<type>).\'),\n');
         this.emit('location: ' + JSON.stringify(ast.location) + '\n');
         this.emit('});');
-    },
-    gen_SequenceProc: function(ast) {
+    }
+    gen_SequenceProc(ast) {
         var self = this;
         ast.filters = _.map(ast.filters, function(filter) { return self.build_reifier_expr(filter); });
         return this.gen_proc(ast);
-    },
-    gen_FilterProc: function(ast) {
+    }
+    gen_FilterProc(ast) {
         ast.filter = this.build_reifier_expr(ast.filter);
         return this.gen_proc(ast);
-    },
-    gen_SortProc: function(ast) {
+    }
+    gen_SortProc(ast) {
         return this.gen_proc(ast);
-    },
-    gen_View: function(ast) {
+    }
+    gen_View(ast) {
         return this.gen_proc(ast);
-    },
-    gen_CalendarExpression: function(ast) {
+    }
+    gen_CalendarExpression(ast) {
         if (ast.direction === 'up') {
             return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
         } else {
             return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
         }
-    },
-    gen_ReadProc: function(ast) {
+    }
+    gen_ReadProc(ast) {
         ast.filter = this.build_reifier_expr(ast.filter);
         return this.gen_proc(ast);
-    },
-    gen_WriteProc: function(ast) {
+    }
+    gen_WriteProc(ast) {
         return this.gen_proc(ast);
-    },
-    gen_reducers: function(aName, reducers) {
+    }
+    gen_reducers(aName, reducers) {
         var k, uname, args;
         var code = '';
         for (k = 0; k < reducers.length; ++k) {
@@ -517,9 +518,9 @@ var Build = CodeGenerator.extend({
             code += aName + '.push(' + uname + '(' + argstr + '));\n';
         }
         return code;
-    },
+    }
 
-    gen_ReifierProc: function(ast) {
+    gen_ReifierProc(ast) {
         ast.pname = {type:'Eval', expr:'builder.alloc_pname()' };
         ast.exprs = this.build_reifier_expr(ast.exprs);
         var code = 'var ' + ast.uname + ' = ';
@@ -530,17 +531,17 @@ var Build = CodeGenerator.extend({
         code += 'builder.add_node(' + ast.uname + ');\n';
         this.emit(code);
         return ast.uname;
-    },
-    gen_ReduceProc: function(ast) {
+    }
+    gen_ReduceProc(ast) {
         return this.gen_ReifierProc(ast);
-    },
-    gen_PutProc: function(ast) {
+    }
+    gen_PutProc(ast) {
         return this.gen_ReifierProc(ast);
-    },
-    gen_FunctionProc: function(ast) {
+    }
+    gen_FunctionProc(ast) {
         return this.gen_sub_call(ast);
-    },
-    gen_InputStatement: function(ast, opts) {
+    }
+    gen_InputStatement(ast, opts) {
         var self = this;
         var input_opts = '{ ' + _.map(ast.options, function(option) {
             return option.id + ': ' + self.gen_expr(option.expr);
@@ -560,8 +561,8 @@ var Build = CodeGenerator.extend({
 
         code += 'builder.set_const("' + uname + '",' + uname + ');\n';
         this.emit( code);
-    },
-    gen_assignment_lhs: function(ast) {
+    }
+    gen_assignment_lhs(ast) {
         switch (ast.type) {
             case 'UnaryExpression':
                 return this.gen_UnaryExpression(ast);
@@ -574,14 +575,14 @@ var Build = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized expression lhs ' + ast.type);
         }
-    },
+    }
 
     //
     // walk the tree and leave AST nodes that must run in streaming/reducer
     // context and compile nodes that can be eval'd at build time (into AST
     // nodes of type 'Eval').
     //
-    build_reifier_expr: function(ast) {
+    build_reifier_expr(ast) {
         var self = this;
         if (ast === null || typeof(ast) !== 'object') {
             return ast;
@@ -596,8 +597,8 @@ var Build = CodeGenerator.extend({
             ast[key] = self.build_reifier_expr(val);
         });
         return ast;
-    },
-    gen_expr: function(ast) {
+    }
+    gen_expr(ast) {
         switch (ast.type) {
             case 'AssignmentExpression':
             case 'FunctionCall':
@@ -633,9 +634,9 @@ var Build = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized expression type ' + ast.type);
         }
-    },
+    }
 
-    gen_PostfixExpression: function(ast) {
+    gen_PostfixExpression(ast) {
         var expr = this.gen_expr(ast.expression);
         var op = ast.operator;
 
@@ -643,8 +644,8 @@ var Build = CodeGenerator.extend({
             + expr
             + ', \'"' + op + '" operator: Invalid operand type (<type>).\'),'
             + expr + op + ')';
-    },
-    gen_FunctionCall: function(ast) {
+    }
+    gen_FunctionCall(ast) {
         var code, self=this;
         code = 'juttle.ops.call(' + ast.fname.uname;
         code += _.map(ast.arguments, function(arg) {
@@ -652,17 +653,17 @@ var Build = CodeGenerator.extend({
         }).join('');
         code += ')';
         return code;
-    },
-    gen_ReducerCall: function(ast) {
+    }
+    gen_ReducerCall(ast) {
         var result = 'fns[' + ast.reducer_call_index + '].result()';
         if (ast.context === 'stream') {
             // put must consume the current point before calling result
             result = '(fns[' + ast.reducer_call_index + '].update(pt),' + result + ')';
         }
         return result;
-    },
+    }
 
-    gen_UnaryExpression: function(ast) {
+    gen_UnaryExpression(ast) {
         var expr = this.gen_expr(ast.expression);
         var op = ast.operator;
 
@@ -685,8 +686,8 @@ var Build = CodeGenerator.extend({
             default:
                 return 'juttle.ops.' + UNARY_OPS_TO_FUNCTIONS[op] + '(' + expr + ')';
         }
-    },
-    gen_BinaryExpression: function(ast) {
+    }
+    gen_BinaryExpression(ast) {
         var left = this.gen_expr(ast.left);
         var right = this.gen_expr(ast.right);
 
@@ -703,15 +704,15 @@ var Build = CodeGenerator.extend({
                 + BINARY_OPS_TO_FUNCTIONS[ast.operator]
                 + '(' + left + ', ' + right + ')';
         }
-    },
-    gen_ConditionalExpression: function(ast) {
+    }
+    gen_ConditionalExpression(ast) {
         return '(juttle.values.ensureBoolean('
             + this.gen_expr(ast.condition)
             + ', \'Ternary operator: Invalid operand type (<type>).\')?('
             + this.gen_expr(ast.trueExpression) + '):('
             + this.gen_expr(ast.falseExpression) + '))';
-    },
-    gen_ByList: function(ast) {
+    }
+    gen_ByList(ast) {
         var k, elem = ast.elements;
         // ast.elements is an array of the comma separated expressions
         // each element can be an identifier (which may be a variable
@@ -749,8 +750,8 @@ var Build = CodeGenerator.extend({
                 +'});';
         code += 'return out;\n})()\n';
         return code;
-    },
-    gen_SortByList: function(ast) {
+    }
+    gen_SortByList(ast) {
         var k, elem = ast.elements;
         var code = '(function() { var t, out = [];\n';
         for (k = 0; k < elem.length; k++) {
@@ -770,8 +771,8 @@ var Build = CodeGenerator.extend({
             +'});';
         code += 'return out;\n})()\n';
         return code;
-    },
-    gen_Variable: function(ast) {
+    }
+    gen_Variable(ast) {
         switch (ast.symbol.type) {
             case 'const':
                 return 'builder.get_const("' + ast.uname + '")';
@@ -786,11 +787,11 @@ var Build = CodeGenerator.extend({
             default:
                 return ast.uname;
         }
-    },
-    gen_Field: function(ast) {
+    }
+    gen_Field(ast) {
         return 'juttle.ops.pget(pt,' + JSON.stringify(ast.name) + ')';
-    },
-    gen_MemberExpression: function(ast, opts) {
+    }
+    gen_MemberExpression(ast, opts) {
         if (!ast.computed) {
             return ast.uname;
         } else {
@@ -805,6 +806,6 @@ var Build = CodeGenerator.extend({
             }
         }
     }
-});
+}
 
 module.exports = Build;

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -1,45 +1,43 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
-
-var CodeGenerator = Base.extend({
-    gen_ArrayLiteral: function(ast) {
+class CodeGenerator {
+    gen_ArrayLiteral(ast) {
         var self = this;
         var exprs = _.map(ast.elements, function(element) {
             return self.gen_expr(element);
         } );
         return '[' + exprs.join(',') + ']';
-    },
-    gen_NumberLiteral: function(ast) {
+    }
+    gen_NumberLiteral(ast) {
         return ast.value.toString();
-    },
-    gen_InfinityLiteral: function(ast) {
+    }
+    gen_InfinityLiteral(ast) {
         return (ast.negative ? '-' : '') + 'Infinity';
-    },
-    gen_NaNLiteral: function() {
+    }
+    gen_NaNLiteral() {
         return 'NaN';
-    },
-    gen_BooleanLiteral: function(ast) {
+    }
+    gen_BooleanLiteral(ast) {
         return JSON.stringify(ast.value);
-    },
-    gen_StringLiteral: function(ast) {
+    }
+    gen_StringLiteral(ast) {
         return JSON.stringify(ast.value);
-    },
-    gen_MultipartStringLiteral: function(ast) {
+    }
+    gen_MultipartStringLiteral(ast) {
         var self = this;
         var exprs = _.map(ast.parts, function(part) {
             return self.gen_expr(part);
         });
         return '(' + exprs.join(' + ') + ')';
-    },
-    gen_NullLiteral: function() {
+    }
+    gen_NullLiteral() {
         return 'null';
-    },
-    gen_RegExpLiteral: function(ast) {
+    }
+    gen_RegExpLiteral(ast) {
         return '/'+ ast.pattern +'/'+ ast.flags;
-    },
-    gen_ObjectLiteral: function(ast) {
+    }
+    gen_ObjectLiteral(ast) {
         var self = this;
         var simple = _(ast.properties).any(function(property) {
             return property.key.type === 'StringLiteral';
@@ -51,25 +49,25 @@ var CodeGenerator = Base.extend({
         return simple
             ? '{' + props.join(', ') + '}'
             : 'juttle.values.buildObject([' + props.join(', ') + '])';
-    },
-    gen_ObjectProperty: function(ast, simple) {
+    }
+    gen_ObjectProperty(ast, simple) {
         return simple
             ? this.gen_expr(ast.key) + ': ' + this.gen_expr(ast.value)
             : '[' + this.gen_expr(ast.key) + ', ' + this.gen_expr(ast.value) + ']';
-    },
-    gen_DurationLiteral: function(ast) {
+    }
+    gen_DurationLiteral(ast) {
         return 'juttle.types.JuttleMoment.duration("' + ast.value + '")';
-    },
-    gen_MomentLiteral: function(ast) {
+    }
+    gen_MomentLiteral(ast) {
         return 'new juttle.types.JuttleMoment("' + ast.value + '")';
-    },
-    gen_FilterLiteral: function(ast) {
+    }
+    gen_FilterLiteral(ast) {
         return 'new juttle.types.Filter(' + JSON.stringify(ast.ast) + ',' + JSON.stringify(ast.source) + ')';
-    },
-    gen_ToString: function(ast) {
+    }
+    gen_ToString(ast) {
         return 'juttle.ops.str(' + this.gen_expr(ast.expression) + ')';
-    },
-});
+    }
+}
 
 
 module.exports = CodeGenerator;

--- a/lib/compiler/filters/dynamic-filter-checker.js
+++ b/lib/compiler/filters/dynamic-filter-checker.js
@@ -8,18 +8,18 @@
 var ASTVisitor = require('../ast-visitor');
 var errors = require('../../errors');
 
-var DynamicFilterChecker = ASTVisitor.extend({
-    check: function(node) {
+class DynamicFilterChecker extends ASTVisitor {
+    check(node) {
         this.visit(node);
-    },
+    }
 
-    visitSimpleFilterTerm: function(node) {
+    visitSimpleFilterTerm(node) {
         if (node.expression.type !== 'FilterLiteral') {
             throw errors.compileError('NO-FREE-TEXT', {
                 location: node.location
             });
         }
     }
-});
+}
 
 module.exports = DynamicFilterChecker;

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -43,60 +43,60 @@ var BINARY_OPS_TO_FUNCTIONS = {
     '??':  'coal'
 };
 
-var FilterJSCompiler = ASTVisitor.extend({
-    compile: function(node) {
+class FilterJSCompiler extends ASTVisitor {
+    compile(node) {
         return '(function(pt) { return ' + this.visit(node) + ' })';
-    },
+    }
 
-    visitNullLiteral: function(node) {
+    visitNullLiteral(node) {
         return 'null';
-    },
+    }
 
-    visitBooleanLiteral: function(node) {
+    visitBooleanLiteral(node) {
         return String(node.value);
-    },
+    }
 
-    visitNumberLiteral: function(node) {
+    visitNumberLiteral(node) {
         return String(node.value);
-    },
+    }
 
-    visitInfinityLiteral: function(node) {
+    visitInfinityLiteral(node) {
         return (node.negative ? '-' : '') + 'Infinity';
-    },
+    }
 
-    visitNaNLiteral: function(node) {
+    visitNaNLiteral(node) {
         return 'NaN';
-    },
+    }
 
-    visitStringLiteral: function(node) {
+    visitStringLiteral(node) {
         return JSON.stringify(node.value);
-    },
+    }
 
-    visitMultipartStringLiteral: function(node) {
+    visitMultipartStringLiteral(node) {
         return '(' + _.map(node.parts, this.visit, this).join(' + ') + ')';
-    },
+    }
 
-    visitRegExpLiteral: function(node) {
+    visitRegExpLiteral(node) {
         return 'new RegExp(' + JSON.stringify(node.pattern) + ', ' + JSON.stringify(node.flags) + ')';
-    },
+    }
 
-    visitMomentLiteral: function(node) {
+    visitMomentLiteral(node) {
         return 'new juttle.types.JuttleMoment(' + JSON.stringify(node.value) + ')';
-    },
+    }
 
-    visitDurationLiteral: function(node) {
+    visitDurationLiteral(node) {
         return 'juttle.types.JuttleMoment.duration(' + JSON.stringify(node.value) + ')';
-    },
+    }
 
-    visitFilterLiteral: function(node) {
+    visitFilterLiteral(node) {
         return this.visit(node.ast);
-    },
+    }
 
-    visitArrayLiteral: function(node) {
+    visitArrayLiteral(node) {
         return '[ ' + _.map(node.elements, this.visit, this).join(', ') + ' ]';
-    },
+    }
 
-    visitObjectLiteral: function(node) {
+    visitObjectLiteral(node) {
         var self = this;
 
         var hasSimpleKeys = _.every(node.properties, function(property) {
@@ -111,23 +111,23 @@ var FilterJSCompiler = ASTVisitor.extend({
         return hasSimpleKeys
             ? '{ ' + propertiesCode + ' }'
             : 'juttle.values.buildObject([ ' + propertiesCode + ' ])';
-    },
+    }
 
-    visitObjectProperty: function(node, hasSimpleKeys) {
+    visitObjectProperty(node, hasSimpleKeys) {
         return hasSimpleKeys
             ? this.visit(node.key) + ': ' + this.visit(node.value)
             : '[' + this.visit(node.key) + ', ' + this.visit(node.value) + ']';
-    },
+    }
 
-    visitField: function(node) {
+    visitField(node) {
         return 'juttle.ops.pget(pt, ' + JSON.stringify(node.name) + ')';
-    },
+    }
 
-    visitToString: function(node) {
+    visitToString(node) {
         return 'juttle.ops.str(' + this.visit(node.expression) + ')';
-    },
+    }
 
-    visitMemberExpression: function(node) {
+    visitMemberExpression(node) {
         if (!node.computed) {
             return node.uname;
         } else {
@@ -137,17 +137,17 @@ var FilterJSCompiler = ASTVisitor.extend({
                 + this.visit(node.property)
                 + ')';
         }
-    },
+    }
 
-    visitFunctionCall: function(node) {
+    visitFunctionCall(node) {
         return  'juttle.ops.call('
             + node.fname
             + ', '
             + _.map(node.arguments, this.visit, this).join(', ')
             + ')';
-    },
+    }
 
-    visitUnaryExpression: function(node) {
+    visitUnaryExpression(node) {
         switch (node.operator) {
             case '*':
                 return 'juttle.ops.pget(pt, ' + this.visit(node.expression) + ')';
@@ -164,9 +164,9 @@ var FilterJSCompiler = ASTVisitor.extend({
                     + this.visit(node.expression)
                     + ')';
         }
-    },
+    }
 
-    visitBinaryExpression: function(node) {
+    visitBinaryExpression(node) {
         switch (node.operator) {
             case '&&':
             case '||':
@@ -189,9 +189,9 @@ var FilterJSCompiler = ASTVisitor.extend({
                     + this.visit(node.right)
                     + ')';
         }
-    },
+    }
 
-    visitConditionalExpression: function(node) {
+    visitConditionalExpression(node) {
         return 'juttle.values.ensureBoolean('
             + this.visit(node.condition)
             + ', '
@@ -201,13 +201,13 @@ var FilterJSCompiler = ASTVisitor.extend({
             + this.visit(node.trueExpression)
             + ' : '
             + this.visit(node.falseExpression);
-    },
+    }
 
-    visitExpressionFilterTerm: function(node) {
+    visitExpressionFilterTerm(node) {
         return this.visit(node.expression);
-    },
+    }
 
-    visitSimpleFilterTerm: function(node) {
+    visitSimpleFilterTerm(node) {
         switch (node.expression.type) {
             case 'StringLiteral':
                 throw errors.compileError('NO-FREE-TEXT');
@@ -219,6 +219,6 @@ var FilterJSCompiler = ASTVisitor.extend({
                 throw new Error('Invalid node type: ' + node.expression.type + '.');
         }
     }
-});
+}
 
 module.exports = FilterJSCompiler;

--- a/lib/compiler/filters/partial-filter-js-compiler.js
+++ b/lib/compiler/filters/partial-filter-js-compiler.js
@@ -36,16 +36,16 @@ var BINARY_OPS_TO_FUNCTIONS = {
     'OR':  'lor'
 };
 
-var PartialFilterJSCompiler = FilterJSCompiler.extend({
-    compile: function(node, fields) {
+class PartialFilterJSCompiler extends FilterJSCompiler {
+    compile(node, fields) {
         // construct a function that returns true if node is true or is unresolved
         this.fields = fields;
         return '(function(pt) { return ('
             + this.visitPartialBoolean(node, '\'Invalid operator type (<type>).\'')
             + ') !== false; })';
-    },
+    }
 
-    visitPartialBoolean: function(node, message) {
+    visitPartialBoolean(node, message) {
         // generate a visit that ensures boolean and propagates unresolved
         // values as undefined, for safe handling by the caller.
         return 'function() { try {'
@@ -56,16 +56,16 @@ var PartialFilterJSCompiler = FilterJSCompiler.extend({
             + '} else {'
             + '    throw exc ;'
             + '}}}()';
-    },
+    }
 
-    visitField: function(node) {
+    visitField(node) {
         var index = JSON.stringify(node.name);
         return '(' + JSON.stringify(this.fields) + '.indexOf(' + index + ') >= 0 '
             + '? juttle.ops.pget(pt, ' + index + ') '
             + ': juttle.partialOps.throw_unresolved())';
-    },
+    }
 
-    visitUnaryExpression: function(node) {
+    visitUnaryExpression(node) {
         switch (node.operator) {
             case 'NOT':
                 var message = '\'"NOT" operator: Invalid operator type (<type>).\'';
@@ -82,9 +82,9 @@ var PartialFilterJSCompiler = FilterJSCompiler.extend({
             default:
                 throw new Error('Invalid operator: ' + node.operator + '.');
         }
-    },
+    }
 
-    visitBinaryExpression: function(node) {
+    visitBinaryExpression(node) {
         if (node.operator === '&&' || node.operator === '||') {
             var message = '\'"' + node.operator + '" operator: Invalid operator type (<type>).\'';
             return 'juttle.partialOps.' + BINARY_OPS_TO_FUNCTIONS[node.operator] + '('
@@ -97,7 +97,7 @@ var PartialFilterJSCompiler = FilterJSCompiler.extend({
                 + this.visit(node.right)
                 + ')';
         }
-    },
-});
+    }
+}
 
 module.exports = PartialFilterJSCompiler;

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -111,12 +111,12 @@ var ALLOWED_OP_FORMS = {
     ]
 };
 
-var StaticFilterChecker = ASTVisitor.extend({
-    check: function(node) {
+class StaticFilterChecker extends ASTVisitor {
+    check(node) {
         this.visit(node);
-    },
+    }
 
-    visitExpressionFilterTerm: function(node) {
+    visitExpressionFilterTerm(node) {
         var forms = ALLOWED_OP_FORMS[node.expression.operator];
 
         var valid = _.any(forms, function(form) {
@@ -138,9 +138,9 @@ var StaticFilterChecker = ASTVisitor.extend({
                 location: node.location
             });
         }
-    },
+    }
 
-    visitSimpleFilterTerm: function(node) {
+    visitSimpleFilterTerm(node) {
         switch (node.expression.type) {
             case 'StringLiteral':
                 break;
@@ -156,6 +156,6 @@ var StaticFilterChecker = ASTVisitor.extend({
                 });
         }
     }
-});
+}
 
 module.exports = StaticFilterChecker;

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Base = require('extendable-base');
 var _ = require('underscore');
 var values = require('../runtime/values');
 var procs = require('../runtime/procs');
@@ -23,8 +22,8 @@ function build_pname(index) {
     return 'p' + index;
 }
 
-var GraphBuilder = Base.extend({
-    initialize: function(options) {
+class GraphBuilder {
+    constructor(options) {
         this.nodes = [];
         this.inputs = [];
         this.functions = [];
@@ -41,24 +40,24 @@ var GraphBuilder = Base.extend({
         this.input_values = options.inputs || {};
         // contains the set of functions computing implicit defaults of inputs
         this.input_defaults = options.input_defaults || {};
-    },
-    alloc_pname: function() {
+    }
+    alloc_pname() {
         return build_pname(this.nproc++);
-    },
+    }
     //
     // go through all the nodes and remove head and tail data structures
     // that were used to build the graph.  this isn't needed after the
     // flowgraph has been built (and interferes with JSON.stringify)
     //
-    cleanup: function() {
+    cleanup() {
         var k, nodes = this.nodes;
         for (k = 0; k < nodes.length; ++k) {
             delete nodes[k].head;
             delete nodes[k].tail;
         }
         delete this.bnames;
-    },
-    graph: function() {
+    }
+    graph() {
         this.cleanup();
         return {nodes: this.nodes,
                 inputs: this.inputs,
@@ -66,27 +65,27 @@ var GraphBuilder = Base.extend({
                 reducers: this.reducers,
                 now: this.now,
                 stats: this.stats};
-    },
-    shortname: function(node) {
+    }
+    shortname(node) {
         return node.type + ' (' + node.uname + ')';
-    },
+    }
     //XXX too simple but ok for a start
-    describe_node: function(node) {
+    describe_node(node) {
         var k, out = node.out;
         var desc = this.shortname(node) + '\n';
         for (k = 0; k < out.length; ++k) {
             desc += '\t-> ' + this.shortname(out[k]) + '\n';
         }
         return desc;
-    },
-    describe: function() {
+    }
+    describe() {
         var k, nodes = this.nodes, desc = '';
         for (k = 0; k < nodes.length; ++k) {
             desc += this.describe_node(nodes[k]);
         }
         return desc;
-    },
-    add_node: function(node) {
+    }
+    add_node(node) {
         node.pname= node.pname.value;
         this.nodes.push(node);
         node.head = [ node ];
@@ -94,9 +93,9 @@ var GraphBuilder = Base.extend({
         node.out = [];
         node.in = [];
         node.shortcuts = [];
-    },
+    }
     //XXX need a disconnect method
-    connect: function(from, to) {
+    connect(from, to) {
         if (is_sink(from)) {
             return false;
         }
@@ -106,8 +105,8 @@ var GraphBuilder = Base.extend({
         from.out.push(to.pname);
         to.in.push(from.pname);
         return true;
-    },
-    append: function(from, to) {
+    }
+    append(from, to) {
         var t, h, tail, head;
         tail = from.tail;
         head = to.head;
@@ -134,8 +133,8 @@ var GraphBuilder = Base.extend({
             }
         }
         from.tail = to.tail;
-    },
-    combine: function(a, b) {
+    }
+    combine(a, b) {
         var k;
         // append the head items from proc to this.head
         // and the tail items from proc to this.tail
@@ -146,19 +145,19 @@ var GraphBuilder = Base.extend({
         for (k = 0; k < b.tail.length; ++k) {
             a.tail.push(b.tail[k]);
         }
-    },
-    uname: function(uname) {
+    }
+    uname(uname) {
         if (this.bnames[uname]) {
             return this.bnames[uname];
         } else {
             return uname;
         }
-    },
-    alloc_const: function(uname, initializer) {
+    }
+    alloc_const(uname, initializer) {
         return uname + '_' + this.uid++;
-    },
+    }
 
-    input_bname: function(mod_name, sub_list, input_name) {
+    input_bname(mod_name, sub_list, input_name) {
         var mod_component = mod_name ? mod_name + '/' : '';
         var sub_component = sub_list.join('.') + '.';
 
@@ -173,41 +172,41 @@ var GraphBuilder = Base.extend({
             this.input_seqnos[key] = 0;
         }
         return key + '[' + this.input_seqnos[key]  + ']';
-    },
-    define_input: function(bname, input_name, options, isStatic) {
+    }
+    define_input(bname, input_name, options, isStatic) {
         var input = {id: bname, name: input_name, options: options, static: isStatic};
         input.value = this._compute_input_val(input);
         this.inputs.push(input);
         return input.value;
-    },
-    add_function: function(ast) {
+    }
+    add_function(ast) {
         var bname = ast.uname + '_' + this.uid++;
         this.bnames[ast.uname] = bname;
         ast.sname = ast.uname;
         ast.uname = bname;
         this.functions.push(ast);
-    },
-    add_reducer: function(ast) {
+    }
+    add_reducer(ast) {
         var bname = ast.uname + '_' + this.uid++;
         this.bnames[ast.uname] = bname;
         ast.uname = bname;
         this.reducers.push(ast);
-    },
-    set_const: function(uname, val) {
+    }
+    set_const(uname, val) {
         this.consts[uname] = val;
-    },
-    get_const: function(uname, val) {
+    }
+    get_const(uname, val) {
         if (!this.consts.hasOwnProperty(uname)) {
             throw new Error('GraphBuilder.get_const: attempt to retrieve undefined const ' + uname);
         }
         return this.consts[uname];
-    },
-    value_ast: function(result) {
+    }
+    value_ast(result) {
         // The _semantic_ast call is needed to correctly process filter
         // literals.
         return this._semantic_ast(values.toAST(result));
-    },
-    build_sub_args: function (sub_sig, callopts, subname, location) {
+    }
+    build_sub_args(sub_sig, callopts, subname, location) {
         var opts = {};
         var argnames = _.pluck(sub_sig, 'name');
 
@@ -235,11 +234,11 @@ var GraphBuilder = Base.extend({
             return val;
         });
         return sub_params;
-    },
-    record_stats: function(stats) {
+    }
+    record_stats(stats) {
         this.stats = stats;
-    },
-    _compute_input_val: function(input) {
+    }
+    _compute_input_val(input) {
         if (_.has(this.input_values, input.id)) {
             return this.input_values[input.id];
         }
@@ -253,12 +252,12 @@ var GraphBuilder = Base.extend({
         }
 
         return null;
-    },
-    _semantic_ast: function(ast) {
+    }
+    _semantic_ast(ast) {
         var semantic = new SemanticPass({ now: this.now });
         return semantic.sa_expr(ast);
     }
-});
+}
 
 module.exports = {
     GraphBuilder: GraphBuilder,

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -52,14 +52,15 @@ var SYMBOL_TYPE_NAMES = {
 // take a dataflow graph representation and generate a javascript program
 // that runs against the Juttle javascript runtime
 //
-var GraphCompiler = CodeGenerator.extend({
-    initialize: function() {
+class GraphCompiler extends CodeGenerator {
+    constructor() {
+        super();
         // XXX/sm we can easily get rid of emit and just recursively return
         // the code strings, except we rely on returning the uname for the
         // proc when building the graph contruction code
         this.code = '';
-    },
-    gen: function(graph) {
+    }
+    gen(graph) {
         var code, body, entry;
         this.now = graph.now;
         this.gen_now(graph.now);
@@ -82,31 +83,31 @@ var GraphCompiler = CodeGenerator.extend({
         code += 'graph: ' + entry + ' };\n';
         code += '})';
         return code;
-    },
-    emit: function(s) {
+    }
+    emit(s) {
         this.code += s;
-    },
-    gen_now: function(now) {
+    }
+    gen_now(now) {
         this.emit('program.now = ' + 'new juttle.types.JuttleMoment("' + now + '");');
         this.emit('program.channels = 0;');
-    },
-    gen_functionDefs: function(fns) {
+    }
+    gen_functionDefs(fns) {
         var k;
         for (k = 0; k < fns.length; ++k) {
             this.gen_FunctionDef(fns[k]);
         }
-    },
-    gen_reducerDefs: function(reducers) {
+    }
+    gen_reducerDefs(reducers) {
         var k;
         for (k = 0; k < reducers.length; ++k) {
             this.gen_ReducerDef(reducers[k]);
         }
-    },
+    }
     //XXX we shouldn't have to do this, but to support the old FlowGraph
     // module that reaches into the head field of the proc nodes, we do
     // this here and call combine() to set things up.  once we clean up
     // the FlowGraph implementation, we can simply and/or remove this
-    find_sources: function(procs) {
+    find_sources(procs) {
         var k, i, id, out, touch = {}, srcs = [];
         for (k = 0; k < procs.length; ++k) {
             id = procs[k].pname;
@@ -122,8 +123,8 @@ var GraphCompiler = CodeGenerator.extend({
             }
         }
         return srcs;
-    },
-    gen_procs: function(procs) {
+    }
+    gen_procs(procs) {
         var k, i, first, node, from, out, shorts, srcs;
         for (k = 0; k < procs.length; ++k) {
             node = this.gen_proc_element(procs[k]);
@@ -151,19 +152,19 @@ var GraphCompiler = CodeGenerator.extend({
             this.emit(first + '.combine(' + srcs[k] + ');\n');
         }
         return first;
-    },
-    gen_var: function(uname) {
+    }
+    gen_var(uname) {
         return 'var ' + uname + ';\n';
-    },
-    gen_var_decl: function(decl) {
+    }
+    gen_var_decl(decl) {
         var code = this.gen_var(decl.uname);
         code += decl.uname;
         code += ' = ';
         code += decl.expr ? this.gen_expr(decl.expr) : 'null';
         code += ';\n';
         return code;
-    },
-    gen_const_decl: function(decl) {
+    }
+    gen_const_decl(decl) {
         var uname = decl.uname;
         var code = this.gen_var(uname);
         code += uname;
@@ -171,13 +172,13 @@ var GraphCompiler = CodeGenerator.extend({
         code += this.gen_expr(decl.expr);
         code += ';\n';
         return code;
-    },
-    gen_BuiltinProc: function(ast) {
+    }
+    gen_BuiltinProc(ast) {
         // When everything is switched over, gen_proc can
         // take ast.name from ast and we don't need to pass it as arg
         return this.gen_proc(ast, ast.name);
-    },
-    gen_proc: function(ast, procName, params) {
+    }
+    gen_proc(ast, procName, params) {
         var pname = ast.pname;
         params = params || {};
         params.$pname = pname;
@@ -192,8 +193,8 @@ var GraphCompiler = CodeGenerator.extend({
             + ');\n';
         this.emit(code);
         return pname;
-    },
-    extend_options: function(opts, location) {
+    }
+    extend_options(opts, location) {
         var options = { type: 'ObjectLiteral', properties: [], location: location };
         function setopt(name, val, location) {
             var parts = name.split('.');
@@ -246,16 +247,16 @@ var GraphCompiler = CodeGenerator.extend({
         });
 
         return options;
-    },
-    gen_options: function(options, location, params) {
+    }
+    gen_options(options, location, params) {
         params = params || {};
 
         var code = this.gen_expr(this.extend_options(options, location));
         code += ',';
         code += this.gen_params(params);
         return code;
-    },
-    gen_params: function(params) {
+    }
+    gen_params(params) {
         var code = '{';
         var comma = '';
         _.each(params, function(val, name) {
@@ -272,10 +273,10 @@ var GraphCompiler = CodeGenerator.extend({
         } );
         code += '}';
         return code;
-    },
+    }
 
     // statements that can appear inside functions or reducers
-    gen_function_statement: function(ast) {
+    gen_function_statement(ast) {
         switch (ast.type) {
             case 'StatementBlock':
             case 'FunctionDef':
@@ -291,8 +292,8 @@ var GraphCompiler = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized function statement type ' + ast.type);
         }
-    },
-    gen_fill_args: function(args) {
+    }
+    gen_fill_args(args) {
         for (var k = 0; k < args.length; k++) {
             if (args[k].default) {
                 this.emit('if (' + args[k].uname + ' === undefined) {\n');
@@ -300,8 +301,8 @@ var GraphCompiler = CodeGenerator.extend({
                 this.emit('}\n');
             }
         }
-    },
-    gen_FunctionDef: function(ast) {
+    }
+    gen_FunctionDef(ast) {
         var k, elems = ast.elements;
         var args = _.pluck(ast.args, 'uname');
         if (ast.stream) {
@@ -316,9 +317,9 @@ var GraphCompiler = CodeGenerator.extend({
         this.emit('return null;\n');
         this.emit('};\n');
         this.emit(ast.uname + '.location = ' + JSON.stringify(ast.location) + ';\n');
-    },
+    }
 
-    gen_ReducerDef: function(ast) {
+    gen_ReducerDef(ast) {
         var k, code;
         var uname = ast.uname;
         var args = _.pluck(ast.args, 'uname');
@@ -348,15 +349,15 @@ var GraphCompiler = CodeGenerator.extend({
 
         this.emit('return ' + code + ';\n');
         this.emit('};\n');
-    },
-    gen_StatementBlock: function(ast) {
+    }
+    gen_StatementBlock(ast) {
         for (var k = 0; k < ast.elements.length; ++k) {
             this.gen_function_statement(ast.elements[k]);
         }
-    },
+    }
 
     // elements of a flowgraph
-    gen_proc_element: function(ast) {
+    gen_proc_element(ast) {
         // XXX
         var methods = {
             ParallelGraph: this.gen_ParallelGraph,
@@ -377,40 +378,40 @@ var GraphCompiler = CodeGenerator.extend({
         }
 
         throw new Error('unrecognized processor or sub: ' + ast.type);
-    },
+    }
 
-    gen_EmptyStatement: function(ast) {
-    },
+    gen_EmptyStatement(ast) {
+    }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    gen_AssignmentStatement: function(ast) {
+    gen_AssignmentStatement(ast) {
         var code = this.gen_assignment_lhs(ast.left);
         //XXX need to handle op's other than "="
         code +=  ' = ' + this.gen_expr(ast.expr) + ';\n';
         this.emit(code);
-    },
+    }
     // this type of assignment lives in places where there can be
     // points or reducers
-    gen_AssignmentExpression: function(ast) {
+    gen_AssignmentExpression(ast) {
         var code = this.gen_assignment_lhs(ast.left);
         code += ' ' + ast.operator + ' ';
         code += this.gen_expr(ast.right);
         return code;
-    },
+    }
 
-    gen_VarStatement: function(ast) {
+    gen_VarStatement(ast) {
         var k, decls = ast.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_var_decl(decls[k]));
         }
-    },
-    gen_ConstStatement: function(ast) {
+    }
+    gen_ConstStatement(ast) {
         var k, decls = ast.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_const_decl(decls[k]));
         }
-    },
-    gen_IfStatement: function(ast) {
+    }
+    gen_IfStatement(ast) {
         this.emit('if (');
         this.emit('juttle.values.ensureBoolean('
             + this.gen_expr(ast.condition)
@@ -423,19 +424,19 @@ var GraphCompiler = CodeGenerator.extend({
             this.gen_function_statement(ast.elseStatement);
             this.emit('}\n');
         }
-    },
-    gen_ReturnStatement: function(ast) {
+    }
+    gen_ReturnStatement(ast) {
         this.emit('return (' + (ast.value ? this.gen_expr(ast.value) : 'null') + ');\n');
-    },
-    gen_ErrorStatement: function(ast) {
+    }
+    gen_ErrorStatement(ast) {
         this.emit('throw juttle.errors.runtimeError(\'CUSTOM-ERROR\', {\n');
         this.emit('message: juttle.values.ensureString('
             + this.gen_expr(ast.message)
             + ', \'error statement: Invalid message type (<type>).\'),\n');
         this.emit('location: ' + JSON.stringify(ast.location) + '\n');
         this.emit('});');
-    },
-    gen_ReadProc: function(ast) {
+    }
+    gen_ReadProc(ast) {
         if (ast.filter) {
             var checker = new StaticFilterChecker();
             checker.check(ast.filter);
@@ -448,11 +449,11 @@ var GraphCompiler = CodeGenerator.extend({
         };
 
         return this.gen_proc(ast, 'read', params);
-    },
-    gen_WriteProc: function(ast) {
+    }
+    gen_WriteProc(ast) {
         return this.gen_proc(ast, 'write', {$adapter: ast.adapter});
-    },
-    gen_FilterProc: function(ast) {
+    }
+    gen_FilterProc(ast) {
         var checker = new DynamicFilterChecker();
         checker.check(ast.filter);
 
@@ -460,8 +461,8 @@ var GraphCompiler = CodeGenerator.extend({
         var code = compiler.compile(ast.filter);
 
         return this.gen_proc(ast, 'filter', {predicate: code});
-    },
-    gen_SequenceProc: function(ast) {
+    }
+    gen_SequenceProc(ast) {
         var checker = new DynamicFilterChecker();
         _.each (ast.filters, (filter) => { checker.check(filter);});
 
@@ -473,11 +474,11 @@ var GraphCompiler = CodeGenerator.extend({
         var code = '[' + filters.join (',') + ']';
 
         return this.gen_proc(ast, 'sequence', {predicates: code});
-    },
-    gen_SortProc: function(ast) {
+    }
+    gen_SortProc(ast) {
         return this.gen_proc(ast, 'sort');
-    },
-    gen_View: function(ast) {
+    }
+    gen_View(ast) {
         // silly special case for ast.name due to sink's special-case parsing
         // and AST.
         var proc = this.gen_proc(ast, 'view', {$name: ast.name});
@@ -487,15 +488,15 @@ var GraphCompiler = CodeGenerator.extend({
                   'location: ' + JSON.stringify(ast.location) + '});\n');
 
         return proc;
-    },
-    gen_CalendarExpression: function(ast) {
+    }
+    gen_CalendarExpression(ast) {
         if (ast.direction === 'up') {
             return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
         } else {
             return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
         }
-    },
-    gen_reducers: function(aName, reducers) {
+    }
+    gen_reducers(aName, reducers) {
         var k, uname, args;
         var code = '';
         for (k = 0; k < reducers.length; ++k) {
@@ -509,8 +510,8 @@ var GraphCompiler = CodeGenerator.extend({
             code += aName + '.push(' + uname + '(' + argstr + '));\n';
         }
         return code;
-    },
-    gen_reifier: function(reducers) {
+    }
+    gen_reifier(reducers) {
         var code = '';
 
         //
@@ -526,8 +527,8 @@ var GraphCompiler = CodeGenerator.extend({
         code += '}';
 
         return code;
-    },
-    gen_ReifierProc: function(ast, which) {
+    }
+    gen_ReifierProc(ast, which) {
         var k;
 
         var maker, expr = 'function(pt, fns) {\n';
@@ -548,15 +549,15 @@ var GraphCompiler = CodeGenerator.extend({
             $reducer_index: reducer_index,
             $lhs: lhs
         });
-    },
+    }
 
-    gen_ReduceProc: function(ast) {
+    gen_ReduceProc(ast) {
         return this.gen_ReifierProc(ast, 'reduce');
-    },
-    gen_PutProc: function(ast) {
+    }
+    gen_PutProc(ast) {
         return this.gen_ReifierProc(ast, 'put');
-    },
-    gen_assignment_lhs: function(ast) {
+    }
+    gen_assignment_lhs(ast) {
         switch (ast.type) {
             case 'UnaryExpression':
                 return this.gen_UnaryExpression(ast, { lhs: true });
@@ -569,9 +570,9 @@ var GraphCompiler = CodeGenerator.extend({
             default:
                 throw new Error('unrecognized expression lhs ' + ast.type);
         }
-    },
+    }
 
-    gen_expr: function(ast) {
+    gen_expr(ast) {
 
         switch (ast.type) {
             case 'AssignmentExpression':
@@ -611,9 +612,9 @@ var GraphCompiler = CodeGenerator.extend({
                 throw new Error('unrecognized expression type ' + ast.type +
                             '\n' + JSON.stringify(ast, 0, 4));
         }
-    },
+    }
 
-    gen_PostfixExpression: function(ast) {
+    gen_PostfixExpression(ast) {
         var expr = this.gen_expr(ast.expression);
         var op = ast.operator;
 
@@ -621,8 +622,8 @@ var GraphCompiler = CodeGenerator.extend({
             + expr
             + ', \'"' + op + '" operator: Invalid operand type (<type>).\'),'
             + expr + op + ')';
-    },
-    gen_FunctionCall: function(ast) {
+    }
+    gen_FunctionCall(ast) {
         var k, code;
         code = 'juttle.ops.call(' + ast.fname;
         if (ast.arguments) {
@@ -633,17 +634,17 @@ var GraphCompiler = CodeGenerator.extend({
         }
         code += ')';
         return code;
-    },
-    gen_ReducerCall: function(ast) {
+    }
+    gen_ReducerCall(ast) {
         var result = 'fns[' + ast.reducer_call_index + '].result()';
         if (ast.context === 'stream') {
             // put must consume the current point before calling result
             result = '(fns[' + ast.reducer_call_index + '].update(pt),' + result + ')';
         }
         return result;
-    },
+    }
 
-    gen_UnaryExpression: function(ast, opts) {
+    gen_UnaryExpression(ast, opts) {
         var expr = this.gen_expr(ast.expression);
         var op = ast.operator;
 
@@ -671,8 +672,8 @@ var GraphCompiler = CodeGenerator.extend({
             default:
                 return 'juttle.ops.' + UNARY_OPS_TO_FUNCTIONS[op] + '(' + expr + ')';
         }
-    },
-    gen_BinaryExpression: function(ast) {
+    }
+    gen_BinaryExpression(ast) {
         var left = this.gen_expr(ast.left);
         var right = this.gen_expr(ast.right);
 
@@ -689,15 +690,15 @@ var GraphCompiler = CodeGenerator.extend({
                 + BINARY_OPS_TO_FUNCTIONS[ast.operator]
                 + '(' + left + ', ' + right + ')';
         }
-    },
-    gen_ConditionalExpression: function(ast) {
+    }
+    gen_ConditionalExpression(ast) {
         return '(juttle.values.ensureBoolean('
             + this.gen_expr(ast.condition)
             + ', \'Ternary operator: Invalid operand type (<type>).\')?('
             + this.gen_expr(ast.trueExpression) + '):('
             + this.gen_expr(ast.falseExpression) + '))';
-    },
-    gen_Variable: function(ast) {
+    }
+    gen_Variable(ast) {
         switch (ast.symbol.type) {
             case 'import':
             case 'function':
@@ -710,16 +711,16 @@ var GraphCompiler = CodeGenerator.extend({
             default:
                 return ast.uname;
         }
-    },
-    gen_Field: function(ast, opts) {
+    }
+    gen_Field(ast, opts) {
         var name = JSON.stringify(ast.name);
         if (opts.lhs) {
             return 'pt[' + name + ']';
         } else {
             return 'juttle.ops.pget(pt,' + name + ')';
         }
-    },
-    gen_MemberExpression: function(ast, opts) {
+    }
+    gen_MemberExpression(ast, opts) {
         if (!ast.computed) {
             return ast.uname;
         } else {
@@ -734,6 +735,6 @@ var GraphCompiler = CodeGenerator.extend({
             }
         }
     }
-});
+}
 
 module.exports = GraphCompiler;

--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var builtin_reducers = require('../runtime/reducers').reducers;
 var errors = require('../errors');
 
@@ -11,29 +10,29 @@ function reset() {
     uid = 0;
 }
 
-var Scope = Base.extend({
-    initialize: function(next, type) {
+class Scope {
+    constructor(next, type) {
         this.next = next;
         this.type = type;
 
         this.symbols = {};
 
         this.arg_uid = uid++;
-    },
-    level: function() {
+    }
+    level() {
         return this.next ? (this.next.level() + 1) : 0;
-    },
-    get: function(name) {
+    }
+    get(name) {
         if (this.symbols.hasOwnProperty(name)) {
             return this.symbols[name];
         }
 
         return this.next ? this.next.get(name) : null;
-    },
-    put: function(name, info) {
+    }
+    put(name, info) {
         this.symbols[name] = info;
-    },
-    lookup: function(name) {
+    }
+    lookup(name) {
         var symbol;
 
         if (this.symbols.hasOwnProperty(name)) {
@@ -47,8 +46,8 @@ var Scope = Base.extend({
         }
 
         return undefined;
-    },
-    lookup_variable: function(name) {
+    }
+    lookup_variable(name) {
         var result = this.lookup(name);
         if (result) {
             return result;
@@ -57,8 +56,8 @@ var Scope = Base.extend({
         } else {
             return undefined;
         }
-    },
-    is_mutable: function(name, opts, context) {
+    }
+    is_mutable(name, opts, context) {
         var symbol;
 
         if (this.symbols.hasOwnProperty(name)) {
@@ -75,8 +74,8 @@ var Scope = Base.extend({
             return this.next.is_mutable(name, opts, context);
         }
         return undefined;
-    },
-    exports: function() {
+    }
+    exports() {
         var result = {};
 
         _.each(this.symbols, function(value, key) {
@@ -86,8 +85,8 @@ var Scope = Base.extend({
         });
 
         return result;
-    },
-    alloc_var: function(sourcename) {
+    }
+    alloc_var(sourcename) {
         var varName, suffix = uid++;// + '_' + this.level();
         if (sourcename) {
             varName = sourcename + '_' + suffix;
@@ -95,33 +94,33 @@ var Scope = Base.extend({
             varName = 'v' + suffix;
         }
         return varName;
-    },
-    define_var: function(name, exported) {
+    }
+    define_var(name, exported) {
         var runtimeVar = this.alloc_var(name);
         this.put(name, { type: 'var', exported: exported, name: runtimeVar });
         return runtimeVar;
-    },
-    define_const: function(name, exported, d) {
+    }
+    define_const(name, exported, d) {
         var runtimeVar = this.alloc_var(name);
         this.put(name, { type: 'const', exported: exported, name: runtimeVar, d: d });
         return runtimeVar;
-    },
-    define_sub: function(name, args, exported) {
+    }
+    define_sub(name, args, exported) {
         var runtimeVar = this.alloc_var(name);
         this.put(name, { type: 'sub', exported: exported, name: runtimeVar, args: args });
         return runtimeVar;
-    },
-    define_func: function(name, exported, arg_count) {
+    }
+    define_func(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
         this.put(name, { type: 'function', exported: exported, arg_count: arg_count, name: runtimeVar });
         return runtimeVar;
-    },
-    define_reducer: function(name, exported, arg_count) {
+    }
+    define_reducer(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
         this.put(name, { type: 'reducer', exported: exported, arg_count: arg_count, name: runtimeVar });
         return runtimeVar;
-    },
-    define_variable: function(name, type, exported, can_redefine, d, location) {
+    }
+    define_variable(name, type, exported, can_redefine, d, location) {
         if (!can_redefine && this.symbols.hasOwnProperty(name)) {
             throw errors.compileError('REDEFINED', {
                 type: type,
@@ -137,17 +136,17 @@ var Scope = Base.extend({
             default:
                 throw new Error('unrecognized variable type ' + type);
         }
-    },
-    fake_builtin_reducer_symbol: function(name) {
+    }
+    fake_builtin_reducer_symbol(name) {
         return {
             type: 'reducer',
             exported: false,
             arg_count: builtin_reducers[name].arg_count,
             name: 'juttle.reducers.' + name + '.fn'
         };
-    },
+    }
 
-    lookup_module_any: function(mod, name, type) {
+    lookup_module_any(mod, name, type) {
         var imp = this.get(mod);
         if (!imp || imp.type !== 'import' || imp.exports[name] === undefined || imp.exports[name].type !== type) {
             return undefined;
@@ -159,24 +158,23 @@ var Scope = Base.extend({
         // module export are simply accessed via the global uname
         //
         return imp.exports[name];
-    },
-    lookup_module_variable: function(mod, name) {
+    }
+    lookup_module_variable(mod, name) {
         if (this.lookup_module_any(mod, name, 'const') !== undefined) {
             return this.lookup_module_any(mod, name, 'const');
         }
         return undefined;
-    },
-    lookup_module_sub: function(mod, name) {
+    }
+    lookup_module_sub(mod, name) {
         return this.lookup_module_any(mod, name, 'sub');
-    },
-    lookup_module_func: function(mod, name) {
+    }
+    lookup_module_func(mod, name) {
         return this.lookup_module_any(mod, name, 'function');
-    },
-    lookup_module_reducer: function(mod, name) {
+    }
+    lookup_module_reducer(mod, name) {
         return this.lookup_module_any(mod, name, 'reducer');
     }
-
-});
+}
 
 module.exports = {
     Scope: Scope,

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -10,7 +10,6 @@
 //   node with resolved names
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var Scope = require('./scope').Scope;
 var reset_scope = require('./scope').reset;
 var StaticInputDetector = require('./static-input-detector');
@@ -44,9 +43,8 @@ const BUILTIN_PROCS = {
     'write': {}
 };
 
-var SemanticPass = Base.extend({
-
-    initialize: function(options) {
+class SemanticPass {
+    constructor(options) {
         reset_scope();
         this.modules = {};
         this.scope = new Scope(null, 'top');
@@ -64,8 +62,8 @@ var SemanticPass = Base.extend({
             imports: 0,
             subs: 0
         };
-    },
-    import_standard_modules: function() {
+    }
+    import_standard_modules() {
         this.import_math_module();
         this.import_null_module();
         this.import_array_module();
@@ -78,8 +76,8 @@ var SemanticPass = Base.extend({
         this.import_object_module();
         this.import_json_module();
         this.import_juttle_module();
-    },
-    import_math_module: function() {
+    }
+    import_math_module() {
         this.scope.put('Math', {
             // everything in the ES 5.1 Math module
             // http://www.ecma-international.org/ecma-262/5.1/#sec-15.8
@@ -117,8 +115,8 @@ var SemanticPass = Base.extend({
                 tan:    { type: 'function', exported: true, name: 'juttle.modules.math.tan',    arg_count: 1             },
             }
         });
-    },
-    import_null_module: function() {
+    }
+    import_null_module() {
         this.scope.put('Null', {
             type: 'import',
             exported: false,
@@ -127,8 +125,8 @@ var SemanticPass = Base.extend({
                 toString: { type: 'function', exported: true, name: 'juttle.modules.null.toString', arg_count: 1 },
             }
         });
-    },
-    import_array_module: function() {
+    }
+    import_array_module() {
         this.scope.put('Array', {
             type: 'import',
             exported: false,
@@ -138,8 +136,8 @@ var SemanticPass = Base.extend({
                 length:  { type: 'function', exported: true, name: 'juttle.modules.array.length',   arg_count: 1 }
             }
         });
-    },
-    import_boolean_module: function() {
+    }
+    import_boolean_module() {
         this.scope.put('Boolean', {
             type: 'import',
             exported: false,
@@ -148,8 +146,8 @@ var SemanticPass = Base.extend({
                 toString: { type: 'function', exported: true, name: 'juttle.modules.boolean.toString', arg_count: 1 },
             }
         });
-    },
-    import_number_module: function() {
+    }
+    import_number_module() {
         this.scope.put('Number', {
             type: 'import',
             exported: false,
@@ -166,8 +164,8 @@ var SemanticPass = Base.extend({
                 toString: { type: 'function', exported: true, name: 'juttle.modules.number.toString', arg_count: 1 },
             }
         });
-    },
-    import_string_module: function() {
+    }
+    import_string_module() {
         this.scope.put('String', {
             type: 'import',
             exported: false,
@@ -188,8 +186,8 @@ var SemanticPass = Base.extend({
                 toUpperCase: { type: 'function', exported: true, name: 'juttle.modules.string.toUpperCase', arg_count: 1   },
             }
         });
-    },
-    import_object_module: function() {
+    }
+    import_object_module() {
         this.scope.put('Object', {
             type: 'import',
             exported: false,
@@ -198,8 +196,8 @@ var SemanticPass = Base.extend({
                 keys: { type: 'function', exported: true, name: 'juttle.modules.object.keys', arg_count: 1 }
             }
         });
-    },
-    import_regexp_module: function() {
+    }
+    import_regexp_module() {
         this.scope.put('RegExp', {
             type: 'import',
             exported: false,
@@ -208,8 +206,8 @@ var SemanticPass = Base.extend({
                 toString: { type: 'function', exported: true, name: 'juttle.modules.regexp.toString', arg_count: 1 },
             }
         });
-    },
-    import_date_module: function() {
+    }
+    import_date_module() {
         this.scope.put('Date', {
             type: 'import',
             exported: false,
@@ -230,8 +228,8 @@ var SemanticPass = Base.extend({
                 unixms:      { type: 'function', exported: true, name: 'juttle.modules.date.unixms',      arg_count: 1      },
             }
         });
-    },
-    import_duration_module: function() {
+    }
+    import_duration_module() {
         this.scope.put('Duration', {
             type: 'import',
             exported: false,
@@ -246,8 +244,8 @@ var SemanticPass = Base.extend({
                 toString:     { type: 'function', exported: true, name: 'juttle.modules.duration.toString',     arg_count: 1 },
             }
         });
-    },
-    import_json_module: function() {
+    }
+    import_json_module() {
         this.scope.put('JSON', {
             type: 'import',
             exported: false,
@@ -256,8 +254,8 @@ var SemanticPass = Base.extend({
                 stringify:   { type: 'function', exported: true, name: 'juttle.modules.json.stringify',   arg_count: 1 },
             }
         });
-    },
-    import_juttle_module: function() {
+    }
+    import_juttle_module() {
         this.scope.put('Juttle', {
             type: 'import',
             exported: false,
@@ -266,8 +264,8 @@ var SemanticPass = Base.extend({
                 adapters: { type: 'function', exported: true, name: 'juttle.modules.juttle.adapters' }
             }
         });
-    },
-    analyze: function(ast) {
+    }
+    analyze(ast) {
         this.module_asts = ast.modules;
 
         var analyzed_ast = this.sa_SubDef(ast);
@@ -276,34 +274,34 @@ var SemanticPass = Base.extend({
         analyzed_ast.stats = this.stats;
 
         return analyzed_ast;
-    },
-    context: function() {
+    }
+    context() {
         return this.scope.type;
-    },
+    }
 
-    sa_var_decl: function(decl, opts) {
+    sa_var_decl(decl, opts) {
         var varname = decl.name;
         if (decl.expr) {
             decl.expr = this.sa_expr(decl.expr, opts);
         }
         decl.uname = this.scope.define_variable(varname, 'var', false, false, false, decl.location);
         return decl;
-    },
-    sa_const_decl: function(decl, exported, can_redefine, opts) {
+    }
+    sa_const_decl(decl, exported, can_redefine, opts) {
         var varname = decl.name;
         decl.expr = this.sa_expr(decl.expr, opts);
         decl.uname = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location);
         return decl;
-    },
+    }
     // a flowgraph node
-    sa_proc: function(ast, opts) {
+    sa_proc(ast, opts) {
         var uname = this.scope.alloc_var();
         //XXX check options and parameters for unknowns and illegals
         ast.uname = uname;
         this.sa_options(ast.options, opts);
         return ast;
-    },
-    sa_sub_call: function(ast, sub) {
+    }
+    sa_sub_call(ast, sub) {
         var that = this;
         ast.uname = this.scope.alloc_var();
         ast.uname_sub = sub.name;
@@ -314,12 +312,12 @@ var SemanticPass = Base.extend({
             return { name: arg.name, required: !arg.default };
         });
         return ast;
-    },
+    }
     //XXX this one operates in place on the option expressions
     //  does not check params
     // XXX should extend this to check for illegal options
     // XXX maybe even try to do some amount of type checking?
-    sa_options: function(options, opts) {
+    sa_options(options, opts) {
         var that = this;
         _.each(options, function(option, index) {
             //XXX need sa_juttle_static_expr() that doesn't operate on stream
@@ -329,19 +327,19 @@ var SemanticPass = Base.extend({
 
             options[index].expr = that.sa_expr(option.expr, opts);
         });
-    },
-    enter_scope: function(context) {
+    }
+    enter_scope(context) {
         this.scope = new Scope(this.scope, context);
-    },
-    exit_scope: function() {
+    }
+    exit_scope() {
         this.scope = this.scope.next;
-    },
-    function_name: function(ast) {
+    }
+    function_name(ast) {
         return ast.name.type !== 'MemberExpression'
             ? ast.name.name
             : ast.name.object.name + '.' + ast.name.property.value;
-    },
-    check_arg_count: function(name, type, actual_count, expected_count, location) {
+    }
+    check_arg_count(name, type, actual_count, expected_count, location) {
         var min_count, max_count;
 
         if (_.isArray(expected_count)) {
@@ -381,8 +379,8 @@ var SemanticPass = Base.extend({
                 });
             }
         }
-    },
-    sa_function_call: function(ast, funcInfo, opts) {
+    }
+    sa_function_call(ast, funcInfo, opts) {
         var k, args = ast.arguments;
         ast.fname = {type: 'function_uname', uname: funcInfo.name};
         this.check_arg_count(this.function_name(ast), 'function', args.length, funcInfo.arg_count, ast.location);
@@ -402,29 +400,29 @@ var SemanticPass = Base.extend({
             ast.d = false;
         }
         return ast;
-    },
-    can_export: function() {
+    }
+    can_export() {
         return (this.context() === 'module' || this.context() === 'main');
-    },
-    check_export: function(ast) {
+    }
+    check_export(ast) {
         if (ast.export  && !this.can_export()) {
             throw errors.compileError('NON-TOPLEVEL-EXPORT', {
                 context: this.context(),
                 location: ast.location
             });
         }
-    },
-    check_reducer_toplevel: function(ast, thing) {
+    }
+    check_reducer_toplevel(ast, thing) {
         if (this.context() === 'reducer') {
             throw errors.compileError('REDUCER-TOPLEVEL-STATEMENT', {
                 thing: thing,
                 location: ast.location
             });
         }
-    },
+    }
 
     // statements that can appear inside subs or at the top level
-    sa_statement: function(ast) {
+    sa_statement(ast) {
         switch (ast.type) {
 
             case 'SubDef':
@@ -443,8 +441,8 @@ var SemanticPass = Base.extend({
             default:
                 throw new Error('unrecognized statement type ' + ast.type);
         }
-    },
-    sa_ModuleDef: function(ast) {
+    }
+    sa_ModuleDef(ast) {
         // turn module name into valid js identifier since
         // it will be used in the runtime module name
         //XXX/sm I don't understand this... this doesn't seem fully robust
@@ -469,8 +467,8 @@ var SemanticPass = Base.extend({
         };
         this.scope = saved_scope;
         return ast;
-    },
-    sa_SubDef: function(ast) {
+    }
+    sa_SubDef(ast) {
         var uname, elems, k, has_graph;
 
         this.check_export(ast);
@@ -499,10 +497,10 @@ var SemanticPass = Base.extend({
         }
 
         return ast;
-    },
+    }
 
     // statements that can appear inside functions or reducers
-    sa_function_statement: function(ast, opts) {
+    sa_function_statement(ast, opts) {
         opts = opts || {};
         switch (ast.type) {
             case 'StatementBlock':
@@ -519,8 +517,8 @@ var SemanticPass = Base.extend({
             default:
                 throw new Error('unrecognized function statement type ' + ast.type);
         }
-    },
-    sa_args: function(args) {
+    }
+    sa_args(args) {
         var is_optional;
         var seen_optional = false;
 
@@ -537,15 +535,15 @@ var SemanticPass = Base.extend({
             seen_optional = is_optional;
         }
         return args;
-    },
-    compute_arg_count: function(args) {
+    }
+    compute_arg_count(args) {
         var requiredArgs = _.filter(args, function(arg) {
             return !arg.default;
         });
 
         return [requiredArgs.length, args.length];
-    },
-    sa_FormalArg: function(ast) {
+    }
+    sa_FormalArg(ast) {
         ast.uname = this.context().match(/fn/) || this.context() === 'reducer'
             ? this.scope.define_var(ast.name, false)
             : this.scope.define_const(ast.name, false, true);
@@ -555,8 +553,8 @@ var SemanticPass = Base.extend({
         }
 
         return ast;
-    },
-    sa_FunctionDef: function(ast, opts) {
+    }
+    sa_FunctionDef(ast, opts) {
         var elems, uname  = this.scope.define_func(ast.name, ast.export, this.compute_arg_count(ast.args));
         ast.uname = uname;
         this.check_export(ast);
@@ -573,9 +571,9 @@ var SemanticPass = Base.extend({
         this.exit_scope();
 
         return ast;
-    },
+    }
 
-    sa_ReducerDef: function(ast) {
+    sa_ReducerDef(ast) {
         var k, elems;
         var uname = this.scope.define_reducer(ast.name, ast.export, this.compute_arg_count(ast.args));
         ast.uname = uname;
@@ -621,8 +619,8 @@ var SemanticPass = Base.extend({
         this.exit_scope();
 
         return ast;
-    },
-    sa_StatementBlock: function(ast, opts) {
+    }
+    sa_StatementBlock(ast, opts) {
         this.check_reducer_toplevel(ast, 'a block');
 
         var elems = ast.elements;
@@ -632,9 +630,9 @@ var SemanticPass = Base.extend({
         }
         this.exit_scope();
         return ast;
-    },
+    }
     // elements of a flowgraph
-    sa_proc_element: function(ast) {
+    sa_proc_element(ast) {
         // XXX
         var methods = {
             ParallelGraph: this.sa_ParallelGraph,
@@ -660,9 +658,9 @@ var SemanticPass = Base.extend({
         }
 
         throw new Error('unrecognized processor or sub: ' + ast.type);
-    },
+    }
 
-    sa_graph: function(ast) {
+    sa_graph(ast) {
         var k, elems = ast.elements;
 
         // ignore top-level flowgraphs for imported modules
@@ -677,21 +675,21 @@ var SemanticPass = Base.extend({
             elems[k] = this.sa_proc_element(elems[k]);
         }
         return ast;
-    },
+    }
 
-    sa_SequentialGraph: function(ast) {
+    sa_SequentialGraph(ast) {
         return this.sa_graph(ast);
-    },
-    sa_ParallelGraph: function(ast) {
+    }
+    sa_ParallelGraph(ast) {
         return this.sa_graph(ast);
-    },
+    }
 
-    sa_EmptyStatement: function(ast, opts) {
+    sa_EmptyStatement(ast, opts) {
         return ast;
-    },
+    }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    sa_AssignmentStatement: function(ast, opts) {
+    sa_AssignmentStatement(ast, opts) {
         this.check_reducer_toplevel(ast, 'an assignment');
 
         opts = opts || {};
@@ -699,24 +697,24 @@ var SemanticPass = Base.extend({
         //XXX need to handle op's other than "="
         ast.expr = this.sa_expr(ast.expr, opts);
         return ast;
-    },
+    }
     // this type of assignment lives in places where there can be
     // points or reducers
-    sa_AssignmentExpression: function(ast, opts) {
+    sa_AssignmentExpression(ast, opts) {
         ast.left = this.sa_assignment_lhs(ast.left, opts);
         ast.right = this.sa_expr(ast.right, opts);
         ast.d = ast.left.d && ast.right.d;
         return ast;
-    },
-    sa_VarStatement: function(ast, opts) {
+    }
+    sa_VarStatement(ast, opts) {
         opts = opts || {};
         var k, decls = ast.declarations;
         for (k = 0; k < decls.length; ++k) {
             decls[k] = this.sa_var_decl(decls[k], opts);
         }
         return ast;
-    },
-    sa_InputStatement: function(ast, opts) {
+    }
+    sa_InputStatement(ast, opts) {
         var self = this;
         opts = opts || {};
 
@@ -739,8 +737,8 @@ var SemanticPass = Base.extend({
         ast.static = detector.isStatic(ast);
 
         return ast;
-    },
-    sa_ConstStatement: function(ast, opts) {
+    }
+    sa_ConstStatement(ast, opts) {
         opts = opts || {};
         var k, decls = ast.declarations;
         this.check_export(ast);
@@ -754,8 +752,8 @@ var SemanticPass = Base.extend({
             decls[k] = this.sa_const_decl(decls[k], ast.export, ast.arg, opts);
         }
         return ast;
-    },
-    sa_ImportStatement: function(ast, functions) {
+    }
+    sa_ImportStatement(ast, functions) {
         var self = this;
         var modulename = ast.modulename.value;
 
@@ -797,9 +795,9 @@ var SemanticPass = Base.extend({
         this.stats.imports++;
 
         return ast;
-    },
+    }
 
-    sa_IfStatement: function(ast, opts) {
+    sa_IfStatement(ast, opts) {
         this.check_reducer_toplevel(ast, 'an if statement');
 
         ast.condition = this.sa_expr(ast.condition, opts);
@@ -809,46 +807,46 @@ var SemanticPass = Base.extend({
                                                            opts);
         }
         return ast;
-    },
-    sa_ReturnStatement: function(ast, opts) {
+    }
+    sa_ReturnStatement(ast, opts) {
         this.check_reducer_toplevel(ast, 'a return statement');
 
         if (ast.value) {
             ast.value = this.sa_expr(ast.value, opts);
         }
         return ast;
-    },
-    sa_ErrorStatement: function(ast, opts) {
+    }
+    sa_ErrorStatement(ast, opts) {
         ast.message = this.sa_expr(ast.message, opts);
         return ast;
-    },
+    }
 
-    sa_ExpressionFilterTerm: function(ast, opts) {
+    sa_ExpressionFilterTerm(ast, opts) {
         ast.expression = this.sa_expr(ast.expression, { context: 'filter', coerce_var: 'field' });
         // will be carried in AST form to a proc implementation
         ast.expression.d = false;
         ast.d = false;
         return ast;
-    },
-    sa_SimpleFilterTerm: function(ast) {
+    }
+    sa_SimpleFilterTerm(ast) {
         ast.expression = this.sa_expr(ast.expression);
         // will be carried in AST form to a proc implementation
         ast.d = false;
         return ast;
-    },
-    sa_FilterLiteral: function(ast) {
+    }
+    sa_FilterLiteral(ast) {
         ast.ast = this.sa_expr(ast.ast);
         // will be carried in AST form to a proc implementation
         ast.d = false;
         return ast;
-    },
-    sa_filter_proc: function(ast, opts) {
+    }
+    sa_filter_proc(ast, opts) {
         if (ast.filter) {
             ast.filter = this.sa_expr(ast.filter, opts);
         }
         return this.sa_proc(ast);
-    },
-    sa_sequence_proc: function(ast) {
+    }
+    sa_sequence_proc(ast) {
         var self = this;
         if (ast.filters.length < 2) {
             throw errors.compileError('PROC-NEEDS-ARG', {
@@ -862,17 +860,17 @@ var SemanticPass = Base.extend({
         }
         ast.filters = _.map(ast.filters, function (ast) { return self.sa_expr(ast); });
         return this.sa_proc(ast);
-    },
-    sa_FilterProc: function(ast) {
+    }
+    sa_FilterProc(ast) {
         return this.sa_filter_proc(ast, { allow_field_comparisons: true });
-    },
-    sa_SequenceProc: function(ast) {
+    }
+    sa_SequenceProc(ast) {
         return this.sa_sequence_proc(ast);
-    },
-    sa_ReadProc: function(ast) {
+    }
+    sa_ReadProc(ast) {
         return this.sa_filter_proc(ast, { allow_field_comparisons: false });
-    },
-    sa_option_proc: function(ast, options) {
+    }
+    sa_option_proc(ast, options) {
         // Some procs have syntactical sugar for parameters (e.g. the limit in
         // `head 10` or the bylist in `reduce by a, b`). They show up as named
         // attributes in the AST. We convert those into options (which are
@@ -886,11 +884,11 @@ var SemanticPass = Base.extend({
             }
         });
         return this.sa_proc(ast);
-    },
-    sa_SortProc: function(ast) {
+    }
+    sa_SortProc(ast) {
         return this.sa_option_proc(ast, ['groupby', 'columns']);
-    },
-    sa_View: function(ast) {
+    }
+    sa_View(ast) {
         // The "coerce_var" option needs to be set explicitly so that sa_ByList
         // doesn't override.
         var opts = {
@@ -898,8 +896,8 @@ var SemanticPass = Base.extend({
         };
 
         return this.sa_proc(ast, opts);
-    },
-    sa_ObjectLiteral: function(ast, opts) {
+    }
+    sa_ObjectLiteral(ast, opts) {
         var k, props;
         var d = true;
         props = ast.properties;
@@ -909,18 +907,18 @@ var SemanticPass = Base.extend({
         }
         ast.d = d;
         return ast;
-    },
-    sa_ObjectProperty: function(ast, opts) {
+    }
+    sa_ObjectProperty(ast, opts) {
         ast.key = this.sa_expr(ast.key, opts);
         ast.value = this.sa_expr(ast.value, opts);
         ast.d = ast.key.d && ast.value.d;
         return ast;
-    },
-    sa_RegExpLiteral: function(ast) {
+    }
+    sa_RegExpLiteral(ast) {
         ast.d = true;
         return ast;
-    },
-    sa_reducer_arg: function(arg, opts) {
+    }
+    sa_reducer_arg(arg, opts) {
         // coerce a naked name to a string (ie a field name) if it
         // isn't visible as a variable.
         if (arg.type === 'Variable'
@@ -940,7 +938,7 @@ var SemanticPass = Base.extend({
             // reducer *arguments* are evaluated at build time
             return this.sa_expr(arg, {context:'build'});
         }
-    },
+    }
     //
     // returns an array of objects one for each reducer used in the expressions
     // previously parsed. this gets added to the tree for later use.
@@ -949,7 +947,7 @@ var SemanticPass = Base.extend({
     // in the target language (as of 2014, just javascript) and available
     // in the juttle runtime
     //
-    sa_reducers: function(reducers) {
+    sa_reducers(reducers) {
         var k, op, args, reducerInfo, index;
         var out = [];
         for (k = 0; k < reducers.length; ++k) {
@@ -974,8 +972,8 @@ var SemanticPass = Base.extend({
                 arguments: args });
         }
         return out;
-    },
-    sa_reifier_proc: function(ast, opts) {
+    }
+    sa_reifier_proc(ast, opts) {
         var k, reducers = [];
         opts.reducers = reducers;
 
@@ -997,8 +995,8 @@ var SemanticPass = Base.extend({
             delete ast.groupby;
         }
         return this.sa_proc(ast);
-    },
-    sa_ReduceProc: function(ast) {
+    }
+    sa_ReduceProc(ast) {
         var reified = this.sa_reifier_proc(ast, {context: 'reduce'});
         reified.reducers.forEach(function(reducer) {
             if (reducer.name === 'delta') {
@@ -1008,13 +1006,13 @@ var SemanticPass = Base.extend({
             }
         });
         return reified;
-    },
-    sa_PutProc: function(ast) {
+    }
+    sa_PutProc(ast) {
         return this.sa_reifier_proc(ast, {context: 'stream',
                                          coerce_var: 'field'});
-    },
+    }
 
-    sa_builtin_proc: function(ast) {
+    sa_builtin_proc(ast) {
         ast.type = 'BuiltinProc';
 
         _.each(BUILTIN_PROCS[ast.name].maybe, function(attrname) {
@@ -1035,20 +1033,20 @@ var SemanticPass = Base.extend({
             delete ast[attrname];
         });
         return this.sa_proc(ast);
-    },
-    sa_OptionOnlyProc: function(ast) {
+    }
+    sa_OptionOnlyProc(ast) {
         return this.sa_builtin_proc(ast);
-    },
-    sa_WriteProc: function(ast) {
+    }
+    sa_WriteProc(ast) {
         return this.sa_proc(ast);
-    },
-    sa_SingleArgProc: function(ast) {
+    }
+    sa_SingleArgProc(ast) {
         return this.sa_builtin_proc(ast);
-    },
-    sa_FieldListArgProc: function(ast) {
+    }
+    sa_FieldListArgProc(ast) {
         return this.sa_builtin_proc(ast);
-    },
-    sa_FunctionProc: function(ast) {
+    }
+    sa_FunctionProc(ast) {
         var sub;
 
         if (ast.op.type === 'MemberExpression') {
@@ -1081,9 +1079,9 @@ var SemanticPass = Base.extend({
 
         this.stats.subs++;
         return this.sa_sub_call(ast, sub);
-    },
+    }
 
-    sa_assignment_lhs: function(ast, opts) {
+    sa_assignment_lhs(ast, opts) {
         switch (ast.type) {
             case 'UnaryExpression':
                 ast = this.sa_UnaryExpression(ast, opts);
@@ -1119,9 +1117,9 @@ var SemanticPass = Base.extend({
             default:
                 throw new Error('unrecognized expression lhs ' + ast.type);
         }
-    },
+    }
 
-    sa_expr: function(ast, opts) {
+    sa_expr(ast, opts) {
         opts = opts || {};
         switch (ast.type) {
             case 'NullLiteral':
@@ -1159,9 +1157,9 @@ var SemanticPass = Base.extend({
             default:
                 throw new Error('unrecognized expression type ' + ast.type);
         }
-    },
+    }
 
-    sa_PostfixExpression: function(ast, opts) {
+    sa_PostfixExpression(ast, opts) {
         var name;
         switch (ast.expression.type) {
             case 'Variable':
@@ -1183,8 +1181,8 @@ var SemanticPass = Base.extend({
                     location: ast.location
                 });
         }
-    },
-    sa_FunctionCall: function(ast, opts) {
+    }
+    sa_FunctionCall(ast, opts) {
         var fname, args, funcInfo, i;
         if (ast.name.type === 'MemberExpression') {
             args = ast.arguments;
@@ -1270,8 +1268,8 @@ var SemanticPass = Base.extend({
             ast.name.symbol = funcInfo;
             return this.sa_function_call(ast, funcInfo, opts);
         }
-    },
-    sa_UnaryExpression: function(ast, opts) {
+    }
+    sa_UnaryExpression(ast, opts) {
         var op = ast.operator;
         var name;
 
@@ -1299,22 +1297,22 @@ var SemanticPass = Base.extend({
             }
         }
         return ast;
-    },
-    sa_BinaryExpression: function(ast, opts) {
+    }
+    sa_BinaryExpression(ast, opts) {
         ast.left = this.sa_expr(ast.left, opts);
         ast.right = this.sa_expr(ast.right, opts);
         ast.d = ast.left.d && ast.right.d;
         return ast;
-    },
-    sa_ConditionalExpression: function(ast, opts) {
+    }
+    sa_ConditionalExpression(ast, opts) {
         ast.condition = this.sa_expr(ast.condition, opts);
         ast.trueExpression = this.sa_expr(ast.trueExpression, opts);
         ast.falseExpression = this.sa_expr(ast.falseExpression, opts);
         //XXX can be smarter than this
         ast.d = ast.condition.d && ast.trueExpression.d && ast.falseExpression.d;
         return ast;
-    },
-    sa_MultipartStringLiteral: function(ast, opts) {
+    }
+    sa_MultipartStringLiteral(ast, opts) {
         var k;
         var d = true;
         for (k = 0; k < ast.parts.length; k++) {
@@ -1323,8 +1321,8 @@ var SemanticPass = Base.extend({
         }
         ast.d = d;
         return ast;
-    },
-    sa_ArrayLiteral: function(ast, opts) {
+    }
+    sa_ArrayLiteral(ast, opts) {
         var k;
         var d = true;
         for (k = 0; k < ast.elements.length; k++) {
@@ -1333,8 +1331,8 @@ var SemanticPass = Base.extend({
         }
         ast.d = d;
         return ast;
-    },
-    sa_ByList: function(ast, opts) {
+    }
+    sa_ByList(ast, opts) {
         var k, elem = ast.elements;
         var d = true;
         if (!opts.coerce_var) {
@@ -1353,8 +1351,8 @@ var SemanticPass = Base.extend({
         }
         ast.d = d;
         return ast;
-    },
-    sa_SortByList: function(ast) {
+    }
+    sa_SortByList(ast) {
         var k, elem = ast.elements;
         var d = true;
         var opts = {coerce_var:'string'};
@@ -1364,8 +1362,8 @@ var SemanticPass = Base.extend({
         }
         ast.d = d;
         return ast;
-    },
-    sa_Variable: function(ast, opts) {
+    }
+    sa_Variable(ast, opts) {
         var varInfo = this.scope.get(ast.name);
 
         if (varInfo) {
@@ -1399,8 +1397,8 @@ var SemanticPass = Base.extend({
                     });
             }
         }
-    },
-    sa_Field: function(ast, opts) {
+    }
+    sa_Field(ast, opts) {
         if (opts.context !== 'stream' && opts.context !== 'reduce' && opts.context !== 'filter') {
             throw errors.compileError('INVALID-FIELD-REFERENCE', {
                 location: ast.location
@@ -1408,13 +1406,13 @@ var SemanticPass = Base.extend({
         }
         ast.d = false;
         return ast;
-    },
-    sa_ToString: function(ast, opts) {
+    }
+    sa_ToString(ast, opts) {
         ast.expression = this.sa_expr(ast.expression, opts);
         ast.d = ast.expression.d;
         return ast;
-    },
-    sa_MemberExpression: function(ast, opts) {
+    }
+    sa_MemberExpression(ast, opts) {
         var varInfo;
         if (!ast.computed) {
             varInfo = this.scope.lookup_module_variable(ast.object.name, ast.property.value);
@@ -1441,6 +1439,6 @@ var SemanticPass = Base.extend({
         }
         return ast;
     }
-});
+}
 
 module.exports = SemanticPass;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -18,6 +18,32 @@ var errors = require('../errors');
 
 var is_builtin_reducer = require('../runtime/reducers').is_builtin_reducer;
 
+// Rather than do builtin proc analysis in this ad hoc way, we should add builtins
+// to the scope (similary to how had we add builtin modules), but we can't
+// just handle built-ins as subs, because we don't want the strict
+// arity-checking they have. (Also the goal of this work is to eventually
+// get rid of subs). So in a second pass we should get rid of this and
+// unify the way the compiler handles user-defined subs and built-in subs (and while
+// we're at it support optional user-defined sub arguments, for
+// conveniency, and also for consistency with builtins).
+const BUILTIN_PROCS = {
+    'batch': { maybe: ['arg'] },
+    'emit': {},
+    'head': { maybe: ['arg', 'groupby'] },
+    'join': { maybe: ['columns'] },
+    'keep': { always: ['columns'] },
+    'pace': {},
+    'pass': {},
+    'remove': { always: ['columns'] },
+    'read': {},
+    'skip': { maybe: ['arg', 'groupby'] },
+    'split': { maybe: ['columns'] },
+    'tail': { maybe: ['arg', 'groupby'] },
+    'uniq': { maybe: ['arg', 'groupby'] },
+    'unbatch': {},
+    'write': {}
+};
+
 var SemanticPass = Base.extend({
 
     initialize: function(options) {
@@ -988,42 +1014,17 @@ var SemanticPass = Base.extend({
                                          coerce_var: 'field'});
     },
 
-    // Rather than do builtin proc analysis in this ad hoc way, we should add builtins
-    // to the scope (similary to how had we add builtin modules), but we can't
-    // just handle built-ins as subs, because we don't want the strict
-    // arity-checking they have. (Also the goal of this work is to eventually
-    // get rid of subs). So in a second pass we should get rid of this and
-    // unify the way the compiler handles user-defined subs and built-in subs (and while
-    // we're at it support optional user-defined sub arguments, for
-    // conveniency, and also for consistency with builtins).
-    builtin_procs:  {
-        'batch': { maybe: ['arg'] },
-        'emit': {},
-        'head': { maybe: ['arg', 'groupby'] },
-        'join': { maybe: ['columns'] },
-        'keep': { always: ['columns'] },
-        'pace': {},
-        'pass': {},
-        'remove': { always: ['columns'] },
-        'read': {},
-        'skip': { maybe: ['arg', 'groupby'] },
-        'split': { maybe: ['columns'] },
-        'tail': { maybe: ['arg', 'groupby'] },
-        'uniq': { maybe: ['arg', 'groupby'] },
-        'unbatch': {},
-        'write': {}
-    },
     sa_builtin_proc: function(ast) {
         ast.type = 'BuiltinProc';
 
-        _.each(this.builtin_procs[ast.name].maybe, function(attrname) {
+        _.each(BUILTIN_PROCS[ast.name].maybe, function(attrname) {
             if (ast[attrname]) {
                 ast.options.push({id: attrname, expr: ast[attrname]});
                 delete ast[attrname];
             }
         });
 
-        _.each(this.builtin_procs[ast.name].always, function(attrname) {
+        _.each(BUILTIN_PROCS[ast.name].always, function(attrname) {
             if (!ast[attrname]) {
                 throw errors.compileError('PROC-NEEDS-ARG', {
                     name: ast.name,

--- a/lib/compiler/static-input-detector.js
+++ b/lib/compiler/static-input-detector.js
@@ -11,16 +11,16 @@
 
 var ASTVisitor = require('./ast-visitor');
 
-var StaticInputDetector = ASTVisitor.extend({
-    isStatic: function(node) {
+class StaticInputDetector extends ASTVisitor {
+    isStatic(node) {
         this.result = true;
         this.visit(node);
         return this.result;
-    },
+    }
 
-    visitVariable: function() {
+    visitVariable() {
         this.result = false;
     }
-});
+}
 
 module.exports = StaticInputDetector;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,7 +2,6 @@
 
 // Juttle exception classes and related helper functions.
 
-var Base = require('extendable-base');
 var messages = require('./messages');
 
 // Base class of all Juttle exceptions. Idally, all exceptions thrown by the
@@ -11,8 +10,9 @@ var messages = require('./messages');
 //
 // Don't throw this exception directly, use its subclasses and related helpers
 // instead.
-var JuttleError = Base.inherits(Error, {
-    initialize: function(message, code, info) {
+class JuttleError extends Error {
+    constructor(message, code, info) {
+        super(message, code, info);
         this.name = 'JuttleError';
         this.message = message;
         this.code = code;
@@ -22,37 +22,40 @@ var JuttleError = Base.inherits(Error, {
             Error.captureStackTrace(this, this.constructor);
         }
     }
-});
+}
 
 // Exception thrown when Juttle program parsing fails.
 //
 // Don't throw this exception directly, use the syntaxError helper instead.
-var SyntaxError_ = JuttleError.extend({
-    initialize: function(message, code, info) {
+class SyntaxError_ extends JuttleError {
+    constructor(message, code, info) {
+        super(message, code, info);
         this.name = 'SyntaxError';
     }
-});
+}
 
 // Exception thrown when Juttle program compilation fails. Compilation includes
 // everything that happens before points start flowing through the graph (e.g.
 // proc initialization).
 //
 // Don't throw this exception directly, use the compileError helper instead.
-var CompileError = JuttleError.extend({
-    initialize: function(message, code, info) {
+class CompileError extends JuttleError {
+    constructor(message, code, info) {
+        super(message, code, info);
         this.name = 'CompileError';
     }
-});
+}
 
 // Exception thrown when Juttle program fails at runtime. Runtime is the time
 // when points flow through the graph.
 //
 // Don't throw this exception directly, use the runtimeError helper instead.
-var RuntimeError = JuttleError.extend({
-    initialize: function(message, code, info) {
+class RuntimeError extends JuttleError {
+    constructor(message, code, info) {
+        super(message, code, info);
         this.name = 'RuntimeError';
     }
-});
+}
 
 // Build a SyntaxError with given code and info. Its message will be created
 // automatically using the messages file.

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -2,17 +2,16 @@
 
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var values = require('./runtime/values');
 var build_pname = require('./compiler/graph-builder').build_pname;
 
 
-var Graph = Base.extend({
-    get_inputs: function() {
+class Graph {
+    get_inputs() {
         return this.built_graph.inputs;
-    },
+    }
 
-    add_node: function(type, name) {
+    add_node(type, name) {
         var index = this.get_nodes().length;
         var new_pname = build_pname(index);
 
@@ -27,25 +26,25 @@ var Graph = Base.extend({
         }
         this.built_graph.nodes.push(node);
         return node;
-    },
-    get_roots: function() {
+    }
+    get_roots() {
         return _.filter(this.built_graph.nodes, function(node) { return node.in.length === 0;});
-    },
-    get_leaves: function() {
+    }
+    get_leaves() {
         return _.filter(this.built_graph.nodes, function(node) { return node.out.length === 0;});
-    },
-    _get_node: function(pname) {
+    }
+    _get_node(pname) {
         return _.findWhere(this.built_graph.nodes, {pname: pname});
-    },
-    get_nodes: function() {
+    }
+    get_nodes() {
         return this.built_graph.nodes;
-    },
-    node_get_outputs: function(node) {
+    }
+    node_get_outputs(node) {
         var self = this;
         return _.map(node.out, function(pname) { return self._get_node(pname);});
-    },
+    }
 
-    swap_neighbors: function(left, right) {
+    swap_neighbors(left, right) {
         var left_inputs = this.node_get_inputs(left);
         var right_outputs = this.node_get_outputs(right);
 
@@ -66,13 +65,13 @@ var Graph = Base.extend({
             this.remove_edge(right, node);
             this.add_edge(left, node);
         }, this);
-    },
-    node_get_inputs: function(node) {
+    }
+    node_get_inputs(node) {
         var self = this;
         return _.map(node.in, function(pname) { return self._get_node(pname);});
-    },
+    }
     // If an option with this name is already present, it will be overridden
-    node_set_option: function(node, name, value) {
+    node_set_option(node, name, value) {
         var ast = values.toAST(value);
         var opt_ast = _.findWhere(node.options, {id: name});
         if (opt_ast) {
@@ -80,52 +79,52 @@ var Graph = Base.extend({
         } else {
             node.options.push({id: name, val: ast});
         }
-    },
-    node_set_param: function(node, name, value) {
+    }
+    node_set_param(node, name, value) {
         node[name] = value;
-    },
-    node_has_option: function(node, name) {
+    }
+    node_has_option(node, name) {
         var opt_ast = _.findWhere(node.options, {id: name});
         return opt_ast !== undefined;
-    },
-    node_get_param: function(node, name) {
+    }
+    node_get_param(node, name) {
         return node[name];
-    },
-    node_get_option_names: function(node) {
+    }
+    node_get_option_names(node) {
         return _.pluck(node.options, 'id');
-    },
-    node_get_option: function(node, name) {
+    }
+    node_get_option(node, name) {
         var opt_ast = _.findWhere(node.options, {id: name});
 
         if (opt_ast === undefined) {
             return undefined;
         }
         return values.fromAST(opt_ast.val);
-    },
+    }
     // Returns whether or not the given node has only the given option keys
-    node_contains_only_options: function(node, options) {
+    node_contains_only_options(node, options) {
         return _.difference(this.node_get_option_names(node), options).length === 0;
-    },
+    }
     // Danger! If you add an edge between nodes that are already connected by
     // another directed path, fan-in accounting at the dest will likely be
     // confused, with unpredictable runtime results.
-    add_edge: function(src, dest) {
+    add_edge(src, dest) {
         if (_.contains(src.out, dest.pname)) {
             throw new Error('Invalid edge');
         }
         src.out.push(dest.pname);
         dest.in.push(src.pname);
-    },
+    }
 
-    remove_edge: function(src, dest) {
+    remove_edge(src, dest) {
         if (!_.contains(src.out, dest.pname)) {
             throw new Error('Invalid edge: does not exist');
         }
 
         src.out = _.without(src.out, dest.pname);
         dest.in = _.without(dest.in, src.pname);
-    },
-    remove_node: function(node) {
+    }
+    remove_node(node) {
         var self = this;
         var inputs = this.node_get_inputs(node);
         var outputs = this.node_get_outputs(node);
@@ -150,12 +149,12 @@ var Graph = Base.extend({
         }
 
         this.built_graph.nodes.splice(index, 1);
-    },
+    }
     // Unlike edges, shortcuts can be added between nodes that already have a
     // directed path between them. This works by having the shortcut appear
     // (to the dest) to be coming from a 'pair' node rather than the actual
     // source. The pair must be connected to one of the dest's inputs.
-    add_shortcut: function(src, pair, dest, shortcut_name) {
+    add_shortcut(src, pair, dest, shortcut_name) {
         if (!_.contains(dest.in, pair.pname)) {
             throw new Error('Invalid shortcut (pair)');
         }
@@ -166,6 +165,6 @@ var Graph = Base.extend({
                             pair: pair.pname,
                             name: shortcut_name});
     }
-});
+}
 
 module.exports = Graph;

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -4,7 +4,6 @@
 var fs = require('fs');
 var path = require('path');
 var Promise = require('bluebird');
-var Base = require('extendable-base');
 
 function search_paths() {
     var env = process.env;
@@ -16,8 +15,8 @@ function search_paths() {
     return paths;
 }
 
-var FileResolver = Base.extend({
-    initialize: function(options) {
+class FileResolver {
+    constructor(options) {
         var self = this;
 
         options = options || {};
@@ -28,18 +27,18 @@ var FileResolver = Base.extend({
         self._additional_search_paths = options.search_paths || search_paths();
 
         self.resolve = self._resolve.bind(self);
-    },
+    }
 
-    _is_file: function (module_path) {
+    _is_file(module_path) {
         try {
             var stats = fs.statSync(module_path);
             return stats.isFile();
         } catch (e) {
             return false;
         }
-    },
+    }
 
-    _search: function(module_path) {
+    _search(module_path) {
         var self = this;
 
         var k, paths = self._search_paths;
@@ -59,9 +58,9 @@ var FileResolver = Base.extend({
             }
         }
         return false;
-    },
+    }
 
-    _resolve: function(module_path) {
+    _resolve(module_path) {
         var self = this;
 
         var src_code = self._search(module_path);
@@ -70,7 +69,7 @@ var FileResolver = Base.extend({
         }
         return Promise.resolve({ source: src_code, name: module_path});
     }
-});
+}
 
 module.exports = FileResolver;
 

--- a/lib/module-resolvers/url-resolver.js
+++ b/lib/module-resolvers/url-resolver.js
@@ -1,22 +1,20 @@
 'use strict';
 
 var Promise = require('bluebird');
-var Base = require('extendable-base');
 
 /* globals global */
 global.Promise = Promise;
 
 var fetch = require('isomorphic-fetch');
 
-var URLResolver = Base.extend({
-
-    initialize: function(options) {
+class URLResolver {
+    constructor(options) {
         var self = this;
 
         self.resolve = self._resolve.bind(self);
-    },
+    }
 
-    _resolve: function(path) {
+    _resolve(path) {
         if (path.indexOf('http') !== 0) {
             return Promise.reject('Invalid URL: ' + path);
         } else {
@@ -36,6 +34,6 @@ var URLResolver = Base.extend({
                 });
         }
     }
-});
+}
 
 module.exports = URLResolver;

--- a/lib/program.js
+++ b/lib/program.js
@@ -2,7 +2,6 @@
 
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var Promise = require('bluebird');
 
 var juttle = require('./runtime').runtime;
@@ -13,15 +12,15 @@ var view = require('./runtime/procs/view');
 var errors = require('./errors');
 
 
-var Program = Base.extend({
-    initialize: function() {
+class Program {
+    constructor() {
         this.env = {};
         this.visitGen = 0;
-    },
-    set_env: function(env) {
+    }
+    set_env(env) {
         this.env = _.extend(this.env, env);
-    },
-    deactivate: function() {
+    }
+    deactivate() {
         var k;
         this.scheduler.stop();
         if (this.graph) {
@@ -32,21 +31,21 @@ var Program = Base.extend({
                 this.graph.head[k].deactivate(this.visitGen);
             }
         }
-    },
-    _eval: function() {
+    }
+    _eval() {
         var o = eval(this.code)(juttle);
         this.set_env({now: o.now});
         this.graph = o.graph;
         o.program.scheduler = this.scheduler;
-    },
+    }
     // Returns a promise that is resolved when the program completes execution,
     // which is determined when all of the sinks have seen an eof.
-    done: function() {
+    done() {
         return Promise.settle(_.map(this.get_sinks(), function(sink) {
             return sink.isDone;
         }));
-    },
-    activate: function() {
+    }
+    activate() {
         var env = this.env;
         var events = this.events;
         _.each(this.get_nodes(), function(node) {
@@ -58,8 +57,8 @@ var Program = Base.extend({
         });
 
         this.scheduler.start();
-    },
-    _validate_sources: function() {
+    }
+    _validate_sources() {
         var sources = this.get_sources();
 
         // Check that all heads are sources.
@@ -81,9 +80,9 @@ var Program = Base.extend({
                 location: invalidSources[0].location
             });
         }
-    },
+    }
 
-    _validate_sinks: function() {
+    _validate_sinks() {
         var sinks = this.get_sinks();
         var terminalNodes = this.get_terminal_nodes();
 
@@ -106,16 +105,16 @@ var Program = Base.extend({
                 location: invalidSinks[0].location
             });
         }
-    },
+    }
 
-    get_sources: function() {
+    get_sources() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
             return (proc instanceof source);
         });
-    },
+    }
 
     // returns a list of the views of this program, formatted for use by the app
-    get_views: function() {
+    get_views() {
         var allSinks = this.get_sinks();
         return _.filter(allSinks, function(sink) {
             return (sink instanceof view);
@@ -123,35 +122,35 @@ var Program = Base.extend({
         .map(function(view) {
             return {name: view.name, channel: view.channel, options: view.options, location: view.location};
         });
-    },
+    }
 
-    get_sinks: function() {
+    get_sinks() {
         return this._get_nodes_helper(this.graph.head, function(proc) {
             return (proc instanceof sink);
         });
-    },
+    }
 
-    get_terminal_nodes: function() {
+    get_terminal_nodes() {
         var self = this;
         return this._get_nodes_helper(this.graph.head, function(proc) {
             return (self._outputs(proc).length === 0);
         });
-    },
+    }
 
-    get_nodes: function() {
+    get_nodes() {
         return this._get_nodes_helper(this.graph.head, function(node) {
             return true;
         });
-    },
+    }
 
-    _outputs: function(proc) {
+    _outputs(proc) {
         var names = proc.out_names();
         var output_objs = _.flatten(_.map(names, function(name) { return proc.out(name);}));
         var output_procs = _.map(output_objs, function (p)  { return p.proc;});
         return output_procs;
-    },
+    }
     // Returns nodes that pass the predicate function.
-    _get_nodes_helper: function _get_nodes_helper(procs, predicate) {
+    _get_nodes_helper(procs, predicate) {
         var nodes = [];
         var self = this;
 
@@ -166,6 +165,6 @@ var Program = Base.extend({
 
         return _(nodes).uniq();
     }
-});
+}
 
 module.exports = Program;

--- a/lib/runtime/groups.js
+++ b/lib/runtime/groups.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Base = require('extendable-base');
 var values = require('./values');
 
 // a class wrapping functions that group points by the value(s)
@@ -22,8 +21,8 @@ var values = require('./values');
 //
 var NO_GROUP_KEY = 'NO_GROUP_KEY';
 
-var Groups = Base.extend({
-    initialize: function(proc, options, funcMaker) {
+class Groups {
+    constructor(proc, options, funcMaker) {
         this.proc = proc;
         // array of field names to act as keys (and subkeys) by
         // which to group points (for processing as units)
@@ -46,44 +45,44 @@ var Groups = Base.extend({
 
         this._undefined_fields_warned = {};
         this.no_groupby_warning = options.no_groupby_warning;
-    },
+    }
 
-    reset: function() {
+    reset() {
         this.reset_groups();
-    },
+    }
 
     // Resets the state of all rows and index.
-    reset_groups: function() {
+    reset_groups() {
         this.table = {};
         this.index = {};
         this.nkeys = 0;
         this.key_vals = [];
-    },
+    }
 
     // removes a particular group from the table
-    delete_group: function(keyID) {
+    delete_group(keyID) {
         delete this.table[keyID];
         // don't bother updating the index, it is complicated and not necessary
-    },
+    }
 
     // Resets the state of each row's funcs
-    reset_fns: function() {
+    reset_fns() {
         var self = this;
         this.apply(function(key) {
             self.reset_row(self.get_row(key));
         });
-    },
+    }
 
-    reset_row: function(row) {
+    reset_row(row) {
         if (!row.funcMaker) {
             row.funcMaker =  this.funcMakerMaker ? this.funcMakerMaker() : this.funcMaker;
         }
         row.fns = row.funcMaker();
         row.pts = null;
         row.npts = 0;
-    },
+    }
 
-    mixin_keys: function(pt, keyID) {
+    mixin_keys(pt, keyID) {
         var by, colno, n, vals;
         by = this.by;
         n = by.length;
@@ -94,7 +93,7 @@ var Groups = Base.extend({
         for (colno = 0; colno < n; ++colno) {
             pt[by[colno]] = vals[colno];
         }
-    },
+    }
     //
     // for a given point, lookup a unique group-by key for the
     // by fields of this group returns a keyID (integer) for that
@@ -109,7 +108,7 @@ var Groups = Base.extend({
     // key string index from all the key values in a way that
     // guarantees that the input data won't mess things up
     //
-    lookup_key: function(pt) {
+    lookup_key(pt) {
         var colno, field;
         var by = this.by;
         var n = by.length;
@@ -138,8 +137,8 @@ var Groups = Base.extend({
             keyID = this._insert_key(pt);
         }
         return keyID;
-    },
-    _get_key: function(pt) {
+    }
+    _get_key(pt) {
         var index = this.index;
         var by = this.by;
 
@@ -155,9 +154,9 @@ var Groups = Base.extend({
 
         var lastField = pt[by[by.length - 1]];
         return index[values.inspect(lastField)];
-    },
+    }
 
-    _insert_key: function(pt) {
+    _insert_key(pt) {
         var index = this.index;
         var next_index;
         var by = this.by;
@@ -178,20 +177,20 @@ var Groups = Base.extend({
         index[values.inspect(val)] = keyID;
         this.key_vals[keyID] = vals;
         return keyID;
-    },
+    }
 
     // Looks up and returns the row for the point. If a row doesn't exist, it
     // creates one and sets the rows functions by calling the appropriate funcMaker().
-    lookup: function(pt) {
+    lookup(pt) {
         var keyID = this.lookup_key(pt);
         if (keyID === undefined) {
             return;
         }
 
         return this.get_row(keyID);
-    },
+    }
 
-    get_row: function(keyID) {
+    get_row(keyID) {
         var row = this.table[keyID] || {};
 
         if (!row.fns) {
@@ -201,13 +200,13 @@ var Groups = Base.extend({
         this.table[keyID] = row;
 
         return row;
-    },
+    }
     //
     // apply a function to every (leaf) key in the table
     // the function takes the key objects and the group-by
     // values of this key
     //
-    apply: function(fn) {
+    apply(fn) {
         if (this.by.length === 0) {
             // Ensure row exists and reducers are initialized.
             this.get_row(NO_GROUP_KEY);
@@ -220,7 +219,7 @@ var Groups = Base.extend({
             }
         }
     }
-});
+}
 
 
 module.exports = Groups;

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -2,16 +2,15 @@
 
 var _ = require('underscore');
 var JuttleLogger = require('../../logger');
-var Base = require('extendable-base');
 var errors = require('../../errors');
 
 var DEFAULT_OUT_NAME = 'default';
 
-var base = Base.extend({
+class base {
     //
     // called by the default constructor
     //
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
         this.options = options;
         this.params = params;
         var job_id;
@@ -32,13 +31,13 @@ var base = Base.extend({
         this.logger_name = 'proc-' + this.procName() + job_id;
         this.logger = JuttleLogger.getLogger(this.logger_name);
         this.logger.debug('initialize', JSON.stringify(options), JSON.stringify(params));
-    },
+    }
 
-    procName: function() {
+    procName() {
         throw new Error('procName() not implemented');
-    },
+    }
 
-    validate_options: function(allowedOptions, requiredOptions) {
+    validate_options(allowedOptions, requiredOptions) {
         var options = _.keys(this.options);
         var unknown = _.difference(options, allowedOptions);
         if (unknown.length > 0) {
@@ -55,29 +54,29 @@ var base = Base.extend({
                 option: missing[0]
             });
         }
-    },
+    }
 
-    out: function(output_name) {
+    out(output_name) {
         output_name = output_name || DEFAULT_OUT_NAME;
         if (!this.out_.hasOwnProperty(output_name)) {
             this.out_[output_name] = [];
         }
         return this.out_[output_name];
-    },
-    out_names: function() {
+    }
+    out_names() {
         return Object.keys(this.out_);
-    },
+    }
     //
     // called by gencode:JuttleEngine.activate during try_apply after
     // successful program compilation.
     //
-    start: function() { },
+    start() { }
 
     //
     // traverse the graph and call teardown once on every reachable proc
     // this would typically be called on the entry node
     //
-    deactivate: function(mark) {
+    deactivate(mark) {
         if (this.visitMark !== mark) {
             this.visitMark = mark;
             _.each(this.out_, function(outputList) {
@@ -87,8 +86,8 @@ var base = Base.extend({
             });
             this.teardown();
         }
-    },
-    combine: function(proc) {
+    }
+    combine(proc) {
         var k;
         // append the head items from proc to this.head
         // and the tail items from proc to this.tail
@@ -99,27 +98,27 @@ var base = Base.extend({
         for (k = 0; k < proc.tail.length; ++k) {
             this.tail.push(proc.tail[k]);
         }
-    },
+    }
     //XXX need a disconnect method
-    connect: function(proc) {
+    connect(proc) {
         var out = this.out();
         // add proc as a downstream consumer of our points.
         out.push({proc: proc, from: this});
         proc.connect_input(this);
         return true;
-    },
+    }
     // Add a named shortcut link from this node to `target_proc`.
     // `name` can later be used by emit_xxx methods.
     // `logical_from_proc` is the proc that points sent over this
     // shortcut should appear to come from (for eof/mark fanin accounting purposes).
-    shortcut: function(target, logical_from, name) {
+    shortcut(target, logical_from, name) {
         var out = this.out(name);
         // add proc as a downstream consumer of our points.
         out.push({proc: target, from:logical_from});
         target.shortcut_input(logical_from);
         return true;
-    },
-    connect_input: function(proc) {
+    }
+    connect_input(proc) {
         var l = _.where(this.ins, { from: proc});
         if (l.length) {
             throw new Error('connecting input from already-connected node');
@@ -127,19 +126,19 @@ var base = Base.extend({
         // add proc as an upstream source, to keep track of fan-in.
         // override this for more elaborate input-state tracking.
         this.ins.push(this.build_input(proc));
-    },
-    shortcut_input: function(proc) {
+    }
+    shortcut_input(proc) {
         var l = _.where(this.ins, { from: proc});
         if (l.length === 0) {
             throw new Error('connecting shortcut but shortcut pair does not exist');
         }
-    },
-    build_input: function(proc) {
+    }
+    build_input(proc) {
         // build an input state object for this input. override this
         // if you need fancier accounting.
         return {from: proc};
-    },
-    in_from: function(from) {
+    }
+    in_from(from) {
         // return input state object for this input node
         for (var i=0 ; i < this.ins.length ; i++) {
             if (this.ins[i].from === from) {
@@ -147,14 +146,14 @@ var base = Base.extend({
             }
         }
         throw new Error('unknown input');
-    },
-    teardown: function() {
-    },
+    }
+    teardown() {
+    }
     //
     // upstream neighbors feed us points, marks, ticks, and eofs by
     // calling the appropriate consume* methods on their data.
     //
-    consume: function(points, from) {
+    consume(points, from) {
         this.stats.points_in += points.length;
 
         try {
@@ -162,38 +161,38 @@ var base = Base.extend({
         } catch (err) {
             this.trigger('error', err);
         }
-    },
-    consume_mark: function(time, from) {
+    }
+    consume_mark(time, from) {
         this.mark(time);
-    },
-    consume_tick: function(time, from) {
+    }
+    consume_tick(time, from) {
         this.tick(time);
-    },
-    consume_eof: function(from) {
+    }
+    consume_eof(from) {
         this.eof();
-    },
+    }
     //
     // default proc behavior simply forwards points, marks, and eofs
     // to downstream neighbors. Extensions should override process(), mark(),
     // or eof() if they want something more than that.
     //
-    process: function(points) {
+    process(points) {
         this.emit(points);
-    },
-    mark: function(time) {
+    }
+    mark(time) {
         this.emit_mark(time);
-    },
-    tick: function(time) {
+    }
+    tick(time) {
         this.emit_tick(time);
-    },
-    eof: function() {
+    }
+    eof() {
         this.emit_eof();
-    },
+    }
     //
     // propagate points/marks/eofs down the graph by invoking
     // our downstream neighbors' consume* methods.
     //
-    emit: function(points, output_name) {
+    emit(points, output_name) {
         if (!points.length) {
             return;
         }
@@ -208,26 +207,26 @@ var base = Base.extend({
         }
         this.last_used_output = output_name || DEFAULT_OUT_NAME;
         this.stats.points_out += points.length;
-    },
-    emit_mark: function(time, output_name) {
+    }
+    emit_mark(time, output_name) {
         var k, out = this.out(output_name);
         for (k = 0; k < out.length; ++k) {
             out[k].proc.consume_mark(time, out[k].from);
         }
-    },
-    emit_tick: function(time, output_name) {
+    }
+    emit_tick(time, output_name) {
         var out = this.out(output_name);
         for (var k=0; k<out.length; ++k) {
             out[k].proc.consume_tick(time, out[k].from);
         }
-    },
-    emit_eof: function() {
+    }
+    emit_eof() {
         var k, out = this.out(this.last_used_output);
         for (k = 0; k < out.length; ++k) {
             out[k].proc.consume_eof(out[k].from);
         }
-    },
-    trigger: function(type, err) {
+    }
+    trigger(type, err) {
         if (err.info && _.isObject(err.info)) {
             if (! err.info.procName) {
                 err.info.procName = this.procName();
@@ -238,11 +237,11 @@ var base = Base.extend({
             }
         }
         this.program.events.emit(type, err.message, err);
-    },
-    locate_juttle_errors: function(block) {
+    }
+    locate_juttle_errors(block) {
         return errors.locate(block, this.location);
-    },
-    compile_error: function(code, info) {
+    }
+    compile_error(code, info) {
         if (info === undefined) {
             info = {};
         }
@@ -251,8 +250,8 @@ var base = Base.extend({
             code,
             _.defaults(_.clone(info), { location: this.location })
         );
-    },
-    runtime_error: function(code, info) {
+    }
+    runtime_error(code, info) {
         if (info === undefined) {
             info = {};
         }
@@ -262,6 +261,6 @@ var base = Base.extend({
             _.defaults(_.clone(info), { location: this.location })
         );
     }
-});
+}
 
 module.exports = base;

--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -22,8 +22,9 @@ var INFO = {
     }
 };
 
-var batch = periodic_fanin.extend({
-    initialize: function(options, params, location, program) {
+class batch extends periodic_fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['arg', 'every', 'on'];
         this.validate_options(allowed_options);
 
@@ -71,35 +72,37 @@ var batch = periodic_fanin.extend({
             this.on = null;
         }
         this.init_warnings();
-    },
-    procName: function() {
+    }
+    procName() {
         return 'batch';
-    },
-    process_points: function(points) {
+    }
+    process_points(points) {
         this.emit(points);
-    },
-    advance_epoch: function(epoch) {
+    }
+    advance_epoch(epoch) {
         this.emit_mark(epoch);
         // callers expect to receive an array of points to emit
         // which doesn't apply to batch
         return [];
-    },
-    tick: function(time, from) {
+    }
+    tick(time, from) {
         if (time.gt(this.program.now)) {
             // advance on live ticks
             this.advance(time);
         }
         this.emit_tick(time);
-    },
-    periodic_eof: function(from) {
+    }
+    periodic_eof(from) {
         if (this.next_epoch) {
             // output the final end of batch mark.
             this.advance(this.next_epoch);
         }
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = batch;

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -18,8 +18,9 @@ var INFO = {
     }
 };
 
-var emit = source.extend({
-    initialize: function(options, params, location, program) {
+class emit extends source {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var NOW = this.program.now;
         var allowedOptions = _.union(_.keys(INFO.options), _.keys(INFO._options));
         this.validate_options(allowedOptions);
@@ -120,11 +121,11 @@ var emit = source.extend({
         }
         this.next_time = this.from;
         this.n = 0;
-    },
-    procName: function() {
+    }
+    procName() {
         return 'emit';
-    },
-    start: function() {
+    }
+    start() {
         var ts = this.next_run();
         if (ts) {
             this.schedule(ts);
@@ -135,8 +136,8 @@ var emit = source.extend({
             }
             this.emit_eof();
         }
-    },
-    next_point: function(advance) {
+    }
+    next_point(advance) {
         if (this.n < this.limit) {
             var pt = this.points ? this.points[this.n] : {time: this.next_time};
             if (advance) {
@@ -147,8 +148,8 @@ var emit = source.extend({
         } else {
             return null;
         }
-    },
-    next_run: function() {
+    }
+    next_run() {
         var pt = this.next_point(false);
         if (!pt) {
             return null;
@@ -158,13 +159,13 @@ var emit = source.extend({
         } else {
             return new JuttleMoment(0);
         }
-    },
-    schedule: function(ts) {
+    }
+    schedule(ts) {
         var self = this;
         this.program.scheduler.schedule(ts.unixms(),
         function() { self.run(ts); });
-    },
-    run: function(ts) {
+    }
+    run(ts) {
         // Check if it's time to send the next point or emit ticks
         var pt = this.next_point(false);
         if (!pt.time || pt.time.lte(ts)) {
@@ -180,8 +181,10 @@ var emit = source.extend({
             this.emit_eof();
         }
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = emit;

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -3,60 +3,58 @@
 var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var base = require('./base');
-var ExtBase = require('extendable-base');
 
 var DEQueue = require('double-ended-queue');
 
-var Input = ExtBase.extend({
-    initialize: function(options, params, location, program) {
+class Input {
+    constructor(options, params, location, program) {
         this.from = options.proc;       // input node
         this.queue = new DEQueue();
-    },
-    pop: function() {
+    }
+    pop() {
         return this.queue.pop();
-    },
-    push: function(v) {
+    }
+    push(v) {
         return this.queue.push(v);
-    },
-    empty: function() {
+    }
+    empty() {
         return this.queue.isEmpty();
-    },
-    first: function(i) {
+    }
+    first(i) {
         if (!i) {
             return this.queue.peekFront();
         }
         return this.queue.get(i);
-    },
-    last: function(i) {
+    }
+    last(i) {
         if (!i) {
             return this.queue.peekBack();
         }
         return this.queue.get(-i-1);
-    },
-    shift: function() {
+    }
+    shift() {
         return this.queue.shift();
-    },
-    length: function() {
+    }
+    length() {
         return this.queue.length;
-    },
-    toArray: function() {
+    }
+    toArray() {
         return this.queue.toArray();
     }
-});
-
-var fanin = base.extend({
+}class fanin extends base {
     // add input-merging behavior to base behavior so everyone
     // knows what to do with multiple inputs in a flowgraph (consume
     // their points in time order, and de-dup marks and ticks)
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.last_mark = JuttleMoment.epsMoment(-Infinity) ;
         this.last_tick = JuttleMoment.epsMoment(-Infinity) ;
         this.last_emitted = JuttleMoment.epsMoment(-Infinity) ;
         this.emitted_eof = false;
-    },
-    build_input: function(proc) {
+    }
+    build_input(proc) {
         return new Input({proc: proc}) ;
-    },
+    }
     //
     // upstream inputs feed us points, marks, ticks, and eofs by
     // calling the appropriate consume* methods on their data.  We
@@ -66,7 +64,7 @@ var fanin = base.extend({
     // points as if there was a single upstream input feeding
     // them.
     //
-    consume: function(points, from) {
+    consume(points, from) {
         this.stats.points_in += points.length;
         try {
             if (this.ins.length === 1) {
@@ -77,50 +75,50 @@ var fanin = base.extend({
         } catch (err) {
             this.trigger('error', err);
         }
-    },
-    consume_mark: function(time, from) {
+    }
+    consume_mark(time, from) {
         if (this.ins.length === 1) {
             this.mark(time) ;
         } else {
             this.mark_from(time, from);
         }
-    },
-    consume_tick: function(time, from) {
+    }
+    consume_tick(time, from) {
         if (this.ins.length === 1) {
             this.tick(time) ;
         } else {
             this.tick_from(time, from);
         }
-    },
-    consume_eof: function(from) {
+    }
+    consume_eof(from) {
         if (this.ins.length === 1) {
             this.eof() ;
         } else {
             this.eof_from(from);
         }
-    },
-    process_from: function(points, from) {
+    }
+    process_from(points, from) {
         if (points.length === 0) {
             return ;
         }
         var self = this;
         _.each(points, function(pt) {
             self.advance_input({time:pt.time, point:pt}, self.in_from(from));});
-    },
-    mark_from: function(time, from) {
+    }
+    mark_from(time, from) {
         this.advance_input({time:time, mark:true}, this.in_from(from));
-    },
-    tick_from: function(time, from) {
+    }
+    tick_from(time, from) {
         this.advance_input({time:time, tick:true}, this.in_from(from));
-    },
-    eof_from: function(from) {
+    }
+    eof_from(from) {
         this.advance_input({time: new JuttleMoment(Infinity), eof:true}, this.in_from(from));
-    },
-    advance_input: function(tpoint, input) {
+    }
+    advance_input(tpoint, input) {
         input.push(tpoint);
         this.produce();
-    },
-    earliest: function() {
+    }
+    earliest() {
         // return the input having the earliest itemstamped item, or
         // null. In case of ties, prefer marks so they always go out
         // ahead of points in their batch. An item with no timestamps
@@ -147,8 +145,8 @@ var fanin = base.extend({
             }
         }
         return earliest;
-    },
-    produce: function() {
+    }
+    produce() {
         // Whenever we have a timestamp present on each input, or a
         // timestamp equal to the most recently emitted timestamp on
         // an input, dequeue the earliest item. Emit it, unless it is
@@ -186,7 +184,7 @@ var fanin = base.extend({
             earliest = this.earliest();
         }
     }
-});
+}
 
 
 

--- a/lib/runtime/procs/filter.js
+++ b/lib/runtime/procs/filter.js
@@ -8,14 +8,15 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var filter = fanin.extend({
-    initialize: function(options, params, location, program) {
+class filter extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.predicate = params.predicate;
-    },
-    procName: function() {
+    }
+    procName() {
         return 'filter';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k = 0;
         var out = [];
         var fn = this.predicate;
@@ -42,8 +43,10 @@ var filter = fanin.extend({
         }
         this.emit(out);
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = filter;

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -10,8 +10,9 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var head = fanin.extend({
-    initialize: function(options, params, location, program) {
+class head extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('INTEGER-REQUIRED', {
                 proc: 'head',
@@ -20,11 +21,11 @@ var head = fanin.extend({
         }
         this.limit = options.arg;
         this.groups = new Groups(this, options);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'head';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {
             row = this.groups.lookup(points[k]);
@@ -36,18 +37,20 @@ var head = fanin.extend({
                 this.emit([points[k]]);
             }
         }
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         // process and publish each mark
         this.groups.reset();
         this.emit_mark(time);
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         this.groups.reset();
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = head;

--- a/lib/runtime/procs/join.js
+++ b/lib/runtime/procs/join.js
@@ -127,95 +127,95 @@
 // create its own tick stream when stalled (PROD-4876)
 //
 var DEQueue = require('double-ended-queue');
-var ExtBase = require('extendable-base');
 var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 
 var base = require('./base');
 var Groups = require('../groups');
 
-var timeless_time = new JuttleMoment(-Infinity); // timeless points get this timestamp
+// timeless points get this timestamp
+var timeless_time = new JuttleMoment(-Infinity);
 
-var Input = ExtBase.extend({
-    initialize: function(options, params, location, program) {
+class Input {
+    constructor(options, params, location, program) {
         this.from = options.proc;     // input node
         this.i = options.i;           // index in inputs[]
         this.batched = false; // is this input in batching mode?
         this.table = false;   // treat this like a timeless table?
         this.queue = new DEQueue();
-    },
-    live: function() {
+    }
+    live() {
         // input's live group is the beginning of the queue (assumes
         // expired groups have been deleted)
         return this.first();
-    },
-    nextup: function() {
+    }
+    nextup() {
         // input's nextup group is the one following live.
         return (this.length() > 1) ? this.first(1) : null;
-    },
-    live_time: function() {
+    }
+    live_time() {
         return this.empty() ? null : this.first()[0].time;
-    },
-    complete_time: function() {
+    }
+    complete_time() {
         return this.empty() ? null : this.first().complete_time;
-    },
-    next_time: function() {
+    }
+    next_time() {
         // note: next_time is not immediately nextup()[0].time, but
         // eventually becomes that as input arrives.
         return this.empty() ? null : this.first().next_time;
-    },
-    at_eof: function() {
+    }
+    at_eof() {
         return this.empty() ? false : this.first()[0].eof;
-    },
-    toString: function() {
+    }
+    toString() {
         return 'input['+this.i+']'+(this.batched?'.batched':'')+' q:'+JSON.stringify(this.q);
-    },
-    pop: function() {
+    }
+    pop() {
         return this.queue.pop();
-    },
-    push: function(v) {
+    }
+    push(v) {
         return this.queue.push(v);
-    },
-    empty: function() {
+    }
+    empty() {
         return this.queue.isEmpty();
-    },
-    first: function(i) {
+    }
+    first(i) {
         if (!i) {
             return this.queue.peekFront();
         }
         return this.queue.get(i);
-    },
-    last: function(i) {
+    }
+    last(i) {
         if (!i) {
             return this.queue.peekBack();
         }
         return this.queue.get(-i-1);
-    },
-    shift: function() {
+    }
+    shift() {
         return this.queue.shift();
-    },
-    length: function() {
+    }
+    length() {
         return this.queue.length;
-    },
-    toArray: function() {
+    }
+    toArray() {
         return this.queue.toArray();
     }
-});
+}
 
 // when we are passed lists of points to join (the join inner loop),
 // use our group-by technology to group the points of each input by
 // their joinkey values. At the end of that we'll have grouped together
 // the points that should be joined, and won't have to consider joining
 // ones that aren't grouped together, and will escape our O(n^2) hell.
-var JoinkeyGroups = Groups.extend({
-    get_row: function(keyID) {
+class JoinkeyGroups extends Groups {
+    get_row(keyID) {
         var row = this.table[keyID];
         if (!row) {
             row = this.table[keyID] = [];
         }
         return row;
     }
-});
+}
 
 var INFO = {
     type: 'proc',
@@ -231,17 +231,20 @@ var INFO = {
 // which is called whenever a point, mark, tick, or EOF is
 // sent by an input. Everything else fans out from that.
 //
-var join = base.extend({
-    initialize: function(options, params, location, program) {
+class join extends base {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['zip', 'nearest', 'once', 'outer', 'table', 'columns'];
         this.validate_options(allowed_options);
         this.joinfields = options.columns || [];
         delete options.columns;
-        this.once = Boolean(options.once); // one big join, no streaming.
+        // one big join, no streaming.
+        this.once = Boolean(options.once);
         if (options.zip !== undefined && options.nearest !== undefined) {
             throw this.compile_error('JOIN-ZIP-NEAREST-ERROR');
         }
-        this.zip = Boolean(options.zip); // each point joins at most one time
+        // each point joins at most one time
+        this.zip = Boolean(options.zip);
         if (options.zip !== undefined) {
             if (options.zip.duration) {
                 this.maxoffset = options.zip;
@@ -272,18 +275,21 @@ var join = base.extend({
             this.outer = null;
         }
         var impossibly_early = JuttleMoment.epsMoment(-Infinity) ;
-        this.last_emitted = impossibly_early; // most recent point/tick/mark emitted
-        this.last_output = impossibly_early;  // most recent result: point or eps batch-end
-        this.last_mark = impossibly_early; // most recent mark emitted
+        // most recent point/tick/mark emitted
+        this.last_emitted = impossibly_early;
+        // most recent result: point or eps batch-end
+        this.last_output = impossibly_early;
+        // most recent mark emitted
+        this.last_mark = impossibly_early;
         this.eof_emitted = false;
         this.settings_checked = false;
         this.joinkey_groups = new JoinkeyGroups(this, {groupby: this.joinfields});
         this.joinkey_groups._undefined_fields_warned = _.invert(this.joinfields);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'join';
-    },
-    toString: function() {
+    }
+    toString() {
         var s = 'join last_output '+this.last_output;
         this.ins.forEach(function(input) {
             var complete_time = input.complete_time();
@@ -296,14 +302,14 @@ var join = base.extend({
                 );
         }, this);
         return s;
-    },
-    build_input: function(proc) {
+    }
+    build_input(proc) {
         return new Input({
             proc: proc,
             i: this.ins.length
         });
-    },
-    check_settings: function() {
+    }
+    check_settings() {
         // on our first input, verify settings
         if (this.settings_checked) {
             return ;
@@ -330,43 +336,43 @@ var join = base.extend({
                 this.ins[idx - 1].table = true;
             }
         }
-    },
-    consume: function(points, from) {
+    }
+    consume(points, from) {
         this.stats.points_in += points.length;
         try {
             this.process_from(points, from);
         } catch (err) {
             this.trigger('error', err);
         }
-    },
-    consume_mark: function(time, from) {
+    }
+    consume_mark(time, from) {
         this.mark_from(time, from);
-    },
-    consume_tick: function(time, from) {
+    }
+    consume_tick(time, from) {
         this.tick_from(time, from);
-    },
-    consume_eof: function(from) {
+    }
+    consume_eof(from) {
         this.eof_from(from);
-    },
-    process_from: function(points, from) {
+    }
+    process_from(points, from) {
         if (points.length === 0) {
             return ;
         }
         var self = this;
         _.each(points, function(pt) {
             self.advance_input({time:pt.time, point:pt}, self.in_from(from));});
-    },
-    mark_from: function(time, from) {
+    }
+    mark_from(time, from) {
         this.advance_input({time:time, mark:true}, this.in_from(from));
-    },
-    tick_from: function(time, from) {
+    }
+    tick_from(time, from) {
         this.advance_input({time:time, tick:true}, this.in_from(from));
-    },
-    eof_from: function(from) {
+    }
+    eof_from(from) {
         // wrap the eof in a tpoint and process it.
         this.advance_input({time: new JuttleMoment(Infinity), eof:true}, this.in_from(from));
-    },
-    is_expired: function(input) {
+    }
+    is_expired(input) {
         // expired means nothing more for this input group to do.
         // see sequential join definitions
 
@@ -414,8 +420,8 @@ var join = base.extend({
             return true;
         }
         return false;
-    },
-    is_leader: function(input) {
+    }
+    is_leader(input) {
         // most recent live group over all inputs
         // see sequential join definitions
         var t = input.live_time();
@@ -423,8 +429,8 @@ var join = base.extend({
             var ot = other.live_time();
             return !ot || t.gte(ot);
         }));
-    },
-    is_follower: function(input) {
+    }
+    is_follower(input) {
         // live but not a leader
         // see sequential join definitions
         var t = input.live_time();
@@ -432,8 +438,8 @@ var join = base.extend({
             var ot = other.live_time();
             return ot && ot.gt(t);
         }));
-    },
-    is_ready: function(input) {
+    }
+    is_ready(input) {
         // input group can be joined.
         // see sequential join definitions
         var complete_time = input.complete_time();
@@ -461,14 +467,14 @@ var join = base.extend({
         } else {
             return false;
         }
-    },
-    max_live_time: function() {
+    }
+    max_live_time() {
         // leader timestamp. this will become the output timestamp of a join result
         var t = JuttleMoment.max.apply(
             null, _.select(_.map(this.ins, function(input) { return input.live_time(); })));
         return t;
-    },
-    batched_leader: function() {
+    }
+    batched_leader() {
         // if there is a batched input having a group that is a leader, return it
         // so we know to emit a mark after the join result.
         if (this.outer) {
@@ -479,8 +485,8 @@ var join = base.extend({
             }, this);
             return leaders[0];
         }
-    },
-    witness_timestamp: function(tpoint, input) {
+    }
+    witness_timestamp(tpoint, input) {
         // a new timestamped thing has arrived at the input. adjust
         // input states related to maximum-seen timestamps of various types.
         var last = input.last();
@@ -521,8 +527,8 @@ var join = base.extend({
                 last.complete_time = last.next_time = tpoint.time;
             }
         }
-    },
-    queue_tpoint: function(tpoint, input) {
+    }
+    queue_tpoint(tpoint, input) {
         // decide whether to add this point to an existing group,
         // or start a new input group, then queue it.
         if (tpoint.tick) {
@@ -562,8 +568,8 @@ var join = base.extend({
                 last.complete_time = tpoint.table_time;
             }
         }
-    },
-    advance_input: function(tpoint, input) {
+    }
+    advance_input(tpoint, input) {
         // a new point arrived at the input. chew it, view it, and
         // queue it, then kick off any joins made possible by its
         // arrival.
@@ -598,8 +604,8 @@ var join = base.extend({
             this.eof();
             this.eof_emitted = true;
         }
-    },
-    discard_group: function(input) {
+    }
+    discard_group(input) {
         // throw away the earliest group on the input.
         if (this.outer === input.i + 1 && input.live_time().gt(this.last_output)) {
             // we are doing an outer join, and an outer input group is
@@ -612,8 +618,8 @@ var join = base.extend({
             this.emit_result(outer_points) ;
         }
         input.shift();
-    },
-    advance: function() {
+    }
+    advance() {
         // state has changed, either from new input points arriving or
         // new output points being emitted. restore the streaming
         // invariant by removing newly expired groups. advance join
@@ -650,8 +656,8 @@ var join = base.extend({
             }
         }
         return _.every(this.ins, this.is_ready, this);
-    },
-    join_inputs: function() {
+    }
+    join_inputs() {
         // assemble working sets from ready input groups, compute
         // their relational join, and assign an approprite timestamp
         // to the results.
@@ -669,8 +675,8 @@ var join = base.extend({
             });
         }
         return joinpts;
-    },
-    join_points: function(points, joinfields) {
+    }
+    join_points(points, joinfields) {
         // join allll the points. return array of new points resulting
         // from what is essentially a relational join of every point
         // against every other (a union of points having same
@@ -689,8 +695,8 @@ var join = base.extend({
             result.push(_.extend.apply({}, groups[group])); // union all fields for this group
         }
         return result;
-    },
-    join_groups: function(groups) {
+    }
+    join_groups(groups) {
         // return array of new points resulting from an n-way
         // relational join of the points on each input. groups is an
         // array of point lists, one list per input.
@@ -746,8 +752,8 @@ var join = base.extend({
             }
         });
         return joinpts;
-    },
-    emit_result: function(points) {
+    }
+    emit_result(points) {
         // emit the points, possibly bracketed by marks, and update emitter state.
         var leader = this.batched_leader() ;
         var join_time = this.outer ? this.ins[this.outer - 1].live_time() : this.max_live_time();
@@ -762,8 +768,8 @@ var join = base.extend({
         if (leader) {
             this.maybe_emit_mark(leader.live().complete_time);
         }
-    },
-    maybe_emit_mark: function(time) {
+    }
+    maybe_emit_mark(time) {
         // emit a mark at this time if one has not already been emitted
         if (time.gt(this.last_mark)) {
             if (time.lt(this.last_emitted)) {
@@ -773,9 +779,11 @@ var join = base.extend({
             this.last_emitted = time;
             this.last_mark = time;
         }
-    },
-}, {
-    info: INFO
-});
+    }
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = join;

--- a/lib/runtime/procs/keep.js
+++ b/lib/runtime/procs/keep.js
@@ -7,14 +7,15 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var keep = fanin.extend({
-    initialize: function(options, params, location, program) {
+class keep extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.columns = options.columns || [];
-    },
-    procName: function() {
+    }
+    procName() {
         return 'keep';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var pt, k, m, fld;
         var cols = this.columns;
         var out = [];
@@ -33,9 +34,11 @@ var keep = fanin.extend({
         }
         this.emit(out);
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 
 module.exports = keep;

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -4,26 +4,27 @@ var fanin = require('./fanin');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var errors = require('../errors');
 
-var oops_fanin = fanin.extend({
+class oops_fanin extends fanin {
     // watch for out-of-order points and points with non-moment times when emitting
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         if (params && params.lhs && params.lhs.indexOf('time') >= 0) {
             this.watch_oops = true; // true enables out-of-order checks during emit
             this.last_output_time = JuttleMoment.epsMoment(-Infinity); // only updated if watch_oops
         } else {
             this.watch_oops = false;
         }
-    },
-    warn_oops: function(badTime, goodTime) {
+    }
+    warn_oops(badTime, goodTime) {
         this.trigger('warning', this.runtime_error('TIME-OUT-OF-ORDER', {
             badTime:badTime.valueOf(),
             goodTime:goodTime.valueOf()
         }));
-    },
-    warn_time: function(time) {
+    }
+    warn_time(time) {
         this.trigger('warning', errors.typeErrorTime(time));
-    },
-    emit: function(points, output_name) {
+    }
+    emit(points, output_name) {
         if (this.watch_oops) {
             var i = 0;
             while (i < points.length) {
@@ -45,8 +46,8 @@ var oops_fanin = fanin.extend({
             }
         }
         fanin.prototype.emit.call(this, points, output_name);
-    },
-    emit_mark: function(time, output_name) {
+    }
+    emit_mark(time, output_name) {
         if (this.watch_oops) {
             if (time.lt(this.last_output_time)) {
                 this.warn_oops();
@@ -56,8 +57,8 @@ var oops_fanin = fanin.extend({
             }
         }
         fanin.prototype.emit_mark.call(this, time, output_name);
-    },
-    emit_tick: function(time, output_name) {
+    }
+    emit_tick(time, output_name) {
         if (this.watch_oops) {
             // when rewriting time, we don't have a rule for rewriting ticks.
             // to maintain order. setting them to last output is at least valid.
@@ -65,6 +66,6 @@ var oops_fanin = fanin.extend({
         }
         fanin.prototype.emit_tick.call(this, time, output_name);
     }
-});
+}
 
 module.exports = oops_fanin;

--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -15,8 +15,9 @@ var INFO = {
     }
 };
 
-var pace = fanin.extend({
-    initialize: function(options, params, location, program) {
+class pace extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['x', 'every', 'from'];
         this.validate_options(allowed_options);
 
@@ -46,24 +47,30 @@ var pace = fanin.extend({
         }
         this.timer = null;
         this.wakeup_timer = null;
-        this.batched = false;  // true if we have received a mark
-        this.data_t0 = null;   // first timestamp received
-        this.offset = null;    // from - data_t0
-        this.has_eof = false;  // true if we have received eof
-        this.has_realtime = false; // true when we have received a timestamp >= :now:
-        this.last_q_ms = null; // epochms wallclock when most recent item was queued
+        // true if we have received a mark
+        this.batched = false;
+        // first timestamp received
+        this.data_t0 = null;
+        // from - data_t0
+        this.offset = null;
+        // true if we have received eof
+        this.has_eof = false;
+        // true when we have received a timestamp >= :now:
+        this.has_realtime = false;
+        // epochms wallclock when most recent item was queued
+        this.last_q_ms = null;
         this.q = [];
         this.playback = this.playback.bind(this);
         this.wakeup = this.wakeup.bind(this);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'pace';
-    },
-    teardown: function() {
+    }
+    teardown() {
         clearTimeout(this.timer);
         clearTimeout(this.wakeup_timer);
-    },
-    offset_time: function(time) {
+    }
+    offset_time(time) {
         if (!this.data_t0) {
             this.data_t0 = time;
         }
@@ -72,12 +79,12 @@ var pace = fanin.extend({
             this.offset = this.from.subtract(time) ;
         }
         return (this.offset && time) ? time.add(this.offset) : time;
-    },
-    dont_pace: function() {
+    }
+    dont_pace() {
         // no historic points are queued, and no more are coming.
         return ((this.has_realtime || this.has_eof) && this.q.length === 0);
-    },
-    process: function(points) {
+    }
+    process(points) {
         var i;
         if (points.length === 0) {
             return ;
@@ -112,8 +119,8 @@ var pace = fanin.extend({
                 this.wakeup();
             }
         }
-    },
-    mark: function(time) {
+    }
+    mark(time) {
         if (this.dont_pace()) {
             this.emit_mark(this.offset_time(time));
             return;
@@ -134,13 +141,13 @@ var pace = fanin.extend({
                 this.wakeup();
             }
         }
-    },
-    tick: function(time) {
+    }
+    tick(time) {
         if (this.dont_pace()) {
             this.emit_tick(time);
         }
-    },
-    eof: function() {
+    }
+    eof() {
         if (this.dont_pace()) {
             this.emit_eof();
             return;
@@ -150,8 +157,8 @@ var pace = fanin.extend({
         if (!this.timer) {
             this.playback();
         }
-    },
-    wakeup: function() {
+    }
+    wakeup() {
         // historic+live streams sometimes don't have a point at :now:
         // and paced history won't start rendering until the first realtime
         // point has been encountered. To avoid this delay,
@@ -163,8 +170,8 @@ var pace = fanin.extend({
             this.playback();
         }
         this.wakeup_timer = setTimeout(this.wakeup, 1000);
-    },
-    playback: function() {
+    }
+    playback() {
         this.timer = null;
         if (!this.last_t) {
             this.last_t = new JuttleMoment(Date.now()/1000);
@@ -202,8 +209,10 @@ var pace = fanin.extend({
             this.emit_mark(this.q[0][0].time) ; // mark end of batch (but don't shift yet)
         }
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = pace;

--- a/lib/runtime/procs/pass.js
+++ b/lib/runtime/procs/pass.js
@@ -7,12 +7,14 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var pass = fanin.extend({
-    procName: function() {
+class pass extends fanin {
+    procName() {
         return 'pass';
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = pass;

--- a/lib/runtime/procs/periodic-fanin.js
+++ b/lib/runtime/procs/periodic-fanin.js
@@ -6,7 +6,7 @@ var oops_fanin = require('./oops-fanin');
 
 var BATCH_OF_BATCHES = 1000;
 
-var periodic_fanin = oops_fanin.extend({
+class periodic_fanin extends oops_fanin {
     // mixin functions so batch and windowed reduce can share the ability
     // to track periodic intervals in timeseries and trigger actions
     // when crossing epoch boundaries. Mixers need to define process_points(),
@@ -15,13 +15,17 @@ var periodic_fanin = oops_fanin.extend({
     // to keep you on your toes, these mixins swallow eof() so derived
     // classes that implement eof() will break.  instead, this class
     // calls periodic_eof() so implement that instead.
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.epoch = this.next_epoch = undefined;
         this.dead = false;
-        this.periodic = true; // is this mixin mixed in?
+        // is this mixin mixed in?
+        this.periodic = true;
         // child should override these (and call init_warnings):
-        this.interval = null; // a duration
-        this.on = null ; // an optional alignment moment
+        // a duration
+        this.interval = null;
+        // an optional alignment moment
+        this.on = null ;
 
         // queue in case we're in the midst of a large batch-loop.
         // (see advance() below for details)
@@ -29,8 +33,8 @@ var periodic_fanin = oops_fanin.extend({
         this.post_batch_time = null;
         this.post_batch_eof = false;
         this.in_batch_loop = false;
-    },
-    init_warnings: function() {
+    }
+    init_warnings() {
         // call after the proc name and interval have been established
         var self = this;
         this.warn_drop = _.throttle(function() {
@@ -39,19 +43,19 @@ var periodic_fanin = oops_fanin.extend({
         this.warn_timeless = _.once(function() {
             self.trigger('warning', self.runtime_error('TIMELESS-POINTS'));
         });
-    },
-    teardown: function() {
+    }
+    teardown() {
         this.dead = true;
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         // ignore upstream marks, except for advancing time
         this.advance(time);
-    },
-    process_points: function(points) {
+    }
+    process_points(points) {
         // consume points, all in the same epoch
         throw new Error('write me!');
-    },
-    _process_helper: function(points) {
+    }
+    _process_helper(points) {
         var arr = points;
         var process_fun;
 
@@ -100,11 +104,11 @@ var periodic_fanin = oops_fanin.extend({
         }
 
         return out;
-    },
-    process: function(points) {
+    }
+    process(points) {
         this._process_helper(points);
-    },
-    advance: function(time) {
+    }
+    advance(time) {
         if (this.in_batch_loop) {
             this.post_batch_time = this.post_batch_time
                 ? JuttleMoment.max(time, this.post_batch_time) : time;
@@ -115,9 +119,9 @@ var periodic_fanin = oops_fanin.extend({
             this.next_epoch = JuttleMoment.quantize(time, this.interval, this.on);
         }
         return this._advance(time);
-    },
+    }
 
-    _advance: function(time) {
+    _advance(time) {
         var self = this;
         var n = 0;
         while (time.gte(this.next_epoch)) {
@@ -169,24 +173,24 @@ var periodic_fanin = oops_fanin.extend({
         }
 
         return true;
-    },
-    eof: function() {
+    }
+    eof() {
         if (this.in_batch_loop) {
             this.post_batch_eof = true;
         }
         else {
             this.periodic_eof();
         }
-    },
-    first_epoch: function(epoch) {
+    }
+    first_epoch(epoch) {
         // by default,  first epoch is like any other.
         // this is here to be overridden.
         var out = this.advance_epoch(epoch);
         this.emit(out);
-    },
-    advance_epoch: function(epoch) {
+    }
+    advance_epoch(epoch) {
         throw new Error('write me!');
     }
-});
+}
 
 module.exports = periodic_fanin;

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -16,8 +16,9 @@ var INFO = {
     }
 };
 
-var put = oops_fanin.extend({
-    initialize: function(options, params, location, program) {
+class put extends oops_fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var self = this;
         var allowed_options = ['acc', 'groupby', 'over', 'from', 'reset'];
         this.validate_options(allowed_options);
@@ -51,11 +52,11 @@ var put = oops_fanin.extend({
                 return windowMaker(self.groups.funcMaker, self.over, self.location);
             };
         }
-    },
-    procName: function() {
+    }
+    procName() {
         return 'put';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k, row, expr = this.expr;
         var out = [];
         for (k = 0; k < points.length; ++k) {
@@ -102,8 +103,8 @@ var put = oops_fanin.extend({
                 }
             });
         }
-    },
-    reset: function() {
+    }
+    reset() {
         if (this.over) {
             // windowed mode: reset individual rows by calling their funcMakers
             this.groups.reset_fns();
@@ -111,19 +112,21 @@ var put = oops_fanin.extend({
             // non-windowed mode: tear down the whole group table and start over
             this.groups.reset_groups();
         }
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         if (!this.accumulate) {
             this.reset();
         }
         this.emit_mark(time, from);
-    },
-    eof: function() {
+    }
+    eof() {
         this.reset();
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = put;

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -7,8 +7,9 @@ var values = require('../values');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var Promise = require('bluebird');
 
-var Read = source.extend({
-    initialize: function(options, params, location, program) {
+class Read extends source {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
         if (!adapter.read) {
             throw this.compile_error('JUTTLE-UNSUPPORTED-ADAPTER-MODE', {
@@ -63,15 +64,15 @@ var Read = source.extend({
         });
 
         this.nextTick = this.program.now;
-    },
+    }
 
-    procName: function() {
+    procName() {
         return 'read-' + this.params.adapter.name;
-    },
+    }
 
     // Set the initial time parameters for read from the adapter and
     // schedule the initial run.
-    start: function() {
+    start() {
         // First tell the adapter to kick off the process of reading.
         this.adapter.start();
 
@@ -126,10 +127,10 @@ var Read = source.extend({
             this.logger.debug('scheduling first live read at', firstRead.toJSON());
             this.program.scheduler.schedule(firstRead.unixms(), _.bind(this.run, this));
         }
-    },
+    }
 
     // Kick off a read iteration from the adapter.
-    run: function() {
+    run() {
         if (this.reading) {
             throw new Error('run should not be called while reading');
         }
@@ -200,9 +201,9 @@ var Read = source.extend({
             this.trigger('error', err);
             this.emit_eof();
         });
-    },
+    }
 
-    teardown: function() {
+    teardown() {
         var readDone = this.reading || Promise.resolve();
 
         readDone
@@ -212,14 +213,14 @@ var Read = source.extend({
         .then(() => {
             this.emit_eof();
         });
-    },
+    }
 
-    emit_eof: function() {
+    emit_eof() {
         if (!this.eofSent) {
             this.eofSent = true;
             source.prototype.emit_eof.call(this);
         }
     }
-});
+}
 
 module.exports = Read;

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -26,10 +26,11 @@ var INFO = {
     }
 };
 
-var reduce_base = periodic_fanin.extend({
+class reduce_base extends periodic_fanin {
     // basic reducer runner functions to feed points to reducers and
     // evaluate at epochs.
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var self = this;
         // call this from initialize() if you mix in these functions.
         if (options.over && !options.over.duration) {
@@ -85,8 +86,8 @@ var reduce_base = periodic_fanin.extend({
             };
         }
         this.last_epoch = JuttleMoment.epsMoment(-Infinity);
-    },
-    witness_timestamp: function(time) {
+    }
+    witness_timestamp(time) {
         // is time in the half-open interval [from...to), or timeless?
         // return true so it can be processed. Else possibly advance
         // an out-of-window reducer to its final time and return false.
@@ -98,8 +99,8 @@ var reduce_base = periodic_fanin.extend({
             this.emit(out);
         }
         return false;
-    },
-    process_points: function(points) {
+    }
+    process_points(points) {
         var k;
         for (k = 0; k < points.length; ++k) {
             if (this.witness_timestamp(points[k].time)) {
@@ -107,21 +108,21 @@ var reduce_base = periodic_fanin.extend({
                 this.batch_size += 1;
             }
         }
-    },
-    process_pt: function(pt) {
+    }
+    process_pt(pt) {
         // advance/update each reducer on the point
         var row = this.groups.lookup(pt);
         for (var k = 0; k < row.fns.length; ++k) {
             row.fns[k].update(pt);
         }
-    },
-    good_epoch: function(time) {
+    }
+    good_epoch(time) {
         // is time in the closed interval [min...to]?
         var min = this.min_epoch || this.from;
         return ((!min || min.lte(time)) &&
                 (!this.to || this.to.gte(time)));
-    },
-    advance_epoch: function(epoch) {
+    }
+    advance_epoch(epoch) {
         // we are crossing an epoch timestamp, so execute the reduce at the epoch.
         // output some points, and reset for the next one.
         var that = this, out = [];
@@ -178,8 +179,8 @@ var reduce_base = periodic_fanin.extend({
             out.sort(utils.pointSortFunc('time'));
         }
         return out;
-    },
-    reset: function() {
+    }
+    reset() {
         if (this.over || !this.forget) {
             // windowed or remember-groups mode: reset individual rows by calling their funcMakers
             this.groups.reset_fns();
@@ -187,8 +188,8 @@ var reduce_base = periodic_fanin.extend({
             // non-windowed forgetful mode: tear down the whole group table and start over
             this.groups.reset_groups();
         }
-    },
-    tick: function(time) {
+    }
+    tick(time) {
         // give the tick a chance to advance the reducer if it should.
         if (this.periodic && time.gt(this.program.now)) {
             this.advance(time);
@@ -198,13 +199,14 @@ var reduce_base = periodic_fanin.extend({
         }
         this.emit_tick(time);
     }
-});
+}
 
 
 // reduce driven by upstream batches or EOF.
 // Mix in grouping and reduce runner behaviors
-var reduce_batch = reduce_base.extend({
-    initialize: function(options, params, location, program) {
+class reduce_batch extends reduce_base {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
 
@@ -221,14 +223,14 @@ var reduce_batch = reduce_base.extend({
             });
         }
         this.has_first_mark = false;
-    },
-    procName: function() {
+    }
+    procName() {
         return 'reduce';
-    },
-    process: function(points) {
+    }
+    process(points) {
         this.process_points(points);
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         if (this.has_first_mark) {
             var out = this.advance_epoch(time);
             this.emit(out, from);
@@ -240,8 +242,8 @@ var reduce_batch = reduce_base.extend({
         // batch end mark if they came from a sort/reduce/join
         // processor.
         this.emit_mark(time, from);
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         var self = this;
         if (!this.has_first_mark) {
             // unbatched: run once. If -to was specified the one-shot
@@ -260,15 +262,16 @@ var reduce_batch = reduce_base.extend({
         }
         this.emit_eof();
     }
-});
+}
 
 // data-driven reduce. This works like proc._reduce, but with epochs
 // specified by -every and -on, and reduce operations triggered when
 // timestamps cross epoch boundaries. It ignores any received batch
 // marks (except to advance time) and does not emit marks with its results.
 // Mix in periodic, grouping, and reduce runner behaviors
-var reduce_every = reduce_base.extend({
-    initialize: function(options, params, location, program) {
+class reduce_every extends reduce_base {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
 
@@ -308,21 +311,21 @@ var reduce_every = reduce_base.extend({
             this.on = options.from || options.to ;
         }
         this.init_warnings();
-    },
-    procName: function() {
+    }
+    procName() {
         return 'reduce';
-    },
-    first_epoch: function(epoch) {
+    }
+    first_epoch(epoch) {
         // don't run on the first epoch (called by advance)
-    },
+    }
     //
     // mark() and process() are from periodic. tick() from reduce_runner_funcs
     //
-    emit_mark: function(time) {
+    emit_mark(time) {
         // this should ever happen, but let's be sure.
         throw new Error('ereduce: somebody called emit_mark!');
-    },
-    periodic_eof: function(from) {
+    }
+    periodic_eof(from) {
         if (this.batch_size) {
             // run once more for a trailing partial batch of points
             var out = this.advance_epoch(this.next_epoch);
@@ -330,7 +333,7 @@ var reduce_every = reduce_base.extend({
         }
         this.emit_eof();
     }
-});
+}
 
 
 

--- a/lib/runtime/procs/remove.js
+++ b/lib/runtime/procs/remove.js
@@ -8,14 +8,15 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var remove = fanin.extend({
-    initialize: function(options, params, location, program) {
+class remove extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.columns = options.columns || [];
-    },
-    procName: function() {
+    }
+    procName() {
         return 'remove';
-    },
-    process: function (points) {
+    }
+    process(points) {
         var pt, k, m, fld;
         var cols = this.columns;
         var out = [];
@@ -29,8 +30,10 @@ var remove = fanin.extend({
         }
         this.emit(out);
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = remove;

--- a/lib/runtime/procs/sequence.js
+++ b/lib/runtime/procs/sequence.js
@@ -12,8 +12,9 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var sequence = fanin.extend({
-    initialize: function(options, params, location, program) {
+class sequence extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.seqno = 0;
         this.predicates = params.predicates;
         this.seq_fieldname = '_seqno';
@@ -22,10 +23,10 @@ var sequence = fanin.extend({
             return p1.time.milliseconds() - p2.time.milliseconds();
         });
         this.groups = new Groups(this, options);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'sequence';
-    },
+    }
 
     // For each incoming point, look up group buffer
     // evaluate filters[buffer.len] on point
@@ -41,7 +42,7 @@ var sequence = fanin.extend({
     //   away, because that could lead to OOO. So we put it in a buffer, and
     //   we emit all the points from that buffer that have a time that is <
     //   than the minumum time of all in-progress sequences.
-    process: function(points) {
+    process(points) {
         var self = this;
 
         function scan_earliest() {
@@ -105,8 +106,8 @@ var sequence = fanin.extend({
                 }
             }
         });
-    },
-    try_send: function try_send() {
+    }
+    try_send() {
         var out = [];
         while (!this.output_buffer.empty() && this.output_buffer.peek().time.milliseconds() < this.earliest_in_progress) {
             out.push(this.output_buffer.pop());
@@ -114,14 +115,16 @@ var sequence = fanin.extend({
         if (out.length > 0) {
             this.emit(out);
         }
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         this.earliest_in_progress = Infinity;
         this.try_send();
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = sequence;

--- a/lib/runtime/procs/sink.js
+++ b/lib/runtime/procs/sink.js
@@ -9,8 +9,9 @@ var SINK_INFO = {
 };
 
 // base class for all sinks (both client-side views and adapter write procs)
-var sink = fanin.extend({
-    initialize: function(options, params, location, program) {
+class sink extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         // To indicate when the sink is finished, stash a completion trigger in
         // this.done() that resolves the `isDone` promise.
         //
@@ -20,9 +21,11 @@ var sink = fanin.extend({
         this.isDone = new Promise(function(resolve, reject) {
             self.done = resolve;
         });
-    },
-}, {
-    info: SINK_INFO
-});
+    }
+
+    static get info() {
+        return SINK_INFO;
+    }
+}
 
 module.exports = sink;

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -10,8 +10,9 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var skip = fanin.extend({
-    initialize: function(options, params, location, program) {
+class skip extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('INTEGER-REQUIRED', {
                 proc: 'skip',
@@ -20,11 +21,11 @@ var skip = fanin.extend({
         }
         this.n = options.arg;
         this.groups = new Groups(this, options);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'skip';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {
             row = this.groups.lookup(points[k]);
@@ -37,18 +38,20 @@ var skip = fanin.extend({
                 this.emit([points[k]]);
             }
         }
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         // process and publish each mark
         this.groups.reset();
         this.emit_mark(time);
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         this.groups.reset();
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = skip;

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -12,8 +12,9 @@ var INFO = {
     }
 };
 
-var sort = fanin.extend({
-    initialize: function(options, params, location, program) {
+class sort extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         //
         // XXX 'sortby' should be a list of fields like group-by
         // where the list comprises subkeys for subsorts
@@ -23,11 +24,11 @@ var sort = fanin.extend({
         this.cmp = this.sortfunc();
         this.groups = new Groups(this, options);
         this.n_pts = 0;
-    },
-    procName: function() {
+    }
+    procName() {
         return 'sort';
-    },
-    _run: function(time) {
+    }
+    _run(time) {
         var self = this;
         _.each(this.groups.table, function(row) {
             _.each(self.sortby, function(sortKey) {
@@ -57,8 +58,8 @@ var sort = fanin.extend({
 
         this.groups.reset();
         this.n_pts = 0;
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k, row;
         var space_left = this.limit - this.n_pts;
         if (space_left < points.length) {
@@ -79,17 +80,17 @@ var sort = fanin.extend({
             row.pts.push(points[k]);
         }
         this.n_pts += points.length;
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         // process and publish each mark
         this._run(time);
         this.emit_mark(time);
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         this._run(null);
         this.emit_eof();
-    },
-    sortfunc: function() {
+    }
+    sortfunc() {
         var cmps = this.sortby.map(function(sortKey) {
             return utils.pointSortFunc(sortKey.field, sortKey.direction);
         });
@@ -99,8 +100,10 @@ var sort = fanin.extend({
             }, 0);
         };
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = sort;

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -20,15 +20,16 @@ var INFO = {
     }
 };
 
-var source = base.extend({
-    initialize: function(options, params, location, program) {
+class source extends base {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.queue = [];
         this.queueSize = options.queueSize || 100000;
 
         this.lastEmit = new JuttleMoment(0);
         this.tickEvery = JuttleMoment.duration(1, 's');
         this.nextTick = this.program.now.add(this.tickEvery);
-    },
+    }
 
     // Process the common time options (from / to / last) to ensure they are all
     // the correct types and to convert `last` into the corresponding from/to
@@ -36,7 +37,7 @@ var source = base.extend({
     //
     // If the time selection is valid, it is stored in `this.from` and
     // `this.to`.
-    handleTimeOptions: function(options) {
+    handleTimeOptions(options) {
         if (options.from) {
             if (! options.from.moment) {
                 throw this.compile_error('MOMENT-ERROR', {
@@ -77,7 +78,7 @@ var source = base.extend({
             options.from = options.to.subtract(options.last);
             delete options.last;
         }
-    },
+    }
 
     // Assigns the time from timeField to 'time' and attempts to convert it
     // into JuttleMoment
@@ -87,9 +88,9 @@ var source = base.extend({
     //
     // XXX/demmer this can be removed once all adapters have been converted
     // over to the new adapter read API.
-    parseTime: function(points, timeField) {
+    parseTime(points, timeField) {
         return juttle_utils.parseTime(points, timeField, this);
-    },
+    }
 
     // Callback from the subclass to indicate that points have been produced
     // and are ready to be emitted.
@@ -98,18 +99,18 @@ var source = base.extend({
     // the points onto a queue and then rely on interactions with the scheduler
     // to drain the queue before rescheduling. For now it just emits
     // immediately.
-    enqueue: function(points, output) {
+    enqueue(points, output) {
         this.emit(points, output);
         var lastPt = points[points.length - 1];
         if (lastPt.time) {
             this.lastEmit = lastPt.time;
         }
-    },
+    }
 
     // Send ticks downstream if `tickEvery` has elapsed between the last emitted
     // point (stored in `this.lastEmit)` and `to`, which is set by the source to
     // be time up to which the adapter has read all the data.
-    emitTicks: function(to) {
+    emitTicks(to) {
         while (this.nextTick.lt(to)) {
             if (this.nextTick.gt(this.lastEmit)) {
                 this.emit_tick(this.nextTick);
@@ -117,8 +118,10 @@ var source = base.extend({
             this.nextTick = this.nextTick.add(this.tickEvery);
         }
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = source;

--- a/lib/runtime/procs/split.js
+++ b/lib/runtime/procs/split.js
@@ -9,9 +9,10 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var split = fanin.extend({
+class split extends fanin {
     // the wickham 'melt' operation. now with array exploding!
-    initialize: function(options, params, location, program) {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var allowed_options = ['arrays', 'columns'];
         this.validate_options(allowed_options);
 
@@ -20,11 +21,11 @@ var split = fanin.extend({
             throw this.compile_error('SPLIT-NAME');
         }
         this.arrays = (options.arrays === undefined) ? true : Boolean(options.arrays);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'split';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var out = [];
         var i, j, k, field;
         for (i=0 ; i < points.length ; i++) {
@@ -53,8 +54,10 @@ var split = fanin.extend({
         }
         this.emit(out);
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = split;

--- a/lib/runtime/procs/stoke/duraflame.js
+++ b/lib/runtime/procs/stoke/duraflame.js
@@ -36,55 +36,52 @@ var pix_patterns = require('./data/pix-patterns');
 var sysinfo_patterns = require('./data/syslog-info-patterns');
 var syserror_patterns = require('./data/syslog-error-patterns');
 
-var Chooser = StokeSequence.extend({
+class Chooser extends StokeSequence {
     // select random messages from choices.
-    initialize: function initialize(seed, dt, choices) {
+    constructor(seed, dt, choices) {
+        super(seed, dt, choices);
         this.choices = choices;
-    },
-    message: function message(moment) {
+    }
+    message(moment) {
         return this.choose(moment, this.choices);
     }
-});
-
-var MultiChooser = StokeSequence.extend({
+}class MultiChooser extends StokeSequence {
     // select a message generator from choices based on evaluating
     // choicepf which returns an array of probabilities, or may be a
     // constant array of probabilities for corresponding choices.
-    initialize: function initialize(seed, dt, choices, choicepf) {
+    constructor(seed, dt, choices, choicepf) {
+        super(seed, dt, choices, choicepf);
         this.choices = choices;
         this.choicepf = choicepf;
-    },
-    reset: function reset() {
+    }
+    reset() {
         StokeSequence.prototype.reset.call(this);
         this.choices.forEach(function(chooser) { chooser.reset(); });
         return this;
-    },
-    message: function message(moment) {
+    }
+    message(moment) {
         var choicep = ((this.choicepf instanceof Function) ?
                        this.choicepf(moment) : this.choicepf);
         var choiceidx = this.choose_weighted(moment, choicep);
         var choice = this.choices[choiceidx];
         return choice.message(moment);
     }
-});
-
-var TwoWayChooser = MultiChooser.extend({
+}class TwoWayChooser extends MultiChooser {
     // create a chooser that juggles between two choosers according to
     // the firstp function, which gives the probability of the first
     // choice (0..1) at the given moment, or may be a constant.
-    initialize: function initialize(seed, dt, choices, firstpf) {
+    constructor(seed, dt, choices, firstpf) {
+        super(seed, dt, choices, firstpf);
         this.choicepf = function choicepf(moment) {
             var firstp = ((firstpf instanceof Function) ?
                           firstpf(moment) : firstpf);
             return [firstp, 1 - firstp];
         };
     }
-});
-
-
-var Madlib = StokeSequence.extend({
+}class Madlib extends StokeSequence {
     // build a duraflame by madlibbing from a MEOH-distilled list of patterns.
-    initialize: function initialize(seed, dt, patterns) {
+    constructor(seed, dt, patterns) {
+        super(seed, dt, patterns);
         this.words = new Words(seed, dt);
         //
         // compute statistics for each pattern
@@ -105,13 +102,13 @@ var Madlib = StokeSequence.extend({
         });
         this.patterns = patterns;
         this.pattern_p = pattern_p;
-    },
-    reset: function reset() {
+    }
+    reset() {
         StokeSequence.prototype.reset.call(this);
         this.words.reset();
         return this;
-    },
-    realize_token: function realize_token(t, token) {
+    }
+    realize_token(t, token) {
         // turn the token into text
         var n;
         switch (token) {
@@ -132,8 +129,8 @@ var Madlib = StokeSequence.extend({
             default:
                 throw new Error('duraflame: unknown token:'+token);
         }
-    },
-    realize_word: function realize_word(t, term) {
+    }
+    realize_word(t, term) {
         // generate a literal word from a term object by choosing among
         // multiple word possibilties and substituting random values for
         // special tokens
@@ -146,8 +143,8 @@ var Madlib = StokeSequence.extend({
             word = word.replace(prefix+token, prefix+value);
         }
         return word;
-    },
-    realize_message: function realize_message(t, pattern) {
+    }
+    realize_message(t, pattern) {
         // generate a message string from the pattern by randomly choosing
         // among term word possibilities. pattern and its terms must have
         // been pre-annotated with probabilities as in meoh().
@@ -157,15 +154,15 @@ var Madlib = StokeSequence.extend({
             result.push(self.realize_word(t, term));
         });
         return result.join(' ');
-    },
-    message: function message(t) {
+    }
+    message(t) {
         this.push_sequential();
         var choice = this.choose_weighted(t, this.pattern_p);
         var text = this.realize_message(t, this.patterns[choice]);
         this.pop_sequential();
         return text;
     }
-});
+}
 
 function mergelog(seed, dt) {
     return new Chooser(seed, dt, merge_messages);

--- a/lib/runtime/procs/stoke/stoke.js
+++ b/lib/runtime/procs/stoke/stoke.js
@@ -12,7 +12,6 @@ There are two distinct styles of time-indexed randomness:
 which can be re-played by calling a reset function (a StokeSequence)
 */
 var _ = require('underscore');
-var Base = require('extendable-base');
 var util = require('./util');
 var seedrandom = require('seedrandom');
 var primes = require('./primes');
@@ -21,10 +20,10 @@ var errors = require('../../../errors');
 
 var MarkovCache = new FIFOCache(50000);
 
-var Stoke = Base.extend({
+class Stoke {
     // Stoke: stoke.func(t) always returns the same value
     // for a given t.
-    initialize: function initialize(seed, dt) {
+    constructor(seed, dt) {
         // seed: integer. Different seeds produce different random
         // sequences.
         // dt: float: time-granularity of simulated stochastic
@@ -36,26 +35,26 @@ var Stoke = Base.extend({
         this.stride2 = primes[(this.seed + 1) % primes.length];
         this.i = 0;
         this.sequential = 0; // when > 0, successive calls at t yield a sequence
-    },
-    clone: function clone(sequential) {
+    }
+    clone(sequential) {
         var stoke = new Stoke(this.seed, this.dt);
         stoke.sequential = (sequential === undefined)? this.sequential : sequential;
         return stoke;
-    },
-    bump: function bump(sequential) {
+    }
+    bump(sequential) {
         // increment the seed and return a fresh copy.
         var stoke = new Stoke(++this.seed, this.dt);
         stoke.sequential = (sequential === undefined)? this.sequential : sequential;
         return stoke;
-    },
-    reset: function reset() {
+    }
+    reset() {
         // reset the sequence counter, for successive calls with the same
         // t when sequential > 0;
         this.i = 0;
         this.last_t = null;
         return this;
-    },
-    step: function step(t) {
+    }
+    step(t) {
         // bump the sequence counter, for successive calls with the
         // same t when sequential > 0; Note: This resets when t
         // changes, because we do not track states for all t's in
@@ -67,18 +66,18 @@ var Stoke = Base.extend({
             this.last_t = t;
         }
         return this;
-    },
-    push_sequential: function push_sequential() {
+    }
+    push_sequential() {
         // temporarily begin sequential behavior. balance with a call to
         // pop_sequential() to restore original behavior when done.
         this.sequential ++;
-    },
-    pop_sequential: function pop_sequential() {
+    }
+    pop_sequential() {
         if (--this.sequential === 0) {
             this.reset() ;
         }
-    },
-    uniform: function uniform(T) {
+    }
+    uniform(T) {
         // return a uniform random number between 0..1. If !this.sequential, always
         // return the same number for a given t, else return a repeatable sequence
         // for successive calls at t.
@@ -90,8 +89,8 @@ var Stoke = Base.extend({
         var n = Math.floor(Math.abs(t / this.dt - this.seed));
         var idx = (n * this.stride + this.i) % _uniform_samples.length;
         return _uniform_samples[idx];
-    },
-    boxmuller: function boxmuller(t) {
+    }
+    boxmuller(t) {
         // return a pair of Box-Muller approximate normals, indexed by t
         this.push_sequential();
         var u = 2 * this.uniform(t) - 1;
@@ -106,8 +105,8 @@ var Stoke = Base.extend({
         var c = Math.sqrt(-2*Math.log(r)/r);
         this.pop_sequential();
         return [u*c, v*c];
-    },
-    normal: function normal(T) {
+    }
+    normal(T) {
         // return a N(0,1) random number. If !this.sequential, always
         // return the same number for a given t, else return a
         // repeatable sequence for successive calls at t.
@@ -119,13 +118,13 @@ var Stoke = Base.extend({
         var n = Math.floor(Math.abs(t / this.dt - this.seed));
         var idx = (n * this.stride + this.i) % _normal_samples.length;
         return _normal_samples[idx];
-    },
-    integer: function integer(t, min, max) {
+    }
+    integer(t, min, max) {
         // choose an integer uniformly from min..max inclusive.
         var x = this.uniform(t);
         return Math.floor((max - min + 1) * x) + min;
-    },
-    ip: function ip(t) {
+    }
+    ip(t) {
         var ipnum = Math.floor(this.uniform(t)*Math.pow(2,32));
         return ( [
             Math.floor( ipnum / 16777216 ) % 256,
@@ -133,12 +132,12 @@ var Stoke = Base.extend({
             Math.floor( ipnum / 256      ) % 256,
             Math.floor( ipnum            ) % 256
         ]).join('.');
-    },
-    noisy: function noisy(t, val, sigma, min, max) {
+    }
+    noisy(t, val, sigma, min, max) {
         val += sigma * this.normal(t) ;
         return util.bound(val, min, max);
-    },
-    digits: function digits(t, n, base) {
+    }
+    digits(t, n, base) {
         // generate a string of digits of length n in the given base.
         // defaults are length 4 and base 10
         n = n || 4;
@@ -151,8 +150,8 @@ var Stoke = Base.extend({
         }
         this.pop_sequential();
         return result.substr(-n);
-    },
-    mac: function mac(t) {
+    }
+    mac(t) {
         // generate a random MAC address
         var addr = [];
         this.push_sequential();
@@ -161,8 +160,8 @@ var Stoke = Base.extend({
         }
         this.pop_sequential();
         return addr.join(':');
-    },
-    random_occurrences: function random_occurrences(t, period, rate) {
+    }
+    random_occurrences(t, period, rate) {
         // return a random integer count of events over the given period,
         // indexed by t, such that average occurrences per unit time ==
         // rate.  note: this does not do aggregation over specific
@@ -185,14 +184,14 @@ var Stoke = Base.extend({
             // Poisson for large lambda
             return Math.floor(this.normal(t) * Math.sqrt(lambda) + lambda) ;
         }
-    },
-    choose: function choose(t, choices) {
+    }
+    choose(t, choices) {
         // choose an item randomly from the choices such that the same
         // choice holds for this.dt seconds around t.
         var p = this.uniform(t);
         return choices[Math.floor(p * choices.length)];
-    },
-    choose_weighted: function choose_weighted(t, choices) {
+    }
+    choose_weighted(t, choices) {
         // Choose a key from choices, an object whose keys are the items
         // we want to choose from and whose values are the weights of its
         // keys (0..1, summing to 1.0).  If you pass a list of weights
@@ -208,9 +207,9 @@ var Stoke = Base.extend({
             }
         }
         return choice; // roundoff
-    },
+    }
 
-    cached_markov: function cached_markov(t, choices) {
+    cached_markov(t, choices) {
         // Keep a cache of recent markov values to avoid having to search
         // for them each time. We make the sane assumption that nobody
         // would use one stoke for multiple state machines, and thus do
@@ -222,9 +221,9 @@ var Stoke = Base.extend({
             MarkovCache.put(key, result);
         }
         return result;
-    },
+    }
 
-    markov: function markov(t, choices) {
+    markov(t, choices) {
         // Simulate a limited class of discrete markov process in
         // which transition probabilities do not depend on state. For
         // this kind of process, instead of storing an evolving
@@ -254,8 +253,8 @@ var Stoke = Base.extend({
         // fail-safe: return last choice if we're spinning our wheels
         this.pop_sequential();
         return choice;
-    },
-    markov_switcherf: function markov_switcherf(items, avgdur, cached, location) {
+    }
+    markov_switcherf(items, avgdur, cached, location) {
         // return a function(moment) that switches randomly among items
         // over time such that on average a given choice holds for avgdur,
         // with events resolved to granularity dt. dt should be some
@@ -284,8 +283,8 @@ var Stoke = Base.extend({
                 return isNumber ? 1 * choice : choice;
             };
         }
-    },
-    round_robin_switcherf: function round_robin_switcherf(items, period) {
+    }
+    round_robin_switcherf(items, period) {
         // return a function(moment) analogous to markov_switcherf,
         // but that switches sequentially among items, switching once
         // each period. Not random, but convenient.
@@ -294,22 +293,21 @@ var Stoke = Base.extend({
             var idx = Math.floor(moment.unix()/period) % items.length ;
             return items[idx];
         };
-    },
-});
-
-var StokeSequence = Stoke.extend({
+    }
+}class StokeSequence extends Stoke {
     // StokeSequence: stoke.func(t) called repeatedly with the same t
     // returns a random sequence. This sequence is repeatable by
     // calling reset() or whenever t is returned to after evaluations
     // at other values of t.
-    initialize: function(seed, dt) {
+    constructor(seed, dt) {
+        super(seed, dt);
         // seed: integer. Different seeds produce different random sequences.
         // dt: float: time-granularity of simulated stochastic process.
         // invocations separated in time by less than dt will return the same value.
         this.sequential = 1;
         this.last_t = null;
     }
-});
+}
 
 // pre-load global arrays with uniform random samples, and
 // pre-generate normal random samples from these. Thereafter, random
@@ -328,7 +326,8 @@ for (i=0 ; i < (N_SAMPLES+1)/2 ; i++) {
     _normal_samples.push(pair[0]);
     _normal_samples.push(pair[1]);
 }
-_normal_samples.pop() ; // discard so length === N_SAMPLES
+// discard so length === N_SAMPLES
+_normal_samples.pop() ;
 
 module.exports = {
     Stoke: Stoke,

--- a/lib/runtime/procs/stoke/words.js
+++ b/lib/runtime/procs/stoke/words.js
@@ -19,44 +19,44 @@ var lastnames = require('./data/lastname-list');
 var merge_messages = require('./data/merge-message-list');
 var commit_messages = require('./data/commit-message-list');
 
-var Words = StokeSequence.extend({
-    shortword: function word(t) {
+class Words extends StokeSequence {
+    shortword(t) {
         // return a random English word 4-6 characters long
         return this.choose(t, shortwords);
-    },
-    sysword: function sysword(t) {
+    }
+    sysword(t) {
         // return a random unix system path word 3-6 characters long
         return this.choose(t, syswords);
-    },
-    agent: function agent(t) {
+    }
+    agent(t) {
         // return a random browser agent string
         return this.choose(t, agents);
-    },
-    country: function country(t) {
+    }
+    country(t) {
         // return a random country code
         return this.choose(t, countries);
-    },
-    domain: function domain(t) {
+    }
+    domain(t) {
         // return a random internet domain name
         return this.choose(t, domains);
-    },
-    firstname: function firstname(t) {
+    }
+    firstname(t) {
         // return a random firstname
         return this.choose(t, firstnames);
-    },
-    lastname: function lastname(t) {
+    }
+    lastname(t) {
         // return a random lastname
         return this.choose(t, lastnames);
-    },
-    commit_message: function commit_message(t) {
+    }
+    commit_message(t) {
         // return a git commit log message
         return this.choose(t, commit_messages);
-    },
-    merge_message: function merge_message(t) {
+    }
+    merge_message(t) {
         // return a git merge log message
         return this.choose(t, merge_messages);
-    },
-    path: function path(t, n, m) {
+    }
+    path(t, n, m) {
         // return a random unix-like path with length between n and m inclusive.
         // if m is unspecified, return length n. n defaults to 5.
         n = n || 5;
@@ -69,15 +69,15 @@ var Words = StokeSequence.extend({
         }
         this.pop_sequential();
         return '/' + words.join('/');
-    },
-    color: function color(t) {
+    }
+    color(t) {
         return this.choose(t, [
             'black', 'maroon', 'green', 'navy', 'olive',
             'purple', 'teal', 'lime', 'blue', 'silver',
             'gray', 'yellow', 'fuchsia', 'aqua', 'white'
         ]);
     }
-});
+}
 
 module.exports = {
     Words: Words,

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -11,8 +11,9 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var tail = fanin.extend({
-    initialize: function(options, params, location, program) {
+class tail extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('INTEGER-REQUIRED', {
                 proc: 'tail',
@@ -21,11 +22,11 @@ var tail = fanin.extend({
         }
         this.limit = options.arg;
         this.groups = new Groups(this, options);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'tail';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {
             row = this.groups.lookup(points[k]);
@@ -37,22 +38,22 @@ var tail = fanin.extend({
                 row.pts.shift();
             }
         }
-    },
-    _run: function() {
+    }
+    _run() {
         this.emit_ordered_points();
         this.groups.reset();
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         // process and publish each mark
         this._run();
         this.emit_mark(time);
-    },
-    eof: function(from) {
+    }
+    eof(from) {
         this._run();
         this.emit_eof();
-    },
+    }
 
-    emit_ordered_points: function() {
+    emit_ordered_points() {
         var points = _(this.groups.table)
             .chain()
             .map(function(row) {
@@ -84,8 +85,10 @@ var tail = fanin.extend({
 
         this.emit(_.toArray(finalPoints));
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = tail;

--- a/lib/runtime/procs/unbatch.js
+++ b/lib/runtime/procs/unbatch.js
@@ -8,23 +8,25 @@ var INFO = {
 };
 
 // unbatch, simply forwards everything except marks
-var unbatch = fanin.extend({
-    procName: function() {
+class unbatch extends fanin {
+    procName() {
         return 'unbatch';
-    },
-    process: function(points) {
+    }
+    process(points) {
         this.emit(points);
-    },
-    mark: function(time) { },
-    tick: function(time) {
+    }
+    mark(time) { }
+    tick(time) {
         this.emit_tick(time);
-    },
-    eof: function() {
+    }
+    eof() {
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 
 

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -13,15 +13,16 @@ var INFO = {
 /* like unix uniq command:
    Emits each data point that differs from the one
    that came before it. Swallows other points. */
-var uniq = fanin.extend({
-    initialize: function(options, params, location, program) {
+class uniq extends fanin {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.fields = options.arg || [];
         this.groups = new Groups(this, options);
-    },
-    procName: function() {
+    }
+    procName() {
         return 'uniq';
-    },
-    process: function(points) {
+    }
+    process(points) {
         var toEmit = [];
 
         for (var i = 0; i < points.length; i++) {
@@ -57,16 +58,18 @@ var uniq = fanin.extend({
         if (toEmit.length > 0) {
             this.emit(toEmit);
         }
-    },
-    mark: function(time, from) {
+    }
+    mark(time, from) {
         this.groups.reset();
         this.emit_mark(time);
-    },
-    eof: function() {
+    }
+    eof() {
         this.emit_eof();
     }
-}, {
-    info: INFO
-});
+
+    static get info() {
+        return INFO;
+    }
+}
 
 module.exports = uniq;

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -7,15 +7,16 @@ var INFO = {
     options: {}   // documented, non-deprecated options only
 };
 
-var view = sink.extend({
-    initialize: function(options, params, location, program) {
+class view extends sink {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         this.name = params.name;
         this.channel = 'view' + (program.channels++);
-    },
+    }
 
-    procName: function() {
+    procName() {
         return 'view';
-    },
+    }
 
     // When views get points/marks/ticks, they emit events on
     // the related program object. Program users will subscribe for
@@ -25,23 +26,24 @@ var view = sink.extend({
     // error/warning events and has special handling of arguments to
     // include proc names including the error/warning.
 
-    mark: function(time) {
+    mark(time) {
         this.program.events.emit('view:mark', {channel: this.channel, time: time});
-    },
-    tick: function(time) {
+    }
+    tick(time) {
         this.program.events.emit('view:tick', {channel: this.channel, time: time});
-    },
-    eof: function() {
+    }
+    eof() {
         this.program.events.emit('view:eof', {channel: this.channel});
         this.done();
-    },
-    process: function(points) {
+    }
+    process(points) {
         this.program.events.emit('view:points', {channel: this.channel, points: points});
     }
 
-}, {
-    info: INFO
-});
+    static get info() {
+        return INFO;
+    }
+}
 
 
 module.exports = view;

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -4,8 +4,9 @@ var sink = require('./sink');
 var adapters = require('../adapters');
 var Promise = require('bluebird');
 
-var Write = sink.extend({
-    initialize: function(options, params, location, program) {
+class Write extends sink {
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
         if (!adapter.write) {
             throw this.compile_error('JUTTLE-UNSUPPORTED-ADAPTER-MODE', {
@@ -25,21 +26,21 @@ var Write = sink.extend({
         });
 
         this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
-    },
+    }
 
-    procName: function() {
+    procName() {
         return 'write-' + this.params.adapter.name;
-    },
+    }
 
-    start: function() {
+    start() {
         this.adapter.start();
-    },
+    }
 
-    process: function(points) {
+    process(points) {
         this.adapter.write(points);
-    },
+    }
 
-    eof: function() {
+    eof() {
         this.logger.debug('eof');
         Promise.try(() => {
             return this.adapter.eof();
@@ -49,11 +50,13 @@ var Write = sink.extend({
             this.done();
         });
     }
-}, {
-    info: {
-        type: 'sink',
-        options: {}
+
+    static get info() {
+        return {
+            type: 'sink',
+            options: {}
+        };
     }
-});
+}
 
 module.exports = Write;

--- a/lib/runtime/scheduler.js
+++ b/lib/runtime/scheduler.js
@@ -1,33 +1,31 @@
 'use strict';
 
 var Heap = require('heap');
-var Base = require('extendable-base');
-
-var Scheduler = Base.extend({
-    initialize: function(options) {
+class Scheduler {
+    constructor(options) {
         this.timer = null;
         this.queue = new Heap(function(a, b) { return a.ms - b.ms; });
-    },
+    }
 
-    now: function() {
+    now() {
         return Date.now();
-    },
+    }
 
-    schedule: function(time, callback) {
+    schedule(time, callback) {
         this.queue.push({ms:time, callback:callback});
         if (this.timer) { clearTimeout(this.timer); }
         this._run_after(0);
-    },
+    }
 
-    start: function() {
+    start() {
         this._run_after(0);
-    },
+    }
 
-    stop: function() {
+    stop() {
         if (this.timer) { clearTimeout(this.timer); }
-    },
+    }
 
-    _run: function() {
+    _run() {
         var now = this.now();
         var peek;
         while ((peek = this.queue.peek()) && peek.ms <= now) {
@@ -36,18 +34,16 @@ var Scheduler = Base.extend({
         if (peek) {
             this._run_after(Math.max(peek.ms - now, 0));
         }
-    },
+    }
 
-    _run_after: function(delay) {
+    _run_after(delay) {
         var self = this;
         this.timer = setTimeout(function() { self._run(); }, delay);
-    },
-});
-
-var TestScheduler = Scheduler.extend({
+    }
+}class TestScheduler extends Scheduler {
     // All points in the past means no delays between events
-    now: function() { return Infinity; }
-});
+    now() { return Infinity; }
+}
 
 module.exports = {
     Scheduler:Scheduler,

--- a/lib/runtime/types/filter.js
+++ b/lib/runtime/types/filter.js
@@ -1,14 +1,12 @@
 'use strict';
 
-var Base = require('extendable-base');
-
 // Represents a filter expression in Jutttle runtime.
-var Filter = Base.extend({
-    constructor: function(ast, source) {
+class Filter {
+    constructor(ast, source) {
         this.ast = ast;
         this.source = source;
     }
-});
+}
 
 Filter.PASS_ALL = new Filter({ type: 'BooleanLiteral', value: true }, 'true');
 Filter.PASS_NONE = new Filter({ type: 'BooleanLiteral', value: false }, 'false');

--- a/lib/runtime/types/juttle-moment.js
+++ b/lib/runtime/types/juttle-moment.js
@@ -1,24 +1,23 @@
 'use strict';
 
 var _ = require('underscore');
-var Base = require('extendable-base');
 var moment = require('moment-timezone');
 var epoch = moment.utc(0);
 var Moment = Object.getPrototypeOf(epoch);
-require('moment-duration-format'); // momentjs plugin, no reference needed
+// momentjs plugin, no reference needed
+require('moment-duration-format');
 
 const SIMPLE_DURATION = /^([+-])?(\d*([Mdhms]|ms)|Infinity)$/;
 const FORMATTED_DURATION = /^([+-]?\d+\/)?([+-]?\d+\.)?([+-]?\d+):(\d+):([\d.]+)$/;
 
-var JuttleMoment = Base.extend({
-
+class JuttleMoment {
     // Because this is called "constructor" instead of "initialize",
     // JuttleMoment can't be subclassed.
     // So never do var MyMomentClass = JuttleMoment.extend({some new properties})
     //
     // this defeats the whole purpose of extendable base but is
     // measurably faster at creating JuttleMoments which we do a lot
-    constructor: function(options) {
+    constructor(options) {
         options = (options === undefined) ? {} : options;
 
         // Black magic to create a JuttleMoment without calling
@@ -70,9 +69,9 @@ var JuttleMoment = Base.extend({
         } else {
             this.parseDate(options.raw);
         }
-    },
+    }
 
-    milliseconds: function() {
+    milliseconds() {
         // XXX this should not be a moment, but too many tests abuse it
         if (this.moment) {
             var ms = this.moment.toDate().getTime();
@@ -83,29 +82,29 @@ var JuttleMoment = Base.extend({
         } else {
             return this.duration.asMilliseconds();
         }
-    },
+    }
 
-    seconds: function() {
+    seconds() {
         // XXX this should insist on duration, but too many tests abuse it
         return this.milliseconds() / 1000.0;
-    },
+    }
 
-    unix: function() {
+    unix() {
         // return seconds since the epoch for this moment.
         return Math.floor(this.seconds());
-    },
+    }
 
-    unixms: function() {
+    unixms() {
         // return milliseconds since the epoch for this moment.
         return this.milliseconds();
-    },
+    }
 
-    finite: function() {
+    finite() {
         // is this a finite time or duration?
         return _.isFinite(this.milliseconds());
-    },
+    }
 
-    parseDate: function(raw) {
+    parseDate(raw) {
         var parsed = raw;
 
         // arg can be a number of seconds, or an ISO date string, or 'now'
@@ -121,9 +120,9 @@ var JuttleMoment = Base.extend({
             delete this.moment;
             throw new Error('Unable to parse date: ' + JSON.stringify(raw));
         }
-    },
+    }
 
-    parseDuration: function(dur, optunits) {
+    parseDuration(dur, optunits) {
         var simple = _.isString(dur) && dur.match(SIMPLE_DURATION);
         if (simple) {
             // simple durations are like "Nunitabbrev"
@@ -156,9 +155,9 @@ var JuttleMoment = Base.extend({
             this.duration = moment.duration(d);
         }
         this.normalize();
-    },
+    }
 
-    normalize: function() {
+    normalize() {
         // XXX momentjs behaves badly with durations having
         // floating-point days, so be sure we always give integer days
         // until we get a straight answer from the momentjs crew. This
@@ -173,116 +172,116 @@ var JuttleMoment = Base.extend({
         }
         this.duration.subtract(moment.duration({days: floatdays - days}));
         this.duration.add(moment.duration({milliseconds:(floatdays - days) * 86400 * 1000}));
-    },
+    }
 
     // Comparison convenience methods
 
-    eq: function(operand) {
+    eq(operand) {
         return JuttleMoment.compare(this, operand) === 0;
-    },
+    }
 
-    ne: function(operand) {
+    ne(operand) {
         return JuttleMoment.compare(this, operand) !== 0;
-    },
+    }
 
-    gt: function(operand) {
+    gt(operand) {
         return JuttleMoment.compare(this, operand) > 0;
-    },
+    }
 
-    gte: function(operand) {
+    gte(operand) {
         return JuttleMoment.compare(this, operand) >= 0;
-    },
+    }
 
-    lt: function(operand) {
+    lt(operand) {
         return JuttleMoment.compare(this, operand) < 0;
-    },
+    }
 
-    lte: function(operand) {
+    lte(operand) {
         return JuttleMoment.compare(this, operand) <= 0;
-    },
+    }
 
-    add: function(operand) {
+    add(operand) {
         return JuttleMoment.add(this, operand);
-    },
+    }
 
-    subtract: function(operand) {
+    subtract(operand) {
         return JuttleMoment.subtract(this, operand);
-    },
+    }
 
-    multiply: function(operand) {
+    multiply(operand) {
         return JuttleMoment.multiply(this, operand);
-    },
+    }
 
-    divide: function(operand) {
+    divide(operand) {
         return JuttleMoment.divide(this, operand);
-    },
+    }
 
-    negate: function() {
+    negate() {
         return JuttleMoment.negate(this);
-    },
+    }
 
-    is_calendar: function() {
+    is_calendar() {
         return JuttleMoment.is_calendar(this);
-    },
+    }
 
-    is_mixed: function() {
+    is_mixed() {
         return JuttleMoment.is_mixed(this);
-    },
+    }
 
-    quantize: function(T, on) {
+    quantize(T, on) {
         return JuttleMoment.quantize(this, T, on);
-    },
+    }
 
     // If logged, this gives a more accurate representation than toString().
-    toJSON: function() {
+    toJSON() {
         return this.valueOf();
-    },
+    }
 
-    toString: function() {
+    toString() {
         //toString is commonly used to identify the type of the object, so return a more standard result.
         //See underscore's is* functions (isDate, isNumber, etc.) as a common use case that utilizes toString on Objects
         return '[object JuttleMoment]';
-    },
+    }
 
-    valueOf: function() {
+    valueOf() {
         if (this.moment) {
             return JuttleMoment.momentString(this.moment);
         } else {
             return JuttleMoment.durationString(this.duration);
         }
-    },
+    }
 
-    UTCStartOf: function(timeunit) {
+    UTCStartOf(timeunit) {
         // return a new JuttleMoment truncated to the beginning of timeunit (in UTC).
         // timeunit is one of momentjs's accepted timeunit strings,
         // year, month, day, hour, minute, second
         var newMoment = this.clone();
         newMoment.moment.startOf(timeunit);
         return newMoment;
-    },
+    }
 
-    startOf: function(timeunit) {
+    startOf(timeunit) {
         // Same as UTCStartOf, for now.
         return this.UTCStartOf(timeunit);
-    },
+    }
 
-    endOf: function(timeunit) {
+    endOf(timeunit) {
         // return a JuttleMoment truncated to the beginning of timeunit.
         // timeunit is one of momentjs's accepted timeunit strings,
         // year, month, day, hour, minute, second
         var newMoment = this.clone();
         newMoment.moment.endOf(timeunit);
         return newMoment;
-    },
+    }
 
-    clone: function() {
+    clone() {
         return new JuttleMoment({
             duration: this.duration && moment.duration(this.duration),
             moment: this.moment && this.moment.clone()
         });
-    },
+    }
 
-    mapInterval: function(f, to, by) {
+    mapInterval(f, to, by) {
         // evaluate f(moment) over moment...to, and return an array of values.
         // operate directly on internal moment for speed.
         var values = [];
@@ -293,43 +292,41 @@ var JuttleMoment = Base.extend({
             m.moment.add(by.duration);
         }
         return values;
-    },
-    isBeginning: function() {
+    }
+    isBeginning() {
         if (!this.moment) {
             throw new Error('JuttleMoment.isBeginning() expects a Moment');
         }
         return this.unix() === -Infinity;
-    },
-    isEnd: function() {
+    }
+    isEnd() {
         if (!this.moment) {
             throw new Error('JuttleMoment.isEnd() expects a Moment');
         }
         return this.unix() === Infinity;
     }
 
-}, {
-
-    now: function() {
+    static now() {
         return new JuttleMoment();
-    },
+    }
 
-    duration: function(arg1, arg2) {
+    static duration(arg1, arg2) {
         return new JuttleMoment({raw:arg1, raw2:arg2, isDuration:true});
-    },
+    }
 
-    epsDuration: function(arg1, arg2) {
+    static epsDuration(arg1, arg2) {
         return new JuttleMoment({raw:arg1, raw2:arg2, isDuration:true, epsilon:true});
-    },
+    }
 
-    epsMoment: function(arg) {
+    static epsMoment(arg) {
         var m = new JuttleMoment(arg);
         m.epsilon = true;
         return m;
-    },
+    }
 
     // Comparison
 
-    compare: function(operand1, operand2) {
+    static compare(operand1, operand2) {
         if (!(operand1 && operand1 instanceof JuttleMoment
             && operand2 && operand2 instanceof JuttleMoment)) {
             throw new Error('Can\'t compare a Date/Duration with other types.');
@@ -354,33 +351,33 @@ var JuttleMoment = Base.extend({
                 return -1;
             }
         }
-    },
+    }
 
     // Comparison convenience methods
 
-    eq: function(operand1, operand2) {
+    static eq(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) === 0;
-    },
+    }
 
-    ne: function(operand1, operand2) {
+    static ne(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) !== 0;
-    },
+    }
 
-    gt: function(operand1, operand2) {
+    static gt(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) > 0;
-    },
+    }
 
-    gte: function(operand1, operand2) {
+    static gte(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) >= 0;
-    },
+    }
 
-    lt: function(operand1, operand2) {
+    static lt(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) < 0;
-    },
+    }
 
-    lte: function(operand1, operand2) {
+    static lte(operand1, operand2) {
         return JuttleMoment.compare(operand1, operand2) <= 0;
-    },
+    }
 
     // Math
 
@@ -388,7 +385,7 @@ var JuttleMoment = Base.extend({
     // moment   + duration     -> moment
     // duration + moment       -> moment
     // duration + duration     -> duration
-    add: function(operand1, operand2) {
+    static add(operand1, operand2) {
         if (!(operand1 instanceof JuttleMoment
             && operand2 instanceof JuttleMoment)) {
             throw new Error('Both operands must be JuttleMoments.');
@@ -420,13 +417,13 @@ var JuttleMoment = Base.extend({
         }
 
         return newMoment;
-    },
+    }
 
     // moment   - moment       -> duration
     // moment   - duration     -> moment
     // duration - moment       -> **ILLEGAL**
     // duration - duration     -> duration
-    subtract: function(operand1, operand2) {
+    static subtract(operand1, operand2) {
         if (!(operand1 instanceof JuttleMoment
             && operand2 instanceof JuttleMoment)) {
             throw new Error('Both operands must be JuttleMoments.');
@@ -457,11 +454,11 @@ var JuttleMoment = Base.extend({
         }
 
         return newMoment;
-    },
+    }
 
     // number   * duration -> duration
     // duration * number   -> duration
-    multiply: function(operand1, operand2) {
+    static multiply(operand1, operand2) {
         var multiplier, dur ;
         if (_(operand1).isNumber() && operand2.duration) {
             multiplier = operand1 ;
@@ -477,11 +474,11 @@ var JuttleMoment = Base.extend({
                  milliseconds: multiplier * dur.duration._milliseconds};
 
         return new JuttleMoment({duration: moment.duration(d)});
-    },
+    }
 
     // duration / duration -> number
     // duration / number   -> duration
-    divide: function(operand1, operand2) {
+    static divide(operand1, operand2) {
         if (operand1.duration && operand2.duration) {
             return operand1.seconds() / operand2.seconds();
         }
@@ -490,22 +487,22 @@ var JuttleMoment = Base.extend({
         }
 
         throw new Error('Invalid division operands.');
-    },
+    }
 
     // duration % duration -> duration
     // number   % duration -> **ILLEGAL**
     // duration % number   -> **ILLEGAL**
-    remainder: function(operand1, operand2) {
+    static remainder(operand1, operand2) {
         if (operand1.duration && operand2.duration) {
             return JuttleMoment.duration(operand1.seconds() % operand2.seconds());
         }
 
         throw new Error('Invalid remainder operands.');
-    },
+    }
 
     // -moment   -> **ILLEGAL**
     // -duration -> duration
-    negate: function(operand) {
+    static negate(operand) {
         if (!(operand instanceof JuttleMoment)) {
             throw new Error('Operand must be JuttleMoment.');
         }
@@ -515,9 +512,9 @@ var JuttleMoment = Base.extend({
         } else {
             throw new Error('Cannot negate moment.');
         }
-    },
+    }
 
-    max: function() {
+    static max() {
         var moments = _(arguments).toArray();
 
         if (moments.length === 0) {
@@ -533,9 +530,9 @@ var JuttleMoment = Base.extend({
         }
 
         return maxMoment;
-    },
+    }
 
-    min: function() {
+    static min() {
         var moments = _(arguments).toArray();
 
         if (moments.length === 0) {
@@ -551,20 +548,20 @@ var JuttleMoment = Base.extend({
         }
 
         return minMoment;
-    },
+    }
 
-    is_calendar: function(time) {
+    static is_calendar(time) {
         // momentjs implements a "calendar duration" by separately tracking months
         return (time.duration && time.duration._months !== 0);
-    },
+    }
 
-    is_mixed: function(time) {
+    static is_mixed(time) {
         // is this a combined calendar and regular duration?
         return (time.duration && time.duration._months !== 0 &&
                 (time.duration._days !== 0 || time.duration._milliseconds !== 0));
-    },
+    }
 
-    quantize: function(time, T, on) {
+    static quantize(time, T, on) {
         // align the series with the moment 'on' by truncating
         // downwards such that the sequence (time + n*T) will
         // include 'on'. If on is not specified,
@@ -606,54 +603,54 @@ var JuttleMoment = Base.extend({
             }
             return jmoment;
         }
-    },
+    }
 
-    unix: function(moment) {
+    static unix(moment) {
         // return seconds since the epoch for this moment.
         if (!moment.moment) {
             throw new Error('Date.unix() expects a Moment');
         }
 
         return moment.unix();
-    },
+    }
 
-    unixms: function(moment) {
+    static unixms(moment) {
         // return milliseconds since the epoch for this moment.
         if (!moment.moment) {
             throw new Error('Date.unixms() expects a Moment');
         }
 
         return moment.unixms();
-    },
+    }
 
-    elapsed: function(moment) {
+    static elapsed(moment) {
         // return seconds elapsed since this moment.
         if (!moment.moment) {
             throw new Error('Date.elapsed() expects a Moment');
         }
 
         return Date.now()/1000.0 - moment.unix();
-    },
+    }
 
-    milliseconds: function(duration) {
+    static milliseconds(duration) {
         // convert duration to milliseconds. Not the same as momenentjs.milliseconds!
         if (!duration.duration) {
             throw new Error('Duration.milliseconds() expects a Duration');
         }
 
         return duration.milliseconds();
-    },
+    }
 
-    seconds: function(duration) {
+    static seconds(duration) {
         // convert duration to seconds. Not the same as momenentjs.seconds!
         if (!duration.duration) {
             throw new Error('Duration.seconds() expects a Duration');
         }
 
         return duration.seconds();
-    },
+    }
 
-    format: function(operand, format, tzstring) {
+    static format(operand, format, tzstring) {
         if (operand.moment && (format || tzstring)) {
             if (tzstring) {
                 // moment-timezone is not Americacentric enough, as it
@@ -692,9 +689,9 @@ var JuttleMoment = Base.extend({
         } else {
             throw new Error('format() expects a Duration or Moment');
         }
-    },
+    }
 
-    parse: function(s, format) {
+    static parse(s, format) {
         // parse a date string using momentjs's format-driven constructor.
         var m;
         if (typeof format === 'undefined') {
@@ -710,9 +707,9 @@ var JuttleMoment = Base.extend({
             }
             return new JuttleMoment({moment:m});
         }
-    },
+    }
 
-    get: function(operand, timeunit) {
+    static get(operand, timeunit) {
         if (!(operand instanceof JuttleMoment)) {
             throw new Error('Cannot get fields of non-JuttleMoment.');
         }
@@ -730,16 +727,16 @@ var JuttleMoment = Base.extend({
             result += 1;
         }
         return result;
-    },
+    }
 
-    as: function(operand, timeunit) {
+    static as(operand, timeunit) {
         if (!operand.duration) {
             throw new Error('duration.as wants a Duration');
         }
         return operand.duration.as(timeunit);
-    },
+    }
 
-    startOf: function(moment, timeunit) {
+    static startOf(moment, timeunit) {
         // return a JuttleMoment truncated to the beginning of timeunit.
         // timeunit is one of momentjs's accepted timeunit strings,
         // year, month, day, hour, minute, second
@@ -747,9 +744,9 @@ var JuttleMoment = Base.extend({
             throw new Error('Date.startOf() wants a Moment.');
         }
         return moment.startOf(timeunit);
-    },
+    }
 
-    endOf: function(moment, timeunit) {
+    static endOf(moment, timeunit) {
         // return a JuttleMoment truncated to the beginning of timeunit.
         // timeunit is one of momentjs's accepted timeunit strings,
         // year, month, day, hour, minute, second
@@ -757,23 +754,23 @@ var JuttleMoment = Base.extend({
             throw new Error('Date.endOf() wants a Moment.');
         }
         return moment.endOf(timeunit);
-    },
+    }
 
-    valueOf: function(operand) {
+    static valueOf(operand) {
         if (!(operand instanceof JuttleMoment)) {
             throw new Error('Cannot get value of non-JuttleMoment.');
         }
 
         return operand.valueOf();
-    },
-    momentString: function(moment) {
+    }
+    static momentString(moment) {
         if (isNaN(moment.valueOf())) {
             return moment._i.toString();
         } else {
             return moment.toDate().toISOString();
         }
-    },
-    simpleDurationString: function(d) {
+    }
+    static simpleDurationString(d) {
         // format a simple duration that can be represented as N * units
         if (d._milliseconds === 0 && d._days === 0 && d._months === 0) {
             return null; // let the HMS formatter do zero
@@ -786,8 +783,8 @@ var JuttleMoment = Base.extend({
         } else {
             return null;
         }
-    },
-    durationString: function(d) {
+    }
+    static durationString(d) {
         var simple = JuttleMoment.simpleDurationString(d);
         if (simple) {
             return simple;
@@ -826,6 +823,6 @@ var JuttleMoment = Base.extend({
         s += '.' + ('00' + as_milliseconds % 1000).slice(-3);
         return s;
     }
-});
+}
 
 module.exports = JuttleMoment;

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -21,63 +21,63 @@ var TYPE_DISPLAY_NAMES = {
     Object:   'object'
 };
 
-var ValueBuilder = ASTVisitor.extend({
-    buildValue: function(ast) {
+class ValueBuilder extends ASTVisitor {
+    buildValue(ast) {
         return this.visit(ast);
-    },
+    }
 
-    visitNullLiteral: function() {
+    visitNullLiteral() {
         return null;
-    },
+    }
 
-    visitBooleanLiteral: function(node) {
+    visitBooleanLiteral(node) {
         return node.value;
-    },
+    }
 
-    visitNumberLiteral: function(node) {
+    visitNumberLiteral(node) {
         return node.value;
-    },
+    }
 
-    visitInfinityLiteral: function(node) {
+    visitInfinityLiteral(node) {
         return node.negative ? -Infinity : Infinity;
-    },
+    }
 
-    visitNaNLiteral: function(node) {
+    visitNaNLiteral(node) {
         return NaN;
-    },
+    }
 
-    visitStringLiteral: function(node) {
+    visitStringLiteral(node) {
         return node.value;
-    },
+    }
 
-    visitRegExpLiteral: function(node) {
+    visitRegExpLiteral(node) {
         return new RegExp(node.pattern, node.flags);
-    },
+    }
 
-    visitMomentLiteral: function(node) {
+    visitMomentLiteral(node) {
         return new JuttleMoment(node.value);
-    },
+    }
 
-    visitDurationLiteral: function(node) {
+    visitDurationLiteral(node) {
         return JuttleMoment.duration(node.value);
-    },
+    }
 
-    visitFilterLiteral: function(node) {
+    visitFilterLiteral(node) {
         return new Filter(node.ast, node.source);
-    },
+    }
 
-    visitArrayLiteral: function(node) {
+    visitArrayLiteral(node) {
         return _.map(node.elements, this.visit, this);
-    },
+    }
 
-    visitObjectLiteral: function(node) {
+    visitObjectLiteral(node) {
         return _.object((_.map(node.properties, this.visit, this)));
-    },
+    }
 
-    visitObjectProperty: function(node) {
+    visitObjectProperty(node) {
         return [this.visit(node.key), this.visit(node.value)];
     }
-});
+}
 
 var values = {
 

--- a/lib/views/file.js
+++ b/lib/views/file.js
@@ -5,8 +5,9 @@ var fs = require('fs');
 
 // A file view is a text view with no arguments other than
 // format 'json' and writing to a file.
-var FileView = TextView.extend({
-    initialize: function(options, env) {
+class FileView extends TextView {
+    constructor(options, env) {
+        super(options, env);
         this.name = 'file';
         this.options.format = 'json';
         this.filename = options.filename;
@@ -16,7 +17,7 @@ var FileView = TextView.extend({
         }
 
         this.fstream = fs.createWriteStream(this.filename);
-    },
-});
+    }
+}
 
 module.exports = FileView;

--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -6,8 +6,9 @@ var Table = require('cli-table');
 var View = require('./view.js');
 var values = require('../runtime/values');
 
-var TableView = View.extend({
-    initialize: function(options, env) {
+class TableView extends View {
+    constructor(options, env) {
+        super(options, env);
         this.name = 'table';
 
         this.options = _.defaults({}, options, {
@@ -90,11 +91,11 @@ var TableView = View.extend({
         } else {
             this.style = {};
         }
-    },
+    }
 
     // Used to sort keys in a point in a manner that honors
     // columnOrder first, alphabetical second.
-    sort_keys: function(a, b) {
+    sort_keys(a, b) {
         var self = this;
 
         var ai = _.indexOf(self.options.columnOrder, a);
@@ -109,9 +110,9 @@ var TableView = View.extend({
         } else {
             return (ai - bi);
         }
-    },
+    }
 
-    consume: function(data) {
+    consume(data) {
         var self = this;
 
         if (self.options.limit && self.items_written >= self.options.limit) {
@@ -194,10 +195,10 @@ var TableView = View.extend({
             // we can build the big table at the end.
             this.data_points = this.data_points.concat(data);
         }
-    },
+    }
 
     // Called when the stream finishes
-    eof: function() {
+    eof() {
         var self = this;
         var table;
 
@@ -245,15 +246,15 @@ var TableView = View.extend({
         }
 
         self.events.emit('end');
-    },
+    }
 
-    _valueFormatter: function(value) {
+    _valueFormatter(value) {
         if (typeof(value) === 'undefined') {
             return '';
         } else {
             return values.toString(value);
         }
-    },
-});
+    }
+}
 
 module.exports = TableView;

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -6,8 +6,9 @@ var babyparse = require('babyparse');
 var View = require('./view.js');
 var values = require('../runtime/values');
 
-var TextView = View.extend({
-    initialize: function(options, env) {
+class TextView extends View {
+    constructor(options, env) {
+        super(options, env);
         this.name = 'text';
         this.options = _.clone(options);
         this.options.format = this.options.format || 'json';
@@ -31,17 +32,17 @@ var TextView = View.extend({
         this.latest_keys = [];
         this.items_written = 0;
         this.buffer = '';
-    },
+    }
 
-    write: function(data) {
+    write(data) {
         if (this.options.progressive) {
             this.fstream.write(data);
         } else {
             this.buffer += data;
         }
-    },
+    }
 
-    write_item: function(item, skip_newline) {
+    write_item(item, skip_newline) {
         var self = this;
         skip_newline = skip_newline || false;
 
@@ -56,17 +57,17 @@ var TextView = View.extend({
         if (!skip_newline) {
             this.write('\n');
         }
-    },
+    }
 
-    always_write_item: function(item, skip_newline) {
+    always_write_item(item, skip_newline) {
         this.write(item);
 
         if (!skip_newline) {
             this.write('\n');
         }
-    },
+    }
 
-    format_values: function(values_) {
+    format_values(values_) {
         var val2 = _.map(values_, function(value) {
             if (typeof(value) === 'undefined') {
                 return '';
@@ -75,9 +76,9 @@ var TextView = View.extend({
             }
         });
         return babyparse.unparse([val2], {quotes: true});
-    },
+    }
 
-    format_point: function(point) {
+    format_point(point) {
         var self = this;
 
         switch (self.options.format) {
@@ -127,17 +128,17 @@ var TextView = View.extend({
                 self.write_item(JSON.stringify(point, null));
                 break;
         }
-    },
-    consume: function(data) {
+    }
+    consume(data) {
         var self = this;
 
         data.forEach(function(point) {
             self.format_point(point);
         });
-    },
+    }
 
     // This is called when a batch finishes
-    mark: function(time) {
+    mark(time) {
         var self = this;
 
         if (!self.options.marks || self.options.format !== 'raw') {
@@ -150,10 +151,10 @@ var TextView = View.extend({
         }
 
         self.write_item(text);
-    },
+    }
 
     // Called for ticks
-    tick: function(time) {
+    tick(time) {
         var self = this;
 
         if (!self.options.ticks || self.options.format !== 'raw') {
@@ -166,10 +167,10 @@ var TextView = View.extend({
         }
 
         self.write_item(text);
-    },
+    }
 
     // Called when the stream finishes
-    eof: function() {
+    eof() {
         var self = this;
 
         if (self.options.format === 'raw') {
@@ -189,6 +190,6 @@ var TextView = View.extend({
             self.events.emit('end');
         });
     }
-});
+}
 
 module.exports = TextView;

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -3,36 +3,35 @@
 var _ = require('underscore');
 var EventEmitter = require('eventemitter3');
 var Promise = require('bluebird');
-var Base = require('extendable-base');
 var JuttleErrors = require('../errors');
 
-var ViewManager = Base.extend({
-    initialize: function(options, env) {
+class ViewManager {
+    constructor(options, env) {
         this.program = options.program;
         this.view_classes = options.view_classes;
         this.events = new EventEmitter();
         this.env = env;
 
         this.views = {};
-    },
+    }
 
-    warning: function(msg, err) {
+    warning(msg, err) {
         var self = this;
 
         self.events.emit('warning', msg, err);
-    },
+    }
 
-    error: function(msg, err) {
+    error(msg, err) {
         var self = this;
 
         self.events.emit('error', msg, err);
-    },
+    }
 
     // Create the necessary views and return a promise that resolves
     // when all views have received an eof from the program and
     // fully processed the per-view data.
 
-    setup: function(program) {
+    setup(program) {
         var self = this;
 
         var views = self.program.get_views(program);
@@ -112,6 +111,6 @@ var ViewManager = Base.extend({
             self.program.events.off();
         });
     }
-});
+}
 
 module.exports = ViewManager;

--- a/lib/views/view.js
+++ b/lib/views/view.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /* jslint node:true */
-var Base = require('extendable-base');
 var EventEmitter = require('eventemitter3');
 
 // This is a base class used by the other terminal views (text,
@@ -9,37 +8,36 @@ var EventEmitter = require('eventemitter3');
 //
 // The View manager creates objects derived from this base
 // class to handle streams of data from juttle programs.
-var View = Base.extend({
-    initialize: function(options, env) {
+class View {
+    constructor(options, env) {
         this.events = new EventEmitter();
         this.fstream = options.fstream ? options.fstream : process.stdout;
         this.env = env;
-    },
+    }
 
-    warn: function(msg) {
+    warn(msg) {
         this.events.emit('warning', 'view ' + this.name + ': ' + msg);
-    },
+    }
 
-    error: function(msg) {
+    error(msg) {
         this.events.emit('error', 'view ' + this.name + ': ' + msg);
-    },
+    }
 
     // The subclass should override one or more of these callbacks to
     // handle marks, ticks, data, or eof.
-    mark: function(time) {
-    },
-
-    tick: function(time) {
-    },
-
-    // Data is an array of points
-    consume: function(data) {
-    },
-
-    eof: function() {
-        this.events.emit('end');
+    mark(time) {
     }
 
-});
+    tick(time) {
+    }
+
+    // Data is an array of points
+    consume(data) {
+    }
+
+    eof() {
+        this.events.emit('end');
+    }
+}
 
 module.exports = View;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "csv-write-stream": "^1.0.0",
     "double-ended-queue": "^0.9.7",
     "eventemitter3": "^1.1.1",
-    "extendable-base": "^0.3.1",
     "gex": "^0.1.4",
     "heap": "^0.2.3",
     "isomorphic-fetch": "^2.2.0",

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -100,6 +100,7 @@ function set_stdout(stream) {
 
 var TestView = View.extend({
     initialize: function(options, env) {
+        this.name = 'test';
         this.sink = options.sink;
         this.eofs = options.eofs || 1;
         this.data = [];
@@ -109,7 +110,6 @@ var TestView = View.extend({
         this.dt = options.sink.options && options.sink.options.dt;
         this.env = env;
     },
-    name: 'test',
     consume: function(data) {
         this.data = this.data.concat(utils.fromNative(data.map(_.clone)));
     },

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -98,8 +98,9 @@ function set_stdout(stream) {
 })();
 
 
-var TestView = View.extend({
-    initialize: function(options, env) {
+class TestView extends View {
+    constructor(options, env) {
+        super(options, env);
         this.name = 'test';
         this.sink = options.sink;
         this.eofs = options.eofs || 1;
@@ -109,18 +110,18 @@ var TestView = View.extend({
         this.times = options.sink.options && options.sink.options.times;
         this.dt = options.sink.options && options.sink.options.dt;
         this.env = env;
-    },
-    consume: function(data) {
+    }
+    consume(data) {
         this.data = this.data.concat(utils.fromNative(data.map(_.clone)));
-    },
-    mark: function(time) {
+    }
+    mark(time) {
         if (this.marks && this.times) {
             this.data = this.data.concat(utils.fromNative([{time:time, mark:true}]));
         } else if (this.marks) {
             this.data = this.data.concat({mark:true});
         }
-    },
-    tick: function(time) {
+    }
+    tick(time) {
         if (this.ticks) {
             if (this.times) {
                 this.data = this.data.concat(utils.fromNative([{time:time, tick:true}]));
@@ -130,8 +131,8 @@ var TestView = View.extend({
                 this.data = this.data.concat({tick:true});
             }
         }
-    },
-    eof: function() {
+    }
+    eof() {
         if (--this.eofs === 0) {
             var result = {};
             result.data = utils.fromNative(this.data);
@@ -143,7 +144,7 @@ var TestView = View.extend({
             this.events.emit('end', result);
         }
     }
-});
+}
 
 function compile_juttle(options) {
     logger.debug('parsing Juttle program:', options.program);

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Base = require('extendable-base');
 var marked = require('marked');
 var pointsParser = require('../../extlib/points-parser').pointsParser;
 var util = require('util');
@@ -77,34 +76,34 @@ var html = {
  *   * Tests have multiple *sections*, introduced by level 3 headings (e.g.
  *     "Juttle", "Output").
  */
-var SpecRenderer = Base.extend({
-    initialize: function(options) {
+class SpecRenderer {
+    constructor(options) {
         this.title = null;
         this.tests = [];
         this.section = null;
         this.moduleName = null;
 
         this.baseDir = options.baseDir;
-    },
+    }
 
-    check: function() {
+    check() {
         if (this.title === null) {
             throw new Error('Spec is missing a title.');
         }
 
         this.tests.forEach(this.checkTest);
-    },
+    }
 
-    checkTest: function(test) {
+    checkTest(test) {
         if (test.juttle === null) {
             throw new Error('Test "' + test.title + '" is missing the "Juttle" section.');
         }
         if (test.output === null && test.errors.length === 0 && test.warnings.length === 0) {
             throw new Error('Test "' + test.title + '" is missing the "Output", "Errors", or "Warnings" section.');
         }
-    },
+    }
 
-    render: function() {
+    render() {
         var parts = [];
         var self = this;
 
@@ -118,9 +117,9 @@ var SpecRenderer = Base.extend({
         parts.push(this.renderFooter());
 
         return parts.join('\n');
-    },
+    }
 
-    renderHeader: function() {
+    renderHeader() {
         return [
             'var expect = require(\'chai\').expect;',
             '',
@@ -131,13 +130,13 @@ var SpecRenderer = Base.extend({
             '',
             'describe(\'' + js.stringEscape(this.title) + '\', function() {',
         ].join('\n');
-    },
+    }
 
-    renderFooter: function() {
+    renderFooter() {
         return '}); // describe block \n';
-    },
+    }
 
-    renderTest: function(test) {
+    renderTest(test) {
         var parts = [];
 
         parts.push([
@@ -180,11 +179,11 @@ var SpecRenderer = Base.extend({
 
         parts.push('});');
         return parts.join('\n');
-    },
+    }
 
     /* Block-level Methods */
 
-    heading: function(text, level) {
+    heading(text, level) {
         text = html.unescape(text);
 
         switch (level) {
@@ -222,12 +221,12 @@ var SpecRenderer = Base.extend({
         }
 
         return '';
-    },
+    }
 
     /*
      * Simple per-test directives
      */
-    getDirective: function(text) {
+    getDirective(text) {
         if (text.match(/^\(skip.*\)/i)) {
             return '.skip';
         } else if (text.match(/^\(only.*\)/i)) {
@@ -235,9 +234,9 @@ var SpecRenderer = Base.extend({
         } else {
             return '';
         }
-    },
+    }
 
-    code: function(code) {
+    code(code) {
         var test = this.tests[this.tests.length - 1];
 
         switch (this.section) {
@@ -255,9 +254,9 @@ var SpecRenderer = Base.extend({
         }
 
         return '';
-    },
+    }
 
-    listitem: function(text) {
+    listitem(text) {
         text = html.unescape(text);
 
         var test = this.tests[this.tests.length - 1];
@@ -273,69 +272,69 @@ var SpecRenderer = Base.extend({
         }
 
         return '';
-    },
+    }
 
-    blockquote: function() {
+    blockquote() {
         return '';
-    },
+    }
 
-    hr: function() {
+    hr() {
         return '';
-    },
+    }
 
-    html: function() {
+    html() {
         return '';
-    },
+    }
 
-    list: function() {
+    list() {
         return '';
-    },
+    }
 
-    paragraph: function() {
+    paragraph() {
         return '';
-    },
+    }
 
-    table: function() {
+    table() {
         return '';
-    },
+    }
 
-    tablecell: function() {
+    tablecell() {
         return '';
-    },
+    }
 
-    tablerow: function() {
+    tablerow() {
         return '';
-    },
+    }
 
     /* Inline-level Methods */
-    codespan: function pass(s) {
-        return s;
-    },
-
-    br: function() {
-        return '';
-    },
-
-    del: function pass(s) {
-        return s;
-    },
-
-    em: function pass(s) {
-        return s;
-    },
-
-    image: function() {
-        return '';
-    },
-
-    link: function() {
-        return '';
-    },
-
-    strong: function pass(s) {
+    codespan(s) {
         return s;
     }
-});
+
+    br() {
+        return '';
+    }
+
+    del(s) {
+        return s;
+    }
+
+    em(s) {
+        return s;
+    }
+
+    image() {
+        return '';
+    }
+
+    link() {
+        return '';
+    }
+
+    strong(s) {
+        return s;
+    }
+}
 
 /*
  * Main JuttleSpec module. Wraps converting Markdown specs into JavaScript ones.


### PR DESCRIPTION
Add a script based on https://github.com/benjamn/recast that converts an `extendable-base` style class definition into the equivalent ES6 class.

This includes removing the unnecessary `require('extendable-base')` and properly adding the superclass constructor invocation to pass along the same set of arguments that the constructor was called with. It also defines getter properties as a stopgap to handle cases in which we assign literals to the prototype since those are not supported in ES6.

The most substantive change required for this was a rework of the implementation of reduce so it no longer relied on a tangled web of mixins. Instead it now has a simple linear inheritance chain. The one distasteful part of this is that the batch reduce (i.e. not `reduce -every`) ends up inheriting the behavior to process the -every options even though it doesn't use it. This seems like the lesser of two evils when compared with the previous mixin approach, but I could go either way. In any event, it still passes all the tests.

Fixes #341