### PR TITLE
verify that -from/-to are not equal in read adapters

### DIFF
--- a/lib/messages.json
+++ b/lib/messages.json
@@ -41,7 +41,7 @@
   "RT-FORGET-RESET-ERROR": "cannot -forget when -reset false",
   "RT-FROM-OVER-ERROR": "{proc} -from only when -over is specified",
   "RT-FROM-TO-OVER-ERROR": "{proc} -from/-to only when -over is specified",
-  "RT-TO-BEFORE-FROM-MOMENT-ERROR": "-to must not be earlier than -from",
+  "RT-TO-BEFORE-FROM-MOMENT-ERROR": "-from must be before -to",
   "RT-PACE-EVERY-X-ERROR": "Specify either output period with -every or time speedup with -x",
   "RT-METRICS-OR-EVENTS": "-type must be \"metric\" or \"event\"",
   "RT-EMIT-POINTS-ARRAY-ERROR": "emit -points wants an array of points",

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -54,7 +54,7 @@ var source = base.extend({
                 });
             }
 
-            if (options.from && options.from.gt(options.to)) {
+            if (options.from && options.from.gte(options.to)) {
                 throw this.compile_error('RT-TO-BEFORE-FROM-MOMENT-ERROR');
             }
         }

--- a/test/adapters/stochastic.spec.js
+++ b/test/adapters/stochastic.spec.js
@@ -21,7 +21,7 @@ describe('stochastic adapter options', function() {
             throw new Error('this should fail');
         })
         .catch(function(err) {
-            expect(err.message).to.equal('-to must not be earlier than -from');
+            expect(err.message).to.equal('-from must be before -to');
         });
     });
 

--- a/test/runtime/adapter-read-timeseries.spec.js
+++ b/test/runtime/adapter-read-timeseries.spec.js
@@ -18,6 +18,19 @@ describe('read testTimeseries', function () {
         });
     });
 
+    it('requires -from to be before -to', function() {
+        return check_juttle({
+            program: 'read testTimeseries -from :2014-01-01: -to :2014-01-01:'
+        })
+        .then(function(result) {
+            throw new Error('unexpected success');
+        })
+        .catch(function(err) {
+            expect(err.code).equal('RT-TO-BEFORE-FROM-MOMENT-ERROR');
+            expect(err.message).equal('-from must be before -to');
+        });
+    });
+
     it('handles pure historical mode', function() {
         return check_juttle({
             program: 'read testTimeseries -from :2015-01-01: -to :2015-01-05: -every :1d:'


### PR DESCRIPTION
fixes #322

make sure to validate the -from/-to options passed to the read adapters
are never equal and if they are throw an appropriate error.