### PR TITLE
semantic.js - fix function arg count

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -338,7 +338,7 @@ var SemanticPass = Base.extend({
                     throw errors.compileError('RT-WRONG-ARG-COUNT-PLURAL', {
                         type: type,
                         name: name,
-                        expected_count: expected_count,
+                        expected_count: min_count,
                         actual_count: actual_count,
                         location: location
                     });
@@ -512,11 +512,11 @@ var SemanticPass = Base.extend({
         return args;
     },
     compute_arg_count: function(args) {
-        var counts = _.countBy(args, function(arg) {
-            return arg.default ? 'optional' : 'required';
+        var requiredArgs = _.filter(args, function(arg) {
+            return !arg.default;
         });
 
-        return [counts.required, counts.required + counts.optional];
+        return [requiredArgs.length, args.length];
     },
     sa_FormalArg: function(ast) {
         ast.uname = this.context().match(/fn/) || this.context() === 'reducer'

--- a/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
@@ -16,8 +16,8 @@ Works correctly inside a recursive function
 
     { time: "1970-01-01T00:00:00.000Z", result: 120 }
 
-Returns correct result when passed required parameters
-------------------------------------------------------
+Returns correct result when passed required parameters (with optional parameters)
+---------------------------------------------------------------------------------
 
 ### Juttle
 
@@ -31,8 +31,8 @@ Returns correct result when passed required parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters
--------------------------------------------------------------------
+Returns correct result when passed required and optional parameters (with optional parameters)
+----------------------------------------------------------------------------------------------
 
 ### Juttle
 
@@ -46,8 +46,8 @@ Returns correct result when passed required and optional parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters
-------------------------------------------------
+Produces an error when passed too few parameters (with optional parameters)
+---------------------------------------------------------------------------
 
 ### Juttle
 
@@ -61,8 +61,8 @@ Produces an error when passed too few parameters
 
   * Error: function f expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters
--------------------------------------------------
+Produces an error when passed too many parameters (with optional parameters)
+----------------------------------------------------------------------------
 
 ### Juttle
 
@@ -76,8 +76,8 @@ Produces an error when passed too many parameters
 
   * Error: function f expects 1 to 2 arguments but was called with 3
 
-Returns correct result when passed required parameters (module)
----------------------------------------------------------------
+Returns correct result when passed required parameters (module, with optional parameters)
+-----------------------------------------------------------------------------------------
 
 ### Module `m`
 
@@ -95,8 +95,8 @@ Returns correct result when passed required parameters (module)
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters (module)
-----------------------------------------------------------------------------
+Returns correct result when passed required and optional parameters (module, with optional parameters)
+------------------------------------------------------------------------------------------------------
 
 ### Module `m`
 
@@ -114,8 +114,8 @@ Returns correct result when passed required and optional parameters (module)
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters (module)
----------------------------------------------------------
+Produces an error when passed too few parameters (module, with optional parameters)
+-----------------------------------------------------------------------------------
 
 ### Module `m`
 
@@ -133,8 +133,8 @@ Produces an error when passed too few parameters (module)
 
   * Error: function m.f expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters (module)
-----------------------------------------------------------
+Produces an error when passed too many parameters (module, with optional parameters)
+------------------------------------------------------------------------------------
 
 ### Module `m`
 
@@ -151,3 +151,106 @@ Produces an error when passed too many parameters (module)
 ### Errors
 
   * Error: function m.f expects 1 to 2 arguments but was called with 3
+
+Returns correct result when passed required parameters (without optional parameters)
+------------------------------------------------------------------------------------
+
+### Juttle
+
+    function f(a) {
+      return a;
+    }
+
+    emit -from Date.new(0) -limit 1 | put result = f(1) | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 1 }
+
+
+Produces an error when passed too few parameters (without optional parameters)
+------------------------------------------------------------------------------
+
+### Juttle
+
+    function f(a) {
+      return a;
+    }
+
+    emit -from Date.new(0) -limit 1 | put result = f() | view result
+
+### Errors
+
+  * Error: function f expects 1 argument but was called with 0
+
+Produces an error when passed too many parameters (without optional parameters)
+-------------------------------------------------------------------------------
+
+### Juttle
+
+    function f(a) {
+      return a;
+    }
+
+    emit -from Date.new(0) -limit 1 | put result = f(1, 2, 3) | view result
+
+### Errors
+
+  * Error: function f expects 1 argument but was called with 3
+
+Returns correct result when passed required parameters (module, without optional parameters)
+--------------------------------------------------------------------------------------------
+
+### Module `m`
+
+    export function f(a) {
+      return a;
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from Date.new(0) -limit 1 | put result = m.f(1) | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 1 }
+
+Produces an error when passed too few parameters (module, without optional parameters)
+--------------------------------------------------------------------------------------
+
+### Module `m`
+
+    export function f(a) {
+      return a;
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from Date.new(0) -limit 1 | put result = m.f() | view result
+
+### Errors
+
+  * Error: function m.f expects 1 argument but was called with 0
+
+Produces an error when passed too many parameters (module, without optional parameters)
+---------------------------------------------------------------------------------------
+
+### Module `m`
+
+    export function f(a) {
+      return a;
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from Date.new(0) -limit 1 | put result = m.f(1, 2, 3) | view result
+
+### Errors
+
+  * Error: function m.f expects 1 argument but was called with 3


### PR DESCRIPTION
For a function with single required argument, the total number of
arguments would be computed as NaN.

This was caused by the value of the field holding optional number
of arguments being 'undefined' and the addition with an integer
converting the result into NaN.

Fix: #328