### PR TITLE
Date parsing errors

### DIFF
--- a/lib/messages.json
+++ b/lib/messages.json
@@ -25,7 +25,7 @@
   "RT-INVALID-CSV-ERROR": "Invalid CSV data: {detail}",
   "RT-INVALID-JSON-TIME-ERROR": "the time field must contain a number or a string representing time.",
   "RT-FIELD-NOT-FOUND": "field \"{field}\" does not exist",
-  "RT-DATE-PARSE-ERROR": "Unable to parse date:\"{s}\"",
+  "RT-DATE-PARSE-ERROR": "Unable to parse date: \"{s}\"",
 
   "RT-INTEGER-REQUIRED-ERROR": "{argument} for {proc} must be an integer",
   "RT-BATCH-INTERVAL-ERROR": "batch interval must be a positive number or duration.",

--- a/lib/runtime/modules/date.js
+++ b/lib/runtime/modules/date.js
@@ -85,7 +85,13 @@ var date = {
             throw errors.typeErrorFunction('Date.new', 'number or string', seconds);
         }
 
-        return new JuttleMoment(seconds);
+        try {
+            return new JuttleMoment(seconds);
+        } catch (e) {
+            throw juttleErrors.runtimeError('RT-DATE-PARSE-ERROR', {
+                s: seconds
+            });
+        }
     },
 
     time: function() {

--- a/lib/runtime/types/juttle-moment.js
+++ b/lib/runtime/types/juttle-moment.js
@@ -103,18 +103,20 @@ var JuttleMoment = Base.extend({
     },
 
     parseDate: function(raw) {
+        var parsed = raw;
+
         // arg can be a number of seconds, or an ISO date string, or 'now'
-        if (!isNaN(raw)) {
+        if (!isNaN(parsed)) {
             // Convert seconds to milliseconds.
-            raw = Math.round(parseFloat(raw) * 1000) ;
+            parsed = Math.round(parseFloat(parsed) * 1000) ;
         }
 
-        this.moment = moment.utc(raw);
+        this.moment = moment.utc(parsed);
 
         if (!this.moment.isValid()
-            && Math.abs(raw) !== Number.POSITIVE_INFINITY) {
+            && Math.abs(parsed) !== Number.POSITIVE_INFINITY) {
             delete this.moment;
-            throw new Error('Unable to parse: '+ raw);
+            throw new Error('Unable to parse date: ' + JSON.stringify(raw));
         }
     },
 

--- a/test/runtime/specs/juttle-spec/modules/date/new.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/new.spec.md
@@ -11,3 +11,14 @@ Produces an error when passed an argument of invalid type
 ### Warnings
 
   * Invalid argument type for "Date.new": expected number or string, received null.
+
+Produces an error when passed a string with an invalid date
+-----------------------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = Date.new('') | view result
+
+### Warnings
+
+  * Unable to parse date: ""

--- a/test/runtime/specs/juttle-spec/modules/date/parse.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/parse.spec.md
@@ -32,7 +32,7 @@ Complains of badly-formed dates
 
 ### Warnings
 
-  * Unable to parse date:"bad date"
+  * Unable to parse date: "bad date"
 
 
 Parses a custom-formatted date
@@ -62,7 +62,7 @@ Complains of dates not matching a specified format
 
 ### Warnings
 
-  * Unable to parse date:"2015-05-06T19:26:07Z"
+  * Unable to parse date: "2015-05-06T19:26:07Z"
 
 
 Parses Juttle-style date variants

--- a/test/runtime/types/moments.spec.js
+++ b/test/runtime/types/moments.spec.js
@@ -366,10 +366,10 @@ describe('Juttle Moments tests', function() {
             program: 'emit -from :now: -hz 1000 -limit 1 | put foo = Date.new("blah") | view result'
         })
         .then(function(res) {
-            expect(res.errors[0]).to.equal('Unable to parse: blah');
+            expect(res.errors[0]).to.equal('Unable to parse date: "blah"');
         })
         .catch(function(err) {
-            expect(err.message).equal('Unable to parse: blah');
+            expect(err.message).equal('Unable to parse date: "blah"');
         });
     });
 

--- a/test/runtime/types/moments.spec.js
+++ b/test/runtime/types/moments.spec.js
@@ -366,7 +366,7 @@ describe('Juttle Moments tests', function() {
             program: 'emit -from :now: -hz 1000 -limit 1 | put foo = Date.new("blah") | view result'
         })
         .then(function(res) {
-            expect(res.errors[0]).to.equal('Unable to parse date: "blah"');
+            expect(res.warnings[0]).to.equal('Unable to parse date: "blah"');
         })
         .catch(function(err) {
             expect(err.message).equal('Unable to parse date: "blah"');


### PR DESCRIPTION
Date module's `new` wasn't catching errors from JuttleMoment properly and JuttleMoment's parse error wasn't that much descriptive either.

Catch and re-throw JuttleMoment's generic `Error` as Juttle native errors and also improve the error message wording.