### PR TITLE
adapters: check required options in base

### DIFF
--- a/lib/adapters/file/read.js
+++ b/lib/adapters/file/read.js
@@ -11,13 +11,6 @@ class ReadFile extends AdapterRead {
     constructor(options, params) {
         super(options, params);
 
-        if (!_.has(options, 'file')) {
-            throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
-                proc: 'read file',
-                option: 'file'
-            });
-        }
-
         this.filename = options.file;
         this.timeField = options.timeField;
         this.format = options.format ? options.format : 'json'; // default to json
@@ -53,6 +46,10 @@ class ReadFile extends AdapterRead {
 
     static allowedOptions() {
         return AdapterRead.commonOptions.concat(['file', 'format', 'pattern']);
+    }
+
+    static requiredOptions() {
+        return ['file'];
     }
 
     // do not remove as this is used by lib/runtime/specs/juttle-test-utils

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var _ = require('underscore');
 var AdapterWrite = require('../../runtime/adapter-write');
-var errors = require('../../errors');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
 var serializers = require('../serializers');
@@ -11,19 +9,16 @@ class WriteFile extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
 
-        if (!_.has(options, 'file')) {
-            throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
-                proc: 'write file',
-                option: 'file'
-            });
-        }
-
         this.filename = options.file;
         this.format = options.format ? options.format : 'json'; // default to json
     }
 
     static allowedOptions() {
         return ['file', 'format'];
+    }
+
+    static requiredOptions() {
+        return ['file'];
     }
 
     start() {

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -100,13 +100,6 @@ class ReadHTTP extends AdapterRead {
     constructor(options, params) {
         super(options, params);
 
-        if (!_.has(options, 'url')) {
-            throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
-                proc: 'read http',
-                option: 'url'
-            });
-        }
-
         this.url = options.url;
         this.method = options.method ? options.method : 'GET';
         this.headers = options.headers ? options.headers : {};
@@ -135,6 +128,10 @@ class ReadHTTP extends AdapterRead {
         var httpOptions = ['url', 'method', 'headers', 'body', 'timeField',
             'includeHeaders', 'rootPath', 'format'];
         return AdapterRead.commonOptions.concat(httpOptions);
+    }
+
+    static requiredOptions() {
+        return ['url'];
     }
 
     // Override the default time range to make sure it's set when calling

--- a/lib/adapters/http/write.js
+++ b/lib/adapters/http/write.js
@@ -21,13 +21,6 @@ class WriteHTTP extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
 
-        if (!_.has(options, 'url')) {
-            throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
-                proc: 'write http',
-                option: 'url'
-            });
-        }
-
         this.url = options.url;
         this.method = options.method ? options.method : 'POST';
         this.headers = options.headers ? options.headers : {};
