### PR TITLE
events: replace backbone.Events with eventemitter3

### DIFF
--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var events = require('backbone').Events;
+var EventEmitter = require('eventemitter3');
 var Scheduler = require('../runtime/scheduler').Scheduler;
 var Graph = require('../graph');
 var Program = require('../program');
@@ -49,7 +49,7 @@ var stages = {
     eval: function(code, options) {
         var program = new Program();
         program.scheduler = options.scheduler;
-        program.events = _.extend({}, events);
+        program.events = new EventEmitter();
         program.code = code;
 
         program._eval();

--- a/lib/program.js
+++ b/lib/program.js
@@ -45,7 +45,7 @@ var Program = Base.extend({
         var env = this.env;
         var events = this.events;
         _.each(this.get_nodes(), function(node) {
-            _.extend(node.program, env, events);
+            _.extend(node.program, env, {events: events});
         });
 
         _.each(this.get_nodes(), function(node) {

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -222,7 +222,7 @@ var base = Base.extend({
                 err.info.location = this.location;
             }
         }
-        this.program.trigger(type, err.message, err);
+        this.program.events.emit(type, err.message, err);
     },
     locate_juttle_errors: function(block) {
         return errors.locate(block, this.location);

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -25,17 +25,17 @@ var view = sink.extend({
     // include proc names including the error/warning.
 
     mark: function(time) {
-        this.program.trigger('view:mark', {channel: this.channel, time: time});
+        this.program.events.emit('view:mark', {channel: this.channel, time: time});
     },
     tick: function(time) {
-        this.program.trigger('view:tick', {channel: this.channel, time: time});
+        this.program.events.emit('view:tick', {channel: this.channel, time: time});
     },
     eof: function() {
-        this.program.trigger('view:eof', {channel: this.channel});
+        this.program.events.emit('view:eof', {channel: this.channel});
         this.done();
     },
     process: function(points) {
-        this.program.trigger('view:points', {channel: this.channel, points: points});
+        this.program.events.emit('view:points', {channel: this.channel, points: points});
     }
 
 }, {

--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -245,7 +245,7 @@ var TableView = View.extend({
             self.fstream.write(table.toString() + '\n');
         }
 
-        self.events.trigger('end');
+        self.events.emit('end');
     },
 
     _valueFormatter: function(value) {

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -188,7 +188,7 @@ var TextView = View.extend({
         // writes) to flush before emitting the end event.
         // In progressive mode, the buffer is empty.
         self.fstream.write(self.buffer, function() {
-            self.events.trigger('end');
+            self.events.emit('end');
         });
     }
 });

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
-var events = require('backbone').Events;
+var EventEmitter = require('eventemitter3');
 var Promise = require('bluebird');
 var Base = require('extendable-base');
 var JuttleErrors = require('../errors');
@@ -10,7 +10,7 @@ var ViewManager = Base.extend({
     initialize: function(options, env) {
         this.program = options.program;
         this.view_classes = options.view_classes;
-        this.events = _.extend({}, events);
+        this.events = new EventEmitter();
         this.env = env;
 
         this.views = {};
@@ -19,13 +19,13 @@ var ViewManager = Base.extend({
     warning: function(msg, err) {
         var self = this;
 
-        self.events.trigger('warning', msg, err);
+        self.events.emit('warning', msg, err);
     },
 
     error: function(msg, err) {
         var self = this;
 
-        self.events.trigger('error', msg, err);
+        self.events.emit('error', msg, err);
     },
 
     // Create the necessary views and return a promise that resolves

--- a/lib/views/view.js
+++ b/lib/views/view.js
@@ -2,8 +2,7 @@
 
 /* jslint node:true */
 var Base = require('extendable-base');
-var _ = require('underscore');
-var events = require('backbone').Events;
+var EventEmitter = require('eventemitter3');
 
 // This is a base class used by the other terminal views (text,
 // table). Objects of this class should not be created directly.
@@ -12,7 +11,7 @@ var events = require('backbone').Events;
 // class to handle streams of data from juttle programs.
 var View = Base.extend({
     initialize: function(options, env) {
-        this.events = _.extend({}, events);
+        this.events = new EventEmitter();
         this.fstream = options.fstream ? options.fstream : process.stdout;
         this.env = env;
     },
@@ -20,13 +19,13 @@ var View = Base.extend({
     warn: function(msg) {
         var self = this;
 
-        self.events.trigger('warning', 'view ' + self.name + ': ' + msg);
+        self.events.emit('warning', 'view ' + self.name + ': ' + msg);
     },
 
     error: function(msg) {
         var self = this;
 
-        self.events.trigger('error', 'view ' + self.name + ': ' + msg);
+        self.events.emit('error', 'view ' + self.name + ': ' + msg);
     },
 
     // The subclass should override one or more of these callbacks to
@@ -43,7 +42,7 @@ var View = Base.extend({
 
     eof: function() {
         var self = this;
-        self.events.trigger('end');
+        self.events.emit('end');
     }
 
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "JSONStream": "^1.0.7",
     "babyparse": "^0.4.1",
-    "backbone": "^1.1.2",
     "bluebird": "^2.9.30",
     "cli-table": "^0.3.1",
     "cline": "^0.8.2",

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -140,7 +140,7 @@ var TestView = View.extend({
             result.type = this.sink.name;
             result.options = this.sink.options;
             logger.debug('End of file reached: emitting', result);
-            this.events.trigger('end', result);
+            this.events.emit('end', result);
         }
     }
 });
@@ -302,7 +302,7 @@ function run_juttle(prog, options) {
 
 function wait_for_event(program, type, checker) {
     return new Promise(function(resolve, reject) {
-        program.on(type, resolve);
+        program.events.on(type, resolve);
     })
     .then(function(err) {
         checker(err);


### PR DESCRIPTION
Go through the handful of places where we were using Backbone.Events
in juttle and replace with eventemitter3.

This required changing all calls from `events.trigger` to `events.emit`.
Note that the procs still contain a method `this.trigger` to send the
event as compared to `this.emit` which emits points.

Also instead of attaching the event emitter functions to the program
object that's shared between the procs, attach a handle on the event
emitter itself, changing all callers from `program.trigger` to
`program.events.emit`.

Note that there are a couple of places where we still use the native
node EventEmitter -- that should be cleaned up separately.

Partially fixes #49 