### PR TITLE
Consolidate Juttle runtime: Move Juttle.extend_options to the compiler

### DIFF
--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -192,23 +192,64 @@ var GraphCompiler = CodeGenerator.extend({
         this.emit(code);
         return pname;
     },
+    extend_options: function(opts, location) {
+        var options = { type: 'ObjectLiteral', properties: [], location: location };
+        function setopt(name, val, location) {
+            var parts = name.split('.');
+            var o = options;
+            for (var i=0; i<parts.length-1; i++) {
+                var part = parts[i];
+                var index = _.findIndex(o.properties, function(property) {
+                    return property.key.value === part;
+                });
+                if (index === -1) {
+                    o.properties.push({
+                        type: 'ObjectProperty',
+                        key: { type: 'StringLiteral', value: part, location: location },
+                        value: { type: 'ObjectLiteral', properties: [], location: location },
+                        location: location
+                    });
+                    index = o.properties.length - 1;
+                }
+                o = o.properties[index].value;
+                if (o.type !== 'ObjectLiteral') {
+                    throw errors.compileError('RT-BAD-NESTED-OPTION', {
+                        name: name,
+                        location: location
+                    });
+                }
+            }
+            o.properties.push({
+                type: 'ObjectProperty',
+                key: { type: 'StringLiteral', value: parts[parts.length-1], location: location },
+                value: val,
+                location: location
+            });
+        }
+
+        _.each(opts, function(option) {
+            if (option.id === 'o' || option.id === 'options') {
+                if (option.val.type === 'ObjectLiteral' && !option.val.type !== 'ArrayLiteral') {
+                    _.each(option.val.properties, function(property) {
+                        setopt(property.key.value, property.value);
+                    } );
+                } else {
+                    throw errors.compileError('RT-INVALID-SINK-OPTIONS-ERROR', {
+                        procName: '',
+                        location: location
+                    });
+                }
+            } else {
+                setopt(option.id, option.val, option.location);
+            }
+        });
+
+        return options;
+    },
     gen_options: function(options, location, params) {
         params = params || {};
 
-        var code = 'Juttle.extend_options([';
-        var comma = '';
-        var that = this;
-
-        _.each(options, function(option) {
-            var e;
-            code += comma;
-            e = that.gen_expr(option.val);
-            code += '{name: "' + option.id + '", val:' + e + '}';
-            comma = ',\n ';
-        });
-        code += '], ';
-        code += JSON.stringify(location);
-        code += ')';
+        var code = this.gen_expr(this.extend_options(options, location));
         code += ',';
         code += this.gen_params(params);
         return code;

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -1,8 +1,5 @@
 'use strict';
 
-var _ = require('underscore');
-var errors = require('../../errors');
-
 var adapters = require('../adapters');
 
 // Juttle namespace
@@ -12,48 +9,5 @@ var Juttle = {
 };
 
 Juttle.adapters = adapters;
-
-// Additional Functions
-
-Juttle.extend_options = function(opts, location) {
-
-    var options = {};
-    function setopt(name, val) {
-        var parts = name.split('.');
-        var o = options;
-        for (var i=0; i<parts.length-1; i++) {
-            var part = parts[i];
-            if (!o.hasOwnProperty(part)) {
-                o[part] = {};
-            }
-            o = o[part];
-            if (o.constructor !== Object) {
-                throw errors.compileError('RT-BAD-NESTED-OPTION', {
-                    name: name,
-                    location: location
-                });
-            }
-        }
-        o[parts[parts.length-1]] = val;
-    }
-
-    _.each(opts, function(option) {
-        if (option.name === 'o' || option.name === 'options') {
-            if (_(option.val).isObject() && !_(option.val).isArray()) {
-                _.each(option.val, function(val, name) {
-                    setopt(name, val);
-                } );
-            } else {
-                throw errors.compileError('RT-INVALID-SINK-OPTIONS-ERROR', {
-                    location: location
-                });
-            }
-        } else {
-            setopt(option.name, option.val);
-        }
-    });
-
-    return options;
-};
 
 module.exports = Juttle;


### PR DESCRIPTION
`Juttle.extend_options` was a helper function responsible for processing proc options — specifically expanding nested options and `-o`/`-options`. So far it did its work in runtime but there is no good reason for that (options are known in compile-time already).

This PR moves `Juttle.extend_options` into `GraphCompiler`, which runs it in compile-time. Note the move required making it work on AST nodes instead of Juttle values.

Part of work on #97.