### PR TITLE
Filters simplify field reference representation

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -36,6 +36,7 @@ var NODE_CHILDREN = {
 
     /* Expressions */
     Variable:                 [],
+    Field:                    [],
     ToString:                 ['expression'],
     PropertyAccess:           ['base', 'name'],
     FunctionCall:             ['name', 'arguments'],

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -569,6 +569,8 @@ var Build = CodeGenerator.extend({
                 return this.gen_PropertyAccess(ast, { lhs: true });
             case 'Variable':
                 return ast.uname;
+            case 'Field':
+                return this.gen_Field(ast);
             default:
                 throw new Error('unrecognized expression lhs ' + ast.type);
         }
@@ -616,6 +618,7 @@ var Build = CodeGenerator.extend({
             case 'ByList':
             case 'SortByList':
             case 'Variable':
+            case 'Field':
             case 'ToString':
             case 'ObjectLiteral':
             case 'ConditionalExpression':
@@ -783,6 +786,9 @@ var Build = CodeGenerator.extend({
             default:
                 return ast.uname;
         }
+    },
+    gen_Field: function(ast) {
+        return 'juttle.ops.pget(pt,' + JSON.stringify(ast.name) + ')';
     },
     gen_PropertyAccess: function(ast, opts) {
         if (!ast.computed) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -119,6 +119,10 @@ var FilterJSCompiler = ASTVisitor.extend({
             : '[' + this.visit(node.key) + ', ' + this.visit(node.value) + ']';
     },
 
+    visitField: function(node) {
+        return 'juttle.ops.pget(pt, ' + JSON.stringify(node.name) + ')';
+    },
+
     visitToString: function(node) {
         return 'juttle.ops.str(' + this.visit(node.expression) + ')';
     },

--- a/lib/compiler/filters/partial-filter-js-compiler.js
+++ b/lib/compiler/filters/partial-filter-js-compiler.js
@@ -58,6 +58,13 @@ var PartialFilterJSCompiler = FilterJSCompiler.extend({
             + '}}}()';
     },
 
+    visitField: function(node) {
+        var index = JSON.stringify(node.name);
+        return '(' + JSON.stringify(this.fields) + '.indexOf(' + index + ') >= 0 '
+            + '? juttle.ops.pget(pt, ' + index + ') '
+            + ': juttle.partialOps.throw_unresolved())';
+    },
+
     visitUnaryExpression: function(node) {
         switch (node.operator) {
             case 'NOT':

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -14,13 +14,11 @@ var values = require('../../runtime/values');
 // Descriptions of these forms use the following checks to test their operands.
 
 var checks = {
-    isSimpleFieldReference: {
+    isField: {
         displayName: 'field',
 
         test: function(node) {
-            return node.type === 'UnaryExpression'
-                && node.operator === '*'
-                && node.expression.type === 'StringLiteral';
+            return node.type === 'Field';
         }
     },
 
@@ -69,47 +67,47 @@ var checks = {
 
 var ALLOWED_OP_FORMS = {
     '==': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     '!=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     '=~': [
-        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
-        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+        { left: checks.isField, right: checks.isStringLiteral },
+        { left: checks.isField, right: checks.isRegularExpressionLiteral },
     ],
 
     '!~': [
-        { left: checks.isSimpleFieldReference, right: checks.isStringLiteral },
-        { left: checks.isSimpleFieldReference, right: checks.isRegularExpressionLiteral },
+        { left: checks.isField, right: checks.isStringLiteral },
+        { left: checks.isField, right: checks.isRegularExpressionLiteral },
     ],
 
     '<': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     '>': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     '<=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     '>=': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleLiteral },
-        { left: checks.isSimpleLiteral, right: checks.isSimpleFieldReference }
+        { left: checks.isField, right: checks.isSimpleLiteral },
+        { left: checks.isSimpleLiteral, right: checks.isField }
     ],
 
     'in': [
-        { left: checks.isSimpleFieldReference, right: checks.isSimpleArrayLiteral },
+        { left: checks.isField, right: checks.isSimpleArrayLiteral },
     ]
 };
 

--- a/lib/compiler/flowgraph/program_stats.js
+++ b/lib/compiler/flowgraph/program_stats.js
@@ -57,10 +57,8 @@ function getReducerName(node) {
     return node.name.name;
 }
 
-function isSimpleFieldReference(node) {
-    return node.type === 'UnaryExpression'
-        && node.operator === '*'
-        && node.expression.type === 'StringLiteral';
+function isField(node) {
+    return node.type === 'Field';
 }
 
 function isReducerCall(node) {
@@ -76,7 +74,7 @@ function reducer_stats(g) {
             if (!isReducerCall(expr.right)) {
                 return;
             }
-            if (!isSimpleFieldReference(expr.left)) {
+            if (!isField(expr.left)) {
                 logger.error('Found unexpected reduce lhs while optimizing: ', expr.left);
                 return;
             }

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -500,7 +500,7 @@ var GraphCompiler = CodeGenerator.extend({
         maker = this.gen_reifier(ast.reducers);
         var reducer_index = _.pluck(ast.reducers, 'index');
         var lhs = ast.exprs.map(function(expr) {
-            return expr.left.expression.value;
+            return expr.left.type === 'Field' ? expr.left.name : expr.left.expression.value;
         });
 
         return this.gen_proc(ast, which,
@@ -524,6 +524,8 @@ var GraphCompiler = CodeGenerator.extend({
                 return this.gen_PropertyAccess(ast, { lhs: true });
             case 'Variable':
                 return ast.uname;
+            case 'Field':
+                return this.gen_Field(ast, { lhs: true });
             default:
                 throw new Error('unrecognized expression lhs ' + ast.type);
         }
@@ -555,6 +557,9 @@ var GraphCompiler = CodeGenerator.extend({
             case 'MomentLiteral':
             case 'DurationLiteral':
                 return this['gen_' + ast.type](ast);
+
+            case 'Field':
+                return this.gen_Field(ast, {});
 
             case 'UnaryExpression':
                 return this.gen_UnaryExpression(ast, {});
@@ -664,6 +669,14 @@ var GraphCompiler = CodeGenerator.extend({
                 });
             default:
                 return ast.uname;
+        }
+    },
+    gen_Field: function(ast, opts) {
+        var name = JSON.stringify(ast.name);
+        if (opts.lhs) {
+            return 'pt[' + name + ']';
+        } else {
+            return 'juttle.ops.pget(pt,' + name + ')';
         }
     },
     gen_PropertyAccess: function(ast, opts) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1102,6 +1102,9 @@ var SemanticPass = Base.extend({
                 }
                 return this.sa_Variable(ast, opts);
 
+            case 'Field':
+                return this.sa_Field(ast, opts);
+
             case 'PropertyAccess':
                 if (!this.scope.is_mutable(ast.base.name, opts, this.context())) {
                     throw errors.compileError('RT-VARIABLE-NOT-MODIFIABLE', {
@@ -1140,6 +1143,7 @@ var SemanticPass = Base.extend({
             case 'ByList':
             case 'SortByList':
             case 'Variable':
+            case 'Field':
             case 'ToString':
             case 'ObjectLiteral':
             case 'ConditionalExpression':
@@ -1380,15 +1384,8 @@ var SemanticPass = Base.extend({
 
                 case 'field':
                     return {
-                        type: 'UnaryExpression',
-                        operator: '*',
-                        value: ast.name,
-                        expression: {
-                            type: 'StringLiteral',
-                            value: ast.name,
-                            d: true,
-                            location: ast.location
-                        },
+                        type: 'Field',
+                        name: ast.name,
                         d:false,
                         location: ast.location
                     };
@@ -1400,6 +1397,15 @@ var SemanticPass = Base.extend({
                     });
             }
         }
+    },
+    sa_Field: function(ast, opts) {
+        if (opts.context !== 'stream' && opts.context !== 'reduce' && opts.context !== 'filter') {
+            throw errors.compileError('RT-INVALID-FIELD-REFERENCE', {
+                location: ast.location
+            });
+        }
+        ast.d = false;
+        return ast;
     },
     sa_ToString: function(ast, opts) {
         ast.expression = this.sa_expr(ast.expression, opts);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -796,11 +796,6 @@ var SemanticPass = Base.extend({
         return ast;
     },
 
-    is_simple_field_ref: function(ast) {
-        return ast.type === 'UnaryExpression'
-            && ast.operator === '*'
-            && ast.expression.d;
-    },
     sa_ExpressionFilterTerm: function(ast, opts) {
         ast.expression = this.sa_expr(ast.expression, { context: 'filter', coerce_var: 'field' });
         // will be carried in AST form to a proc implementation

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -784,11 +784,8 @@ Variable
 
 FieldReferenceShortcut
     = '#' name:IdentifierNameWithPos {
-          return createNode('UnaryExpression', location(), {
-              operator: '*',
-              expression: createNode('StringLiteral', name.location, {
-                  value: name.name
-              })
+          return createNode('Field', location(), {
+              name: name.name
           });
       }
 
@@ -1003,11 +1000,8 @@ RealLeftHandSideExpression
 // Coerce LHS to a Field Reference.
 RealCoercedLeftHandSideExpression
     = name:IdentifierNameWithPos {
-          return createNode('UnaryExpression', location(), {
-              operator: '*',
-              expression: createNode('StringLiteral', name.location, {
-                  value: name.name
-              })
+          return createNode('Field', location(), {
+              name: name.name
           });
       }
     / FieldReferenceShortcut
@@ -1812,11 +1806,8 @@ ReduceItem
     / expr:FunctionCall {
           return createNode('AssignmentExpression', location(), {
               operator: '=',
-              left: createNode('UnaryExpression', location(), {
-                  operator: '*',
-                  expression: createNode('StringLiteral', expr.name.location, {
-                      value: expr.name.type === 'Variable' ? expr.name.name : expr.name.name.value
-                  })
+              left: createNode('Field', location(), {
+                  name: expr.name.type === 'Variable' ? expr.name.name : expr.name.name.value
               }),
               right: expr
           });

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -170,6 +170,10 @@ describe('FilterJSCompiler', function() {
         expect('a == { "${"ab" + "cd"}": 3 }').to.filter(POINTS_OBJECTS, [ { a: { 'abcd': 3 } } ]);
     });
 
+    it('compiles Field correctly', function() {
+        expect('#a == 2').to.filter(POINTS_NUMBERS, [ { a: 2 } ]);
+    });
+
     it('compiles ToString correctly', function() {
         expect('a == "${"ab" + "cd"}"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
     });

--- a/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
+++ b/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
@@ -35,9 +35,9 @@ Parses toplevel `*` as field dereference with whitespace before and no whitespac
     | reduce count()
     | view result
 
-### Output
+### Errors
 
-    { count: 62 }
+  * Invalid filter term. Valid forms are: "field == value", "value == field".
 
 Parses toplevel `*` as multiplication with whitespace before and whitespace after
 ---------------------------------------------------------------------------------

--- a/test/runtime/types/filter.spec.js
+++ b/test/runtime/types/filter.spec.js
@@ -12,11 +12,7 @@ describe('Filter', function() {
                 expression: {
                     type: 'BinaryExpression',
                     operator: '==',
-                    left: {
-                        type: 'UnaryExpression',
-                        operator: '*',
-                        expression: { type: 'StringLiteral', value: 'a' },
-                    },
+                    left: { type: 'Field', name: 'a' },
                     right: { type: 'NumericLiteral', value: 5 }
                 }
             };


### PR DESCRIPTION
Until now, field references in expressions like `a < 5` or `#b > 6` were represented as `UnaryExpression` nodes with `*` as an operator and a `StringLiteral` with the field name as an expression. The idea behind this was that they are a syntax sugar for field dereference (the canonical form being `*'a' < 5` or `*'b' > 6`).

The `UnaryExpression` representation proved cumbersome to handle, especially in adapter code dealing with static filter expressions. Therefore, this commit gives field references more first-class status, representing them as `Field` nodes.

All relevant places are updated to handle the new nodes (the code is usually taken from `UnaryExpression` handling).

Note that changes done in `StaticFilterChecker` mean that expressions like `*'a' < 5` are no longer considered valid in static filter expressions. I see this as a fix of an irregularity in the language — the `*`
operator is dynamic by its nature and it shouldn’t be allowed in static filter expressions, even with compile-time constant argument.

Fixes #318.