### PR TITLE
verify that -from/-to are not equal in read adapters

### DIFF
--- a/lib/messages.json
+++ b/lib/messages.json
@@ -42,6 +42,7 @@
   "RT-FROM-OVER-ERROR": "{proc} -from only when -over is specified",
   "RT-FROM-TO-OVER-ERROR": "{proc} -from/-to only when -over is specified",
   "RT-TO-BEFORE-FROM-MOMENT-ERROR": "-to must not be earlier than -from",
+  "RT-FROM-TO-EQUAL-ERROR": "{proc} -from/-to must not be equal",
   "RT-PACE-EVERY-X-ERROR": "Specify either output period with -every or time speedup with -x",
   "RT-METRICS-OR-EVENTS": "-type must be \"metric\" or \"event\"",
   "RT-EMIT-POINTS-ARRAY-ERROR": "emit -points wants an array of points",

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -40,6 +40,14 @@ var base = Base.extend({
                 option: unknown[0]
             });
         }
+
+        if (this.options.from !== undefined &&
+            this.options.to !== undefined &&
+            this.options.from.eq(this.options.to)) {
+            throw this.compile_error('RT-FROM-TO-EQUAL-ERROR', {
+                proc: this.procName
+            });
+        }
     },
 
     out: function(output_name) {

--- a/test/runtime/adapter-read-timeseries.spec.js
+++ b/test/runtime/adapter-read-timeseries.spec.js
@@ -18,6 +18,19 @@ describe('read testTimeseries', function () {
         });
     });
 
+    it('requires -from and -to to be different', function() {
+        return check_juttle({
+            program: 'read testTimeseries -from :2014-01-01: -to :2014-01-01:'
+        })
+        .then(function(result) {
+            throw new Error('unexpected success');
+        })
+        .catch(function(err) {
+            expect(err.code).equal('RT-FROM-TO-EQUAL-ERROR');
+            expect(err.message).equal('read testTimeseries -from/-to must not be equal');
+        });
+    });
+
     it('handles pure historical mode', function() {
         return check_juttle({
             program: 'read testTimeseries -from :2015-01-01: -to :2015-01-05: -every :1d:'


### PR DESCRIPTION
fixes #322

make sure to validate the -from/-to options passed to the read adapters
are never equal and if they are throw an appropriate error.