### PR TITLE
http server adapter port to the new adapter api

### DIFF
--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -3,21 +3,18 @@
 var http = require('http');
 var _ = require('underscore');
 var contentType = require('content-type');
-
-var source = require('../runtime/procs/source');
+var AdapterRead = require('../runtime/adapter-read');
 var Promise = require('bluebird');
 var parsers = require('./parsers');
 
-var Read = source.extend({
-    procName: 'read-http_server',
+class ReadHTTPServer extends AdapterRead {
+    constructor(options, params) {
+        super(options, params);
 
-    initialize: function(options, params, location, program) {
-        var allowedOptions = ['port', 'method', 'timeField', 'rootPath'];
-        this.validate_options(allowedOptions);
         var allowed_methods = [ 'POST', 'PUT' ];
 
         if (options.method && allowed_methods.indexOf(options.method) === -1) {
-            throw this.compile_error('RT-INVALID-OPTION-VALUE', {
+            throw this.compileError('RT-INVALID-OPTION-VALUE', {
                 option: 'method',
                 supported: allowed_methods.join(', ')
             });
@@ -27,19 +24,24 @@ var Read = source.extend({
         this.method = options.method || 'POST';
         this.timeField = options.timeField;
         this.rootPath = options.rootPath;
+        this.readEvery = options.every ? options.every.milliseconds() : 50;
 
         if (params.filter_ast) {
-            throw this.compile_error('RT-ADAPTER-UNSUPPORTED-FILTER', {
+            throw this.compileError('RT-ADAPTER-UNSUPPORTED-FILTER', {
                 proc: 'read http_server',
                 filter: 'filtering'
             });
         }
-    },
 
-    start: function() {
-        var self = this;
+        this.points = [];
+    }
 
-        this.server = http.createServer(function(req, res) {
+    static allowedOptions() {
+        return ['port', 'method', 'timeField', 'rootPath', 'every'];
+    }
+
+    start() {
+        this.server = http.createServer((req, res) => {
             var format;
             try {
                 format = contentType.parse(req).type.split('/')[1];
@@ -48,40 +50,37 @@ var Read = source.extend({
                 // type is undefined
             }
 
-            Promise.try(function() {
-                if (req.method !== self.method) {
-                    throw self.runtime_error('RT-INVALID-HTTP-METHOD', {
+            Promise.try(() => {
+                if (req.method !== this.method) {
+                    throw this.runtimeError('RT-INVALID-HTTP-METHOD', {
                         types: 'POST'
                     });
                 }
 
                 if (format !== 'json' && format !== 'csv') {
-                    throw self.runtime_error('RT-INVALID-TYPE', {
+                    throw this.runtimeError('RT-INVALID-TYPE', {
                         types: 'csv, json'
                     });
                 }
 
 
-                var emit_points = [];
-
-                var parser =  parsers.getParser(format , {rootPath: self.rootPath});
-                return parser.parseStream(req, function(points) {
+                var parser = parsers.getParser(format , {rootPath: this.rootPath});
+                return parser.parseStream(req, (points) => {
                     if (!_.isArray(points)) {
                         points = [points];
                     }
 
-                    self.parseTime(points, self.timeField);
-                    emit_points = emit_points.concat(points);
+                    this.parseTime(points, this.timeField);
+                    this.points = this.points.concat(points);
                 })
-                .then(function() {
-                    self.emit(emit_points);
-
+                .then(() => {
+                    this.gotPoints();
                     res.statusCode = 200;
                     res.end();
                 });
             })
-            .catch(function(err) {
-                self._handle_listen_error(res, err);
+            .catch((err) => {
+                this.handleListenError(res, err);
             });
         });
 
@@ -89,9 +88,44 @@ var Read = source.extend({
             port: this.port,
             path: '/'
         });
-    },
+    }
 
-    _handle_listen_error: function(res, err) {
+    read(from, to, limit, state) {
+        this.logger.debug('in read --', this.points.length, 'buffered points');
+        if (this.points.length > 0) {
+            return this.readResult(limit);
+        } else {
+            return new Promise((resolve, reject) => {
+                this.pendingRead = resolve;
+                this.pendingReadLimit = limit;
+            })
+            .timeout(this.readEvery)
+            .catch(Promise.TimeoutError, (err) => {
+                this.logger.debug('read: no points arrived in', this.readEvery, 'ms');
+                return {};
+            });
+        }
+    }
+
+    readResult(limit) {
+        var ret = {};
+        if (this.points.length <= limit) {
+            ret.points = this.points;
+            this.points = [];
+        } else {
+            ret.points = this.points.splice(0, limit);
+        }
+        return ret;
+    }
+
+    gotPoints() {
+        this.logger.debug('_gotPoints -- pendingRead', !!this.pendingRead, 'limit', this.pendingReadLimit);
+        if (this.pendingRead) {
+            this.pendingRead(this.readResult(this.pendingReadLimit));
+        }
+    }
+
+    handleListenError(res, err) {
         res.statusMessage = err.message;
         res.statusCode = 400;
 
@@ -103,21 +137,25 @@ var Read = source.extend({
 
         this.trigger('error', err);
         res.end();
-    },
-
-    teardown: function() {
-        if (this.server) {
-            this.server.close();
-        }
-
-        this.emit_eof();
     }
-});
+
+    teardown() {
+        return new Promise((resolve, reject) => {
+            if (this.server) {
+                this.server.close(() => {
+                    resolve();
+                });
+            } else {
+                resolve();
+            }
+        });
+    }
+}
 
 function HttpServerAdapter(config) {
     return {
         name: 'http_server',
-        read: Read
+        read: ReadHTTPServer
     };
 }
 

--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -114,14 +114,9 @@ class ReadHTTPServer extends AdapterRead {
     }
 
     readResult(limit) {
-        var ret = {};
-        if (this.points.length <= limit) {
-            ret.points = this.points;
-            this.points = [];
-        } else {
-            ret.points = this.points.splice(0, limit);
-        }
-        return ret;
+        return {
+            points: this.points.splice(0, limit)
+        };
     }
 
     handleListenError(res, err) {

--- a/lib/adapters/http_server.js
+++ b/lib/adapters/http_server.js
@@ -72,12 +72,18 @@ class ReadHTTPServer extends AdapterRead {
 
                     this.parseTime(points, this.timeField);
                     this.points = this.points.concat(points);
-                })
-                .then(() => {
-                    this.gotPoints();
-                    res.statusCode = 200;
-                    res.end();
+
+                    this.logger.debug('got', points.length, 'points --',
+                                      'pendingRead', !!this.pendingRead,
+                                      'limit', this.pendingReadLimit);
+                    if (this.pendingRead) {
+                        this.pendingRead(this.readResult(this.pendingReadLimit));
+                    }
                 });
+            })
+            .then(() => {
+                res.statusCode = 200;
+                res.end();
             })
             .catch((err) => {
                 this.handleListenError(res, err);
@@ -116,13 +122,6 @@ class ReadHTTPServer extends AdapterRead {
             ret.points = this.points.splice(0, limit);
         }
         return ret;
-    }
-
-    gotPoints() {
-        this.logger.debug('_gotPoints -- pendingRead', !!this.pendingRead, 'limit', this.pendingReadLimit);
-        if (this.pendingRead) {
-            this.pendingRead(this.readResult(this.pendingReadLimit));
-        }
     }
 
     handleListenError(res, err) {

--- a/lib/runtime/adapter-read.js
+++ b/lib/runtime/adapter-read.js
@@ -113,6 +113,12 @@ class AdapterRead {
     start() {
     }
 
+    // Hook to indicate that teardown has been called. Should return a promise
+    // that is resolved when teardown is complete.
+    teardown() {
+        return Promise.resolve();
+    }
+
     // Core API to read up to `limit` points within the given time interval (if
     // specified).
     //

--- a/lib/runtime/adapter-read.js
+++ b/lib/runtime/adapter-read.js
@@ -2,6 +2,7 @@
 var EventEmitter = require('eventemitter3');
 var JuttleLogger = require('../logger');
 var juttle_utils = require('./juttle-utils');
+var errors = require('../errors');
 
 //
 // Base class for all adapter `read` implementations.
@@ -92,6 +93,20 @@ class AdapterRead {
     // Subscribe to the given event types
     on(type, handler, context) {
         this.events.on(type, handler, context);
+    }
+
+    // Helper function to return a new compilation error. Currently this just
+    // creates the error class directly, but in the future this will allow
+    // custom error codes for each adapter.
+    compileError(code, info) {
+        return errors.compileError(code, info);
+    }
+
+    // Helper function to return a new runtime error. Currently this just
+    // creates the error class directly, but in the future this will allow
+    // custom error codes for each adapter.
+    runtimeError(code, info) {
+        return errors.runtimeError(code, info);
     }
 
     // Hook to indicate that the read has been started

--- a/lib/runtime/adapter-write.js
+++ b/lib/runtime/adapter-write.js
@@ -1,6 +1,7 @@
 'use strict';
 var EventEmitter = require('eventemitter3');
 var JuttleLogger = require('../logger');
+var errors = require('../errors');
 
 //
 // Base class for all adapter `write` implementations.
@@ -25,6 +26,20 @@ class AdapterWrite {
     // Subscribe to the given event types
     on(type, handler, context) {
         this.events.on(type, handler, context);
+    }
+
+    // Helper function to return a new compilation error. Currently this just
+    // creates the error class directly, but in the future this will allow
+    // custom error codes for each adapter.
+    compileError(code, info) {
+        return errors.compileError(code, info);
+    }
+
+    // Helper function to return a new runtime error. Currently this just
+    // creates the error class directly, but in the future this will allow
+    // custom error codes for each adapter.
+    runtimeError(code, info) {
+        return errors.runtimeError(code, info);
     }
 
     // Indication the program has started for the adapter to do any

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -222,6 +222,7 @@ var Read = source.extend({
             this.program.scheduler.schedule(nextRead.unixms(), _.bind(this.run, this));
         })
         .catch((err) => {
+            this.reading = null;
             this.logger.debug('read returned error', err.toString());
             this.trigger('error', err);
             this.emit_eof();
@@ -229,13 +230,15 @@ var Read = source.extend({
     },
 
     teardown: function() {
-        if (! this.reading) {
+        var readDone = this.reading || Promise.resolve();
+
+        readDone
+        .then(() => {
+            return this.adapter.teardown();
+        })
+        .then(() => {
             this.emit_eof();
-        } else {
-            this.reading.then(() => {
-                this.emit_eof();
-            });
-        }
+        });
     }
 });
 

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -161,6 +161,12 @@ var Read = source.extend({
         if (this.reading) {
             throw new Error('run should not be called while reading');
         }
+
+        if (this.eofSent) {
+            this.logger.debug('run called after eof sent... ignoring stale callback');
+            return;
+        }
+
         this.logger.debug('read from', this.readFrom ? this.readFrom.toJSON() : '(null)',
                           'to', this.readTo ? this.readTo.toJSON() : '(null)',
                           'limit', this.queueSize);
@@ -180,11 +186,6 @@ var Read = source.extend({
             }
 
             this.readState = result.state;
-
-            // Check if we are being torn down.
-            if (this.inTeardown) {
-                return;
-            }
 
             // The adapter indicates that it's completed reading all points up
             // to the given end time by returning the ending time in readEnd.
@@ -239,6 +240,13 @@ var Read = source.extend({
         .then(() => {
             this.emit_eof();
         });
+    },
+
+    emit_eof: function() {
+        if (!this.eofSent) {
+            this.eofSent = true;
+            source.prototype.emit_eof.call(this);
+        }
     }
 });
 


### PR DESCRIPTION
Port the http_server adapter to the new adapter API.

In addition to changes to the adapter itself, this also exposed some issues and limitations in the base class:
- Add wrappers for compileError and runtimeError to the adapter read/write base classes. This is not strictly required for the port, but rather than change the adapter to explicitly call errors.compileError, I figured we would need these for per-adapter error codes as described in #59.
- Add a teardown hook for read so the adapter can clean up properly.
- Add simple eof tracking to read. This avoids sending multiple eof's downstream and also as a workaround for the limitation that we can't currently cancel pending scheduler callbacks.