@@ -40,6 +33,10 @@ class WriteHTTP extends AdapterWrite {
 
     static allowedOptions() {
         return ['url', 'method', 'headers', 'maxLength', 'useArray'];
+    }
+
+    static requiredOptions() {
+        return ['url'];
     }
 
     write(points) {

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -56,7 +56,6 @@
   "RT-JOIN-ALL-TABLES-ERROR": "at least one input must not be a table",
   "RT-JOIN-TABLE-OUTER-ERROR": "-table and -outer cannot be specified for the same input",
   "RT-JOIN-TABLE-BATCHED-ERROR": "-table input cannot be batched.",
-  "RT-REQUIRED-OPTION-ERROR": "invalid {proc} required option {option}.",
   "RT-MISSING-OPTION-ERROR": "missing {proc} required option {option}.",
   "RT-UNKNOWN-OPTION-ERROR": "unknown {proc} option {option}.",
   "RT-INCOMPATIBLE-OPTION-ERROR": "-{option} option should not be combined with -{other}",

--- a/lib/runtime/adapter-read.js
+++ b/lib/runtime/adapter-read.js
@@ -69,8 +69,8 @@ class AdapterRead {
     // Common read options that should be supported by all adapters.
     static get commonOptions() { return ['from', 'to', 'last', 'timeField', 'every', 'lag']; }
 
-    // subclasses can override this method to return an array
-    // if they do we'll check that all options passed to the
+    // subclasses override this method to return an array
+    // we'll check that all options passed to the
     // proc are in the array
     static allowedOptions() { return AdapterRead.commonOptions; }
 

--- a/lib/runtime/adapter-read.js
+++ b/lib/runtime/adapter-read.js
@@ -74,6 +74,11 @@ class AdapterRead {
     // proc are in the array
     static allowedOptions() { return AdapterRead.commonOptions; }
 
+    // subclasses override this method to return an array
+    // if they do we'll check that all options in the array
+    // are passed to the proc
+    static requiredOptions() { return []; }
+
     // Assigns the time from timeField to 'time' and attempts to convert it
     // into JuttleMoment.
     parseTime(points, timeField) {

--- a/lib/runtime/adapter-write.js
+++ b/lib/runtime/adapter-write.js
@@ -41,10 +41,10 @@ class AdapterWrite {
         throw new Error('write must be implemented');
     }
 
-    // subclasses can override this method to return an array
-    // if they do we'll check that all options passed to the
+    // subclasses override this method to return an array
+    // we'll check that all options passed to the
     // proc are in the array
-    static allowedOptions() { return false; }
+    static allowedOptions() { return []; }
 
     // subclasses override this method to return an array
     // if they do we'll check that all options in the array

--- a/lib/runtime/adapter-write.js
+++ b/lib/runtime/adapter-write.js
@@ -46,6 +46,11 @@ class AdapterWrite {
     // proc are in the array
     static allowedOptions() { return false; }
 
+    // subclasses override this method to return an array
+    // if they do we'll check that all options in the array
+    // are passed to the proc
+    static requiredOptions() { return []; }
+
     // Signal that the stream is done.
     //
     // Returns a value or a promise once the adapter has completed writing all

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -32,12 +32,21 @@ var base = Base.extend({
         this.logger = JuttleLogger.getLogger(this.logger_name);
     },
 
-    validate_options: function(allowedOptions) {
-        var unknown = _.difference(_.keys(this.options), allowedOptions);
+    validate_options: function(allowedOptions, requiredOptions) {
+        var options = _.keys(this.options);
+        var unknown = _.difference(options, allowedOptions);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
                 proc: this.procName,
                 option: unknown[0]
+            });
+        }
+
+        var missing = _.difference(requiredOptions, options);
+        if (missing.length > 0) {
+            throw this.compile_error('RT-MISSING-OPTION-ERROR', {
+                proc: this.procName,
+                option: missing[0]
             });
         }
     },

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -80,7 +80,7 @@ var Read = source.extend({
         }
 
         this.procName += ' ' + adapter.name;
-        this.validate_options(adapter.read.allowedOptions());
+        this.validate_options(adapter.read.allowedOptions(), adapter.read.requiredOptions());
 
         var defaultTimeRange = this.adapter.defaultTimeRange();
         this.from = this.options.from || defaultTimeRange.from;

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -73,7 +73,7 @@ var Write = sink.extend({
         });
 
         if (adapter.write.allowedOptions()) {
-            this.validate_options(adapter.write.allowedOptions());
+            this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
         }
     },
 

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -72,9 +72,7 @@ var Write = sink.extend({
             this.trigger('warning', err);
         });
 
-        if (adapter.write.allowedOptions()) {
-            this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
-        }
+        this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
     },
 
     start: function() {

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -20,7 +20,7 @@ describe('adapter API tests', function () {
             expect(result.sinks.table.length).equal(0);
         })
         .catch(function(err) {
-            expect(err.message).to.equal('invalid read test required option key.');
+            expect(err.message).to.equal('missing read test required option key.');
         });
     });
 
@@ -32,7 +32,7 @@ describe('adapter API tests', function () {
             throw new Error('this should fail');
         })
         .catch(function(err) {
-            expect(err.message).to.equal('invalid write test required option key.');
+            expect(err.message).to.equal('missing write test required option key.');
         });
     });
 
@@ -189,7 +189,7 @@ describe('adapter API tests', function () {
 
     it('defaults to undefined for -from and -to', function() {
         return check_juttle({
-            program: 'read test -debug "timeBounds"'
+            program: 'read test -debug "timeBounds" -key "bananas"'
         })
         .then(function(result) {
             expect(result.errors).deep.equal([]);

--- a/test/runtime/test-adapter.js
+++ b/test/runtime/test-adapter.js
@@ -22,7 +22,7 @@ function TestAdapter(config) {
             this.debug = options.debug;
             this.key = options.key;
             if (!this.debug && !this.key) {
-                throw new errors.compileError('RT-REQUIRED-OPTION-ERROR', {
+                throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
                     proc: 'read test',
                     option: 'key'
                 });
@@ -136,7 +136,7 @@ function TestAdapter(config) {
             super(options, params);
             this.key = options.key;
             if (! this.key) {
-                throw new errors.compileError('RT-REQUIRED-OPTION-ERROR', {
+                throw new errors.compileError('RT-MISSING-OPTION-ERROR', {
                     proc: 'write test',
                     option: 'key'
                 });

--- a/test/runtime/test-adapter.js
+++ b/test/runtime/test-adapter.js
@@ -143,6 +143,10 @@ function TestAdapter(config) {
             }
         }
 
+        static allowedOptions() {
+            return ['key'];
+        }
+
         write(points) {
             this.logger.debug('write', this.key, points);
             var data = store[this.key] || [];


### PR DESCRIPTION
Also, we don't currently check allowed options for adapter write unless the `allowedOptions` method is overwritten, which is inconsistent with what we do for `read`. So let's check them.

@juttle/developers 