### PR TITLE
docs: update links to point to juttle-engine and not outrigger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ When filing a new bug, include:
 - juttle program you ran (put it in a code block if the program is short, attach in a text file if long)
 - sample data (if your program reads from a storage backend, explain the data format)
 - steps to reproduce the problem, if it's more than just running your juttle program
-- screenshot of the browser output, if the problem is with juttle-viz or outrigger
+- screenshot of the browser output, if the problem is with juttle-viz or juttle-viewer
 - version of the code you used (for example, 'juttle@0.1.0' as reported by `npm list`, or "master as of rev abcd")
 
 What will happen to the bug next? See [wiki](https://github.com/juttle/juttle/wiki/Managing-Issues#bugs).

--- a/README.md
+++ b/README.md
@@ -165,16 +165,18 @@ of wiring Juttle dataflow computation to your browser-based views.
 
 This can be done using [Juttle Engine](https://github.com/juttle/juttle-engine),
 an integrated environment for developing and executing juttle programs and
-visualizations. Juttle Engine integrates
-[juttle-service](https://github.com/juttle/juttle-service), a node.js API server
-that enables execution of Juttle programs using a REST API along with the
-[juttle-viewer](https://github.com/juttle/juttle-viewer) application that
-renders the input controls and results of juttle programs using the
-[juttle-viz](https://github.com/juttle/juttle-viz) visualization library.
-
-Juttle Engine lets you run Juttle programs stored on the file system
-and present the results in a browser for experimentation, development,
+visualizations. Juttle Engine lets you run Juttle programs stored on the file
+system and present the results in a browser for experimentation, development,
 deployment, and debugging of juttles.
+
+It integrates [juttle-service](https://github.com/juttle/juttle-service), a
+node.js API server that enables execution of Juttle programs using a REST API
+with the ability to serve web application bundles. It comes with the
+[juttle-viewer](https://github.com/juttle/juttle-viewer) application that
+provides a simple in browser experience for loading and executing juttle
+programs in the juttle-engine and rendering the results using the
+[juttle-viz](https://github.com/juttle/juttle-viz) visualization library. In the
+future, Juttle Engine may be extended to support other application bundles.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ and energy), Juttle integrates these two layers
 so you don't have to worry about the details
 of wiring Juttle dataflow computation to your browser-based views.
 
-As an example, [Juttle Engine](https://github.com/juttle/juttle-engine) is an
-integrated environment for developing and executing juttle programs and
+This can be done using [Juttle Engine](https://github.com/juttle/juttle-engine),
+an integrated environment for developing and executing juttle programs and
 visualizations. Juttle Engine integrates
-[juttle-service](https://github.com/juttle/juttle-engine), a node.js server that
-enables execution of Juttle programs using a REST API, along with the
+[juttle-service](https://github.com/juttle/juttle-service), a node.js API server
+that enables execution of Juttle programs using a REST API along with the
 [juttle-viewer](https://github.com/juttle/juttle-viewer) application that
-integrates juttle programs with the
+renders the input controls and results of juttle programs using the
 [juttle-viz](https://github.com/juttle/juttle-viz) visualization library.
 
 Juttle Engine lets you run Juttle programs stored on the file system

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Here are some more examples of what you can do with Juttle.
 
 Note that most of these examples use Juttle in conjunction with external systems
 using [adapters](#adapters) and/or depend on visualizations from an environment
-like [outrigger](#outrigger) so they are meant to be
+like [Juttle Engine](#juttle-engine) so they are meant to be
 illustrative and not necessarily functional out of the box.
 
-For more end-to-end examples of juttle usage, see the [outrigger examples](https://github.com/juttle/outrigger/tree/master/examples).
+For more end-to-end examples of juttle usage, see the [Juttle Engine examples](https://github.com/juttle/juttle-engine/tree/master/examples).
 
 ### Hello world
 
@@ -146,8 +146,8 @@ This is a partial list of adapters that can be installed separately. Make sure t
 
 Connections to external adapters are configured in the "adapters" section of the runtime configuration. See the [CLI reference](./docs/reference/cli.md) for specific instructions.
 
-<a name="outrigger"></a>
-## Visualizations with Outrigger
+<a name="juttle-engine"></a>
+## Visualizations with Juttle Engine
 
 The Juttle CLI and its backend adapters provide a
 programmable foundation for dataflow-oriented analytics, but there is no
@@ -163,15 +163,18 @@ and energy), Juttle integrates these two layers
 so you don't have to worry about the details
 of wiring Juttle dataflow computation to your browser-based views.
 
-We haven't yet worked out all of the details of this separation, but
-we've put together the components in a prototype test and development utility
-called [outrigger](https://github.com/juttle/outrigger).
-Outrigger pulls in the Juttle core from this repo along with
-the [juttle-viz](https://github.com/juttle/juttle-viz) visualization library and corresponding glue
-to implement Juttle's visualization capabilities.
-Outrigger lets you run Juttle programs from your local file system
+As an example, [Juttle Engine](https://github.com/juttle/juttle-engine) is an
+integrated environment for developing and executing juttle programs and
+visualizations. Juttle Engine integrates
+[juttle-service](https://github.com/juttle/juttle-engine), a node.js server that
+enables execution of Juttle programs using a REST API, along with the
+[juttle-viewer](https://github.com/juttle/juttle-viewer) application that
+integrates juttle programs with the
+[juttle-viz](https://github.com/juttle/juttle-viz) visualization library.
+
+Juttle Engine lets you run Juttle programs stored on the file system
 and present the results in a browser for experimentation, development,
-and debugging of juttles.
+deployment, and debugging of juttles.
 
 ## Contributing
 

--- a/docs/concepts/inputs.md
+++ b/docs/concepts/inputs.md
@@ -13,7 +13,7 @@ The `name` can be any valid identifier and is treated in the program like a  [co
 
 Inputs can be declared in a Juttle program either at the top level of a flowgraph or inside a [subgraph](./programming_constructs.md#subgraphs).
 
-Before the program is run, an application environment like [outrigger](http://github.com/juttle/outrigger) first evaluates the flowgraph to determine which inputs are in the program and renders them for a user. Then once the user has made their selection, the application gathers the selections and includes them when running the program.
+Before the program is run, an application environment like [juttle engine](http://github.com/juttle/juttle-engine) first evaluates the flowgraph to determine which inputs are in the program and renders them for a user. Then once the user has made their selection, the application gathers the selections and includes them when running the program.
 
 Note: The specific types of supported inputs and the supported options are supplied from the application environment and are not part of Juttle itself. The Juttle CLI has limited support for text and number inputs using command line options.
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -32,7 +32,7 @@ In the simple example above, the following steps occurred:
 
 1. The point is fed into the processor [put](../processors/put.md), which adds a field called message.
 
-1. The point is then sent to a `table` [view](./views.md) which renders the result as the given table. Note that the specific views are actually not part of the Juttle language -- they are passed through to the calling environment, either the Juttle CLI (shown above) or an application environment like [outrigger](https://github.com/juttle/outrigger).
+1. The point is then sent to a `table` [view](./views.md) which renders the result as the given table. Note that the specific views are actually not part of the Juttle language -- they are passed through to the calling environment, either the Juttle CLI (shown above) or an application environment like [juttle engine](https://github.com/juttle/juttle-engine).
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,7 +2,7 @@
 
 `juttle` is the command line interface for running juttle programs. It reads data from configured backends via adapters, executes juttle programs, and provides terminal-oriented visualizations that allow you to view the output of programs.
 
-For more complex visualizations, you can use [outrigger](https://github.com/juttle/outrigger), which provides browser-based visualizations and support for [input controls](../concepts/inputs.md).
+For more complex visualizations, you can use [juttle engine](https://github.com/juttle/juttle-engine), which provides browser-based visualizations and support for [input controls](../concepts/inputs.md).
 
 ## Usage
 

--- a/docs/sinks/view.md
+++ b/docs/sinks/view.md
@@ -33,7 +33,7 @@ Display a raw dump of the output in a fixed-width, console-style font.
 
 These charts are supplied by the [juttle-viz charting library](https://github.com/juttle/juttle-viz) which seamlessly integrates with Juttle.
 
-To use these charts, follow installation instructions for juttle-viz, or try out the integrated Juttle analytics environment [outrigger](https://github.com/juttle/demo-app).
+To use these charts, follow installation instructions for juttle-viz, or try out the integrated Juttle analytics environment [juttle engine](https://github.com/juttle/juttle-engine).
 
 Sink | Description | Image
 ---- | ----------- | -----

--- a/misc/emacs/juttle-derived-mode.el
+++ b/misc/emacs/juttle-derived-mode.el
@@ -14,7 +14,7 @@
 ;; (setq juttle-run-dir "/home/<user>/src/juttle/bin")
 
 (defvar juttle-run-dir "")
-(defvar juttle-run-prog "outrigger-client push --topic mydev --path")
+(defvar juttle-run-prog "juttle-engine-client push --topic mydev --path")
 
 (defvar juttle-derived-mode-hook nil "hooks")
 


### PR DESCRIPTION
Replace the links to the outrigger project with links to juttle-engine.

Note: this is to merge into the 0.4.x branch, to be included in a 0.4.1 release of juttle.
