### PR TITLE
proc names from params

### DIFF
--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -9,10 +9,10 @@ var Promise = require('bluebird');
 var parsers = require('./parsers');
 
 var Read = source.extend({
-    procName: 'read-http_server',
-
     initialize: function(options, params, location, program) {
         var allowedOptions = ['port', 'method', 'timeField', 'rootPath'];
+        this.procName = 'read http_server';
+
         this.validate_options(allowedOptions);
         var allowed_methods = [ 'POST', 'PUT' ];
 

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -178,6 +178,8 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_proc: function(ast, procName, params) {
         var pname = ast.pname;
+        params = params || {};
+        params.$procName = procName;
         var soptions = this.gen_options(ast.options,
                                         ast.location,
                                         params);
@@ -191,8 +193,6 @@ var GraphCompiler = CodeGenerator.extend({
         return pname;
     },
     gen_options: function(options, location, params) {
-        params = params || {};
-
         var code = 'Juttle.extend_options([';
         var comma = '';
         var that = this;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -212,26 +212,21 @@ var GraphCompiler = CodeGenerator.extend({
         return code;
     },
     gen_params: function(params) {
-        var code = '';
+        var code = '{';
         var comma = '';
-        if (typeof params === 'string') {
-            code += params;
-        } else {
-            code += '{';
-            _.each(params, function(val, name) {
-                var e;
-                code += comma;
-                if (name[0] !== '$') {
-                    e = val;
-                } else {
-                    e = JSON.stringify(val);
-                    name = name.substring(1);
-                }
-                code+= name + ':' + e;
-                comma = ',\n ';
-            } );
-            code += '}';
-        }
+        _.each(params, function(val, name) {
+            var e;
+            code += comma;
+            if (name[0] !== '$') {
+                e = val;
+            } else {
+                e = JSON.stringify(val);
+                name = name.substring(1);
+            }
+            code+= name + ':' + e;
+            comma = ',\n ';
+        } );
+        code += '}';
         return code;
     },
 
@@ -420,7 +415,7 @@ var GraphCompiler = CodeGenerator.extend({
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);
 
-        return this.gen_proc(ast, 'filter', '{predicate: ' + code + '}');
+        return this.gen_proc(ast, 'filter', {predicate: code});
     },
     gen_SequenceProc: function(ast) {
         var checker = new DynamicFilterChecker();
@@ -433,7 +428,7 @@ var GraphCompiler = CodeGenerator.extend({
         });
         var code = '[' + filters.join (',') + ']';
 
-        return this.gen_proc(ast, 'sequence', '{predicates: ' + code + '}');
+        return this.gen_proc(ast, 'sequence', {predicates: code});
     },
     gen_SortProc: function(ast) {
         return this.gen_proc(ast, 'sort');
@@ -441,7 +436,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_View: function(ast) {
         // silly special case for ast.name due to sink's special-case parsing
         // and AST.
-        var proc = this.gen_proc(ast, 'view', '{name: "'+ast.name+'"}');
+        var proc = this.gen_proc(ast, 'view', {$name: ast.name});
 
         this.emit('views.push({name: "' + ast.name + '",' +
                   'channel: ' + proc + '.channel,' +
@@ -503,11 +498,12 @@ var GraphCompiler = CodeGenerator.extend({
             return expr.left.expression.value;
         });
 
-        return this.gen_proc(ast, which,
-                             '{ expr:' + expr + ',' +
-                             ' funcMaker:' + maker + ',' +
-                             ' reducer_index:' + JSON.stringify(reducer_index) + ',' +
-                             ' lhs:' + JSON.stringify(lhs) + '}');
+        return this.gen_proc(ast, which, {
+            expr: expr,
+            funcMaker: maker,
+            $reducer_index: reducer_index,
+            $lhs: lhs
+        });
     },
 
     gen_ReduceProc: function(ast) {

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -25,6 +25,7 @@ var base = Base.extend({
         this.logged = {};
         this.location = location;
         this.program = program;
+        this.procName = params.procName;
         this.stats = {points_in: 0, points_out: 0};
         this.last_used_output = DEFAULT_OUT_NAME;
         job_id = this.program.id ? '-' + this.program.id : '';

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -31,6 +31,7 @@ var base = Base.extend({
         job_id = this.program.id ? '-' + this.program.id : '';
         this.logger_name = 'proc-' + this.procName + job_id;
         this.logger = JuttleLogger.getLogger(this.logger_name);
+        this.logger.debug('initialize', JSON.stringify(options), JSON.stringify(params));
     },
 
     validate_options: function(allowedOptions) {

--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -75,7 +75,6 @@ var batch = periodic_fanin.extend({
         }
         this.init_warnings();
     },
-    procName:  'batch',
     process_points: function(points) {
         this.emit(points);
     },

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -121,7 +121,6 @@ var emit = source.extend({
         this.next_time = this.from;
         this.n = 0;
     },
-    procName:  'emit',
     start: function() {
         var ts = this.next_run();
         if (ts) {

--- a/lib/runtime/procs/filter.js
+++ b/lib/runtime/procs/filter.js
@@ -12,7 +12,6 @@ var filter = fanin.extend({
     initialize: function(options, params) {
         this.predicate = params.predicate;
     },
-    procName:  'filter',
     process: function(points) {
         var k = 0;
         var out = [];

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -14,14 +14,12 @@ var head = fanin.extend({
     initialize: function(options) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
-                procName: 'head',
                 argument: 'limit'
             });
         }
         this.limit = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'head',
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/join.js
+++ b/lib/runtime/procs/join.js
@@ -280,7 +280,6 @@ var join = base.extend({
         this.joinkey_groups = new JoinkeyGroups(this, {groupby: this.joinfields});
         this.joinkey_groups._undefined_fields_warned = _.invert(this.joinfields);
     },
-    procName: 'join',
     toString: function() {
         var s = 'join last_output '+this.last_output;
         this.ins.forEach(function(input) {

--- a/lib/runtime/procs/keep.js
+++ b/lib/runtime/procs/keep.js
@@ -11,7 +11,6 @@ var keep = fanin.extend({
     initialize: function(options) {
         this.columns = options.columns || [];
     },
-    procName:  'keep',
     process: function(points) {
         var pt, k, m, fld;
         var cols = this.columns;

--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -56,7 +56,6 @@ var pace = fanin.extend({
         this.playback = this.playback.bind(this);
         this.wakeup = this.wakeup.bind(this);
     },
-    procName:  'pace',
     teardown: function() {
         clearTimeout(this.timer);
         clearTimeout(this.wakeup_timer);

--- a/lib/runtime/procs/pass.js
+++ b/lib/runtime/procs/pass.js
@@ -8,7 +8,6 @@ var INFO = {
 };
 
 var pass = fanin.extend({
-    procName: 'pass'
 }, {
     info: INFO
 });

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -54,7 +54,6 @@ var put = oops_fanin.extend({
             };
         }
     },
-    procName:  'put',
     process: function(points) {
         var k, row, expr = this.expr;
         var out = [];

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -9,8 +9,6 @@ var JuttleMoment = require('../../runtime/types/juttle-moment');
 var Promise = require('bluebird');
 
 var Read = source.extend({
-    procName: 'read',
-
     initialize: function(options, params) {
         this.params = params;
 
@@ -30,7 +28,8 @@ var Read = source.extend({
             });
         }
 
-        this.logger_name = this.logger_name.replace('read', 'read-' + params.adapter.name);
+        this.procName += ' ' + params.adapter.name;
+        this.logger_name = this.logger_name.replace('read', this.procName);
         this.logger = JuttleLogger.getLogger(this.logger_name);
 
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
@@ -79,7 +78,6 @@ var Read = source.extend({
             throw err;
         }
 
-        this.procName += ' ' + adapter.name;
         this.validate_options(adapter.read.allowedOptions());
 
         var defaultTimeRange = this.adapter.defaultTimeRange();

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -224,7 +224,6 @@ var _reduce = __reduce.extend({
         }
         this.has_first_mark = false;
     },
-    procName: 'reduce',
     process: function(points) {
         this.process_points(points);
     },
@@ -310,7 +309,6 @@ var _ereduce = __ereduce.extend({
         }
         this.init_warnings();
     },
-    procName: 'reduce',
     first_epoch: function(epoch) {
         // don't run on the first epoch (called by advance)
     },

--- a/lib/runtime/procs/remove.js
+++ b/lib/runtime/procs/remove.js
@@ -12,7 +12,6 @@ var remove = fanin.extend({
     initialize: function (options) {
         this.columns = options.columns || [];
     },
-    procName:  'remove',
     process: function (points) {
         var pt, k, m, fld;
         var cols = this.columns;

--- a/lib/runtime/procs/sequence.js
+++ b/lib/runtime/procs/sequence.js
@@ -23,7 +23,6 @@ var sequence = fanin.extend({
         });
         this.groups = new Groups(this, options);
     },
-    procName:  'sequence',
 
     // For each incoming point, look up group buffer
     // evaluate filters[buffer.len] on point

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -21,7 +21,6 @@ var skip = fanin.extend({
         this.n = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'skip',
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -24,7 +24,6 @@ var sort = fanin.extend({
         this.groups = new Groups(this, options);
         this.n_pts = 0;
     },
-    procName:  'sort',
     _run: function(time) {
         var self = this;
         _.each(this.groups.table, function(row) {

--- a/lib/runtime/procs/split.js
+++ b/lib/runtime/procs/split.js
@@ -21,7 +21,6 @@ var split = fanin.extend({
         }
         this.arrays = (options.arrays === undefined) ? true : Boolean(options.arrays);
     },
-    procName: 'split',
     process: function(points) {
         var out = [];
         var i, j, k, field;

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -15,14 +15,12 @@ var tail = fanin.extend({
     initialize: function(options) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
-                procName: 'tail',
                 argument: 'limit'
             });
         }
         this.limit = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'tail',
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/unbatch.js
+++ b/lib/runtime/procs/unbatch.js
@@ -9,7 +9,6 @@ var INFO = {
 
 // unbatch, simply forwards everything except marks
 var unbatch = fanin.extend({
-    procName:  'unbatch',
     process: function(points) {
         this.emit(points);
     },

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -18,7 +18,6 @@ var uniq = fanin.extend({
         this.fields = options.arg || [];
         this.groups = new Groups(this, options);
     },
-    procName:  'uniq',
     process: function(points) {
         var toEmit = [];
 

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -14,8 +14,6 @@ var view = sink.extend({
         this.channel = 'view' + (Juttle.channels++);
     },
 
-    procName: 'view',
-
     // When views get points/marks/ticks, they emit events on
     // the related program object. Program users will subscribe for
     // these events to receive the information from the views.

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -6,8 +6,6 @@ var JuttleLogger = require('../../logger');
 var Promise = require('bluebird');
 
 var Write = sink.extend({
-    procName: 'write',
-
     initialize: function(options, params) {
         this.params = params;
 

--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -329,7 +329,7 @@ describe('read http_server', function() {
             throw new Error('the previous statement should have failed');
         })
         .catch(function(err) {
-            expect(err.toString()).to.contain('unknown read-http_server option unknown.');
+            expect(err.toString()).to.contain('unknown read http_server option unknown.');
         });
     });
 });


### PR DESCRIPTION
Instead of having each proc implementation set a prototype property specifying the `procName`, update the compiler to pass in the name of the proc as part of the params that were passed on instantiation.

This required a minor change to the graph-compiler so that it consistently generated params from an object instead of sometimes manually constructing a string.

Also added a debug log to the proc base class that prints out all the options and params as part of the initialization.

Inspired by the discussion on #326.
