### PR TITLE
replace builtin node events with eventemitter3

### DIFF
--- a/lib/adapters/parsers/base.js
+++ b/lib/adapters/parsers/base.js
@@ -3,7 +3,7 @@
 var Base = require('extendable-base');
 var events = require('events');
 
-module.exports = Base.inherits(events.EventEmitter, {
+var ParserBase = Base.inherits(events.EventEmitter, {
     /*
      * A parser must implement the parseStream function below and should fire
      * errors by using the
@@ -29,3 +29,5 @@ module.exports = Base.inherits(events.EventEmitter, {
         throw new Error('parseStream must be implemented');
     }
 });
+
+module.exports = ParserBase;

--- a/lib/adapters/parsers/base.js
+++ b/lib/adapters/parsers/base.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var Base = require('extendable-base');
-var events = require('events');
+var EventEmitter = require('eventemitter3');
 
-var ParserBase = Base.inherits(events.EventEmitter, {
+var ParserBase = Base.inherits(EventEmitter, {
     /*
      * A parser must implement the parseStream function below and should fire
      * errors by using the

--- a/lib/adapters/parsers/csv.js
+++ b/lib/adapters/parsers/csv.js
@@ -5,7 +5,7 @@ var csvParser = require('csv-parser');
 var errors = require('../../errors');
 var Promise = require('bluebird');
 
-module.exports = base.extend({
+var CSVParser = base.extend({
 
     initialize: function(options) {
         this.separator = options.separator ? options.separator : ',';
@@ -66,3 +66,5 @@ module.exports = base.extend({
         });
     }
 });
+
+module.exports = CSVParser;

--- a/lib/adapters/parsers/grok.js
+++ b/lib/adapters/parsers/grok.js
@@ -6,7 +6,7 @@ var grok; // initialized in constructor
 var Promise = require('bluebird');
 var readline = require('readline');
 
-module.exports = base.extend({
+var GrokParser = base.extend({
 
     initialize: function(options) {
         this.pattern = options.pattern || '%{GREEDYDATA:message}';
@@ -95,3 +95,5 @@ module.exports = base.extend({
         });
     }
 });
+
+module.exports = GrokParser;

--- a/lib/adapters/parsers/json.js
+++ b/lib/adapters/parsers/json.js
@@ -6,7 +6,7 @@ var errors = require('../../errors');
 var oboe = require('oboe');
 var Promise = require('bluebird');
 
-module.exports = base.extend({
+var JSONParser = base.extend({
     initialize: function(options) {
         this.rootPath = options.rootPath || undefined;
     },
@@ -71,3 +71,5 @@ module.exports = base.extend({
         });
     }
 });
+
+module.exports = JSONParser;

--- a/lib/adapters/parsers/jsonl.js
+++ b/lib/adapters/parsers/jsonl.js
@@ -5,7 +5,7 @@ var errors = require('../../errors');
 var JSONStream = require('JSONStream');
 var Promise = require('bluebird');
 
-module.exports = base.extend({
+var JSONLParser = base.extend({
 
     parseStream: function(stream, emit) {
         var self = this;
@@ -54,3 +54,5 @@ module.exports = base.extend({
     }
 
 });
+
+module.exports = JSONLParser;

--- a/lib/adapters/serializers/base.js
+++ b/lib/adapters/serializers/base.js
@@ -3,7 +3,7 @@
 var Base = require('extendable-base');
 var events = require('events');
 
-module.exports = Base.inherits(events.EventEmitter, {
+var SerializerBase = Base.inherits(events.EventEmitter, {
     /*
      * A serializer can override the following methods in order to provide the
      * desired serialization method and should fire errors by using the
@@ -23,3 +23,5 @@ module.exports = Base.inherits(events.EventEmitter, {
         // serializer is done flushing the data to the unerlying stream
     }
 });
+
+module.exports = SerializerBase;

--- a/lib/adapters/serializers/base.js
+++ b/lib/adapters/serializers/base.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var Base = require('extendable-base');
-var events = require('events');
+var EventEmitter = require('eventemitter3');
 
-var SerializerBase = Base.inherits(events.EventEmitter, {
+var SerializerBase = Base.inherits(EventEmitter, {
     /*
      * A serializer can override the following methods in order to provide the
      * desired serialization method and should fire errors by using the

--- a/lib/adapters/serializers/csv.js
+++ b/lib/adapters/serializers/csv.js
@@ -6,7 +6,7 @@ var csv = require('csv-write-stream');
 var errors = require('../../errors');
 var values = require('../../runtime/values');
 
-module.exports = base.extend({
+var CSVSerializer = base.extend({
 
     write: function(points) {
         var self = this;
@@ -52,3 +52,5 @@ module.exports = base.extend({
         });
     }
 });
+
+module.exports = CSVSerializer;

--- a/lib/adapters/serializers/json.js
+++ b/lib/adapters/serializers/json.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var base = require('./base');
 
-module.exports = base.extend({
+var JSONSeralizer = base.extend({
 
     initialize: function(stream, options) {
         this.firstPoint = true;
@@ -37,3 +37,5 @@ module.exports = base.extend({
         });
     }
 });
+
+module.exports = JSONSeralizer;

--- a/lib/adapters/serializers/jsonl.js
+++ b/lib/adapters/serializers/jsonl.js
@@ -3,7 +3,7 @@
 var _ = require('underscore');
 var base = require('./base');
 
-module.exports = base.extend({
+var JSONLSerializer = base.extend({
     write: function(points) {
         var self = this;
         _.each(points, function(point) {
@@ -15,3 +15,5 @@ module.exports = base.extend({
         return Promise.resolve();
     }
 });
+
+module.exports = JSONLSerializer;


### PR DESCRIPTION
The parser / serializer base classes were the only places where we used the builtin node event emitter, so for consistency, use eventemitter3.

Along the way, clean up the way that we define all the parser / serializer classes to be more consistent and to pave the way for the big ES6 class conversion in #326.

Finishes up #49