### PR TITLE
fanin: Handle null time field in incoming points

### DIFF
--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -138,7 +138,7 @@ var fanin = base.extend({
                 break;
             } else {
                 var p = input.first();
-                if (p.time === undefined
+                if (!p.time
                     || p.time.lt(earliest_time)
                     || p.time.eq(earliest_time) && p.mark) {
                     earliest = input;

--- a/test/runtime/specs/juttle-spec/flowgraph-tests.spec.md
+++ b/test/runtime/specs/juttle-spec/flowgraph-tests.spec.md
@@ -14,3 +14,21 @@ Modifying a point on one branch does not modify it on another.
     {"label":"branch1"}
     {"label":"branch1"}
     {"label":"pre"}
+
+Points with `time == null` are handled correctly
+------------------------------------------------
+
+Regression test for #351.
+
+### Juttle
+
+    emit -from :0: -limit 1
+    | batch -every :1s:
+    | filter true = false
+    | (reduce time = null; reduce time = null)
+    | view result
+
+### Output
+
+    { time: null }
+    { time: null }


### PR DESCRIPTION
Change a test probing for presence of the `time` field in a point so that a `null` value is treated as if the `time` field was not set. This is in line with other similar checks in the codebase. The end result is that points with `null` time don’t cause an exception.

Fixes #351.