### PR TITLE
Consolidate Juttle runtime: Kill Juttle.visitGen and Juttle.teardown

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -7,7 +7,8 @@ var Promise = require('bluebird');
 
 var juttle = require('./runtime').runtime;
 
-var Juttle = require('./runtime').Juttle;
+// Needed to evaluate compiled programs.
+var Juttle = require('./runtime').Juttle;   // eslint-disable-line
 var source = require('./runtime/procs/source');
 var sink = require('./runtime/procs/sink');
 var view = require('./runtime/procs/view');
@@ -17,14 +18,21 @@ var errors = require('./errors');
 var Program = Base.extend({
     initialize: function() {
         this.env = {};
+        this.visitGen = 0;
     },
     set_env: function(env) {
         this.env = _.extend(this.env, env);
     },
     deactivate: function() {
+        var k;
         this.scheduler.stop();
         if (this.graph) {
-            Juttle.teardown(this.graph);
+            this.visitGen += 1;
+            // loop over the head array to handle the case where
+            // the onramp to the graph is a parallel path
+            for (k = 0; k < this.graph.head.length; ++k) {
+                this.graph.head[k].deactivate(this.visitGen);
+            }
             delete this.graph;
         }
     },

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -8,17 +8,7 @@ var adapters = require('../adapters');
 // Juttle namespace
 
 var Juttle = {
-    channels:0,
-    visitGen:0,
-    teardown: function(entryNode) {
-        var k;
-        Juttle.visitGen += 1;
-        // loop over the head array to handle the case where
-        // the onramp to the graph is a parallel path
-        for (k = 0; k < entryNode.head.length; ++k) {
-            entryNode.head[k].deactivate(Juttle.visitGen);
-        }
-    }
+    channels:0
 };
 
 Juttle.adapters = adapters;


### PR DESCRIPTION
Inline `Juttle.teardown` into `Program#deactivate`. Move `Juttle.visitGen` into `Program#visitGen`.

This is a little step on the path leading to dismantling the `Juttle` global object.

Part of work on #97.