### PR TITLE
Make assigning invalid time in put/reduce produce a warning

### DIFF
--- a/lib/runtime/procs/oops_funcs.js
+++ b/lib/runtime/procs/oops_funcs.js
@@ -20,6 +20,9 @@ var oops_funcs = {
             goodTime:goodTime.valueOf()
         }));
     },
+    warn_time: function(time) {
+        this.trigger('warning', errors.typeErrorTime(time));
+    },
     emit: function(points, output_name) {
         if (this.watch_oops) {
             var i = 0;
@@ -27,7 +30,9 @@ var oops_funcs = {
                 var time = points[i].time;
                 if (time) {
                     if (!time.moment) {
-                        throw errors.typeErrorTime(time);
+                        this.warn_time(time);
+                        points.splice(i, 1); // drop that point!
+                        continue;
                     } else if (time.lt(this.last_output_time)) {
                         this.warn_oops(time, this.last_output_time);
                         points.splice(i, 1); // drop that point!

--- a/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
@@ -34,7 +34,7 @@ complains about non-time assignment to the `time` field
 
     emit -from Date.new(0) -limit 3 | put n=count(), time = :s: | view result
 
-### Errors
+### Warnings
 
    * Invalid type assigned to time: duration (00:00:01.000).
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -463,6 +463,28 @@ complains about out-of-order points
 
    * out-of-order point(s) dropped by reduce
 
+complains about non-time assignment to the `time` field in -every mode
+-----------------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | reduce -every :s: time = :s: | view result
+
+### Warnings
+
+   * Invalid type assigned to time: duration (00:00:01.000).
+
+complains about non-time assignment to the `time` field in batch mode
+-----------------------------------------------------
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | batch :s: | reduce time = :s: | view result
+
+### Warnings
+
+   * Invalid type assigned to time: duration (00:00:01.000).
+
 complains about out-of-order assignment to the `time` field in -every mode
 -----------------------------------------------------
 


### PR DESCRIPTION
This behavior makes handling of invalid time assignment consistent with handling of other runtime errors such as type errors.

Fixes #358 & #359.