### PR TITLE
Fix error message in reducer ooo point drop

### DIFF
--- a/lib/messages.json
+++ b/lib/messages.json
@@ -8,7 +8,7 @@
   "JUTTLE-UNSUPPORTED-ADAPTER-METHOD": "adapter {type} does not implement {method}",
   "RT-GROUP-BY-UNDEFINED": "group by undefined field \"{field}\"",
   "RT-SORT-LIMIT-EXCEEDED": "sort limit exceeded, dropping points",
-  "RT-BATCH-OUT-OF-ORDER": "batch dropped out-of-order point(s)",
+  "RT-POINTS-OUT-OF-ORDER": "out-of-order point(s) dropped by {proc}",
   "RT-TIME-OUT-OF-ORDER": "out-of-order assignment of time {badTime} after {goodTime}, point(s) dropped",
   "RT-TOO-MANY-LOGS-WARNING": "too many logs from {host}, throttling",
   "RT-POINT-MISSING-TIME": "point is missing a time in {field}",

--- a/lib/runtime/procs/periodic_funcs.js
+++ b/lib/runtime/procs/periodic_funcs.js
@@ -33,7 +33,7 @@ var periodic_funcs = {
         // call after procName and interval have been established
         var self = this;
         this.warn_drop = _.throttle(function() {
-            self.trigger('warning', self.runtime_error('RT-BATCH-OUT-OF-ORDER'));
+            self.trigger('warning', self.runtime_error('RT-POINTS-OUT-OF-ORDER', { proc: this.procName }));
         }, this.interval.milliseconds());
         this.warn_timeless = _.once(function() {
             self.trigger('warning', self.runtime_error('RT-TIMELESS-POINTS'));

--- a/test/runtime/batch.spec.js
+++ b/test/runtime/batch.spec.js
@@ -48,7 +48,7 @@ describe('batch tests', function () {
             program: program
         })
         .then(function(res) {
-            expect(res.warnings[0]).match(/batch dropped out-of-order point\(s\)/);
+            expect(res.warnings[0]).match(/out-of-order point\(s\) dropped by batch/);
         });
     });
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -447,6 +447,22 @@ Allows direct assignment to the `time` field
     { time: "1970-01-01T00:01:02.000Z" }
     { time: "1970-01-01T00:01:04.000Z" }
 
+complains about out-of-order points
+-----------------------------------
+
+### Juttle
+
+    emit -points [
+        { "time": "1970-01-01T00:00:01.000Z", "value": 1 },
+        { "time": "1970-01-01T00:00:00.000Z", "value": 0 },
+        { "time": "1970-01-01T00:00:02.000Z", "value": 2 },
+    ]
+    | reduce -every :s: avg=avg(value) | view result
+
+### Warnings
+
+   * out-of-order point(s) dropped by reduce
+
 complains about out-of-order assignment to the `time` field in -every mode
 -----------------------------------------------------
 


### PR DESCRIPTION
When a reducer would process out-of-order points, it drops them and
correctly emits a warning. However, the message is misleading. E.g.:

```
read ... | reduce -every :2s: avg=avg(value) by pop
```

would result in:

"Warning: batch dropped out-of-order point(s)"

although there is no `batch` present. Change the wording to include
the proc name, so the above warning is more precise:

"out-of-order point(s) dropped by reduce"

Fix: #330