### PR TITLE
proc name function

### DIFF
--- a/lib/adapters/stdio/read.js
+++ b/lib/adapters/stdio/read.js
@@ -10,8 +10,6 @@ class ReadStdio extends AdapterRead {
     constructor(options, params) {
         super(options, params);
 
-        this.procName = 'read stdio';
-
         this.timeField = options.timeField;
 
         this.format = options.format ? options.format : 'json'; // default to json
@@ -29,7 +27,7 @@ class ReadStdio extends AdapterRead {
 
         if (params.filter_ast) {
             throw new errors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER', {
-                proc: this.procName,
+                proc: 'read stdio',
                 filter: 'filtering'
             });
         }

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -51,7 +51,7 @@
   "RT-MOMENT-ERROR": "-{option} wants a moment, got {value}",
   "RT-DURATION-OR-MOMENT-ERROR": "-{option} wants a duration or moment, got {value}",
   "RT-INVALID-OFFSET-ERROR": "a duration is required for the offset.",
-  "RT-INVALID-SINK-OPTIONS-ERROR": "{procName} called with non-object argument to -o/-options",
+  "RT-INVALID-SINK-OPTIONS-ERROR": "view called with non-object argument to -o/-options",
   "RT-JOIN-INPUTNUM-ERROR": "-{option} must be an input number (1, 2, ...).",
   "RT-JOIN-ALL-TABLES-ERROR": "at least one input must not be a table",
   "RT-JOIN-TABLE-OUTER-ERROR": "-table and -outer cannot be specified for the same input",

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -27,7 +27,7 @@
   "RT-FIELD-NOT-FOUND": "field \"{field}\" does not exist",
   "RT-DATE-PARSE-ERROR": "Unable to parse date:\"{s}\"",
 
-  "RT-INTEGER-REQUIRED-ERROR": "{argument} for {procName} must be an integer",
+  "RT-INTEGER-REQUIRED-ERROR": "{argument} for {proc} must be an integer",
   "RT-BATCH-INTERVAL-ERROR": "batch interval must be a positive number or duration.",
   "RT-BATCH-INTERVAL-EVERY-ERROR": "Specify either batch -every or batch :interval:",
   "RT-ON-EVERY-ERROR": "{proc} -on cannot be greater than -every",

--- a/lib/program.js
+++ b/lib/program.js
@@ -61,7 +61,7 @@ var Program = Base.extend({
         for (var i = 0; i < this.graph.head.length; i++) {
             if (!(this.graph.head[i] instanceof source)) {
                 throw errors.compileError('RT-PROC-CANNOT-START-FLOWGRAPH', {
-                    proc: this.graph.head[i].procName,
+                    proc: this.graph.head[i].procName(),
                     location: this.graph.head[i].location
                 });
             }
@@ -72,7 +72,7 @@ var Program = Base.extend({
 
         if (invalidSources.length) {
             throw errors.compileError('RT-PROC-MUST-START-FLOWGRAPH', {
-                proc: invalidSources[0].procName,
+                proc: invalidSources[0].procName(),
                 location: invalidSources[0].location
             });
         }
@@ -86,7 +86,7 @@ var Program = Base.extend({
         for (var i = 0; i < terminalNodes.length; i++) {
             if (!(terminalNodes[i] instanceof sink)) {
                 throw errors.compileError('RT-PROC-CANNOT-END-FLOWGRAPH', {
-                    proc: terminalNodes[i].procName,
+                    proc: terminalNodes[i].procName(),
                     location: terminalNodes[i].location
                 });
             }
@@ -97,7 +97,7 @@ var Program = Base.extend({
 
         if (invalidSinks.length) {
             throw errors.compileError('RT-PROC-MUST-END-FLOWGRAPH', {
-                proc: invalidSinks[0].procName,
+                proc: invalidSinks[0].procName(),
                 location: invalidSinks[0].location
             });
         }

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -29,8 +29,13 @@ var base = Base.extend({
         this.stats = {points_in: 0, points_out: 0};
         this.last_used_output = DEFAULT_OUT_NAME;
         job_id = this.program.id ? '-' + this.program.id : '';
-        this.logger_name = 'proc-' + this.procName + job_id;
+        this.logger_name = 'proc-' + this.procName() + job_id;
         this.logger = JuttleLogger.getLogger(this.logger_name);
+        this.logger.debug('initialize', JSON.stringify(options), JSON.stringify(params));
+    },
+
+    procName: function() {
+        throw new Error('procName() not implemented');
     },
 
     validate_options: function(allowedOptions, requiredOptions) {
@@ -38,7 +43,7 @@ var base = Base.extend({
         var unknown = _.difference(options, allowedOptions);
         if (unknown.length > 0) {
             throw this.compile_error('RT-UNKNOWN-OPTION-ERROR', {
-                proc: this.procName,
+                proc: this.procName(),
                 option: unknown[0]
             });
         }
@@ -46,7 +51,7 @@ var base = Base.extend({
         var missing = _.difference(requiredOptions, options);
         if (missing.length > 0) {
             throw this.compile_error('RT-MISSING-OPTION-ERROR', {
-                proc: this.procName,
+                proc: this.procName(),
                 option: missing[0]
             });
         }
@@ -225,7 +230,7 @@ var base = Base.extend({
     trigger: function(type, err) {
         if (err.info && _.isObject(err.info)) {
             if (! err.info.procName) {
-                err.info.procName = this.procName;
+                err.info.procName = this.procName();
             }
 
             if (! err.info.location) {

--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -58,7 +58,7 @@ var batch = periodic_fanin.extend({
             if (options.on.duration) {
                 if (options.on.gt(this.interval)) {
                     throw this.compile_error('RT-ON-EVERY-ERROR', {
-                        proc: this.procName
+                        proc: this.procName()
                     });
                 }
                 this.on = (new JuttleMoment(0)).add(options.on);
@@ -75,7 +75,9 @@ var batch = periodic_fanin.extend({
         }
         this.init_warnings();
     },
-    procName:  'batch',
+    procName: function() {
+        return 'batch';
+    },
     process_points: function(points) {
         this.emit(points);
     },

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -121,7 +121,9 @@ var emit = source.extend({
         this.next_time = this.from;
         this.n = 0;
     },
-    procName:  'emit',
+    procName: function() {
+        return 'emit';
+    },
     start: function() {
         var ts = this.next_run();
         if (ts) {

--- a/lib/runtime/procs/filter.js
+++ b/lib/runtime/procs/filter.js
@@ -12,7 +12,9 @@ var filter = fanin.extend({
     initialize: function(options, params) {
         this.predicate = params.predicate;
     },
-    procName:  'filter',
+    procName: function() {
+        return 'filter';
+    },
     process: function(points) {
         var k = 0;
         var out = [];

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -14,7 +14,7 @@ var head = fanin.extend({
     initialize: function(options) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
-                procName: 'head',
+                proc: 'head',
                 argument: 'limit'
             });
         }

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -21,7 +21,9 @@ var head = fanin.extend({
         this.limit = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'head',
+    procName: function() {
+        return 'head';
+    },
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/join.js
+++ b/lib/runtime/procs/join.js
@@ -280,7 +280,9 @@ var join = base.extend({
         this.joinkey_groups = new JoinkeyGroups(this, {groupby: this.joinfields});
         this.joinkey_groups._undefined_fields_warned = _.invert(this.joinfields);
     },
-    procName: 'join',
+    procName: function() {
+        return 'join';
+    },
     toString: function() {
         var s = 'join last_output '+this.last_output;
         this.ins.forEach(function(input) {

--- a/lib/runtime/procs/keep.js
+++ b/lib/runtime/procs/keep.js
@@ -11,7 +11,9 @@ var keep = fanin.extend({
     initialize: function(options) {
         this.columns = options.columns || [];
     },
-    procName:  'keep',
+    procName: function() {
+        return 'keep';
+    },
     process: function(points) {
         var pt, k, m, fld;
         var cols = this.columns;

--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -56,7 +56,9 @@ var pace = fanin.extend({
         this.playback = this.playback.bind(this);
         this.wakeup = this.wakeup.bind(this);
     },
-    procName:  'pace',
+    procName: function() {
+        return 'pace';
+    },
     teardown: function() {
         clearTimeout(this.timer);
         clearTimeout(this.wakeup_timer);

--- a/lib/runtime/procs/pass.js
+++ b/lib/runtime/procs/pass.js
@@ -8,7 +8,9 @@ var INFO = {
 };
 
 var pass = fanin.extend({
-    procName: 'pass'
+    procName: function() {
+        return 'pass';
+    }
 }, {
     info: INFO
 });

--- a/lib/runtime/procs/periodic_funcs.js
+++ b/lib/runtime/procs/periodic_funcs.js
@@ -30,10 +30,10 @@ var periodic_funcs = {
         this.in_batch_loop = false;
     },
     init_warnings: function() {
-        // call after procName and interval have been established
+        // call after the proc name and interval have been established
         var self = this;
         this.warn_drop = _.throttle(function() {
-            self.trigger('warning', self.runtime_error('RT-POINTS-OUT-OF-ORDER', { proc: this.procName }));
+            self.trigger('warning', self.runtime_error('RT-POINTS-OUT-OF-ORDER', { proc: this.procName() }));
         }, this.interval.milliseconds());
         this.warn_timeless = _.once(function() {
             self.trigger('warning', self.runtime_error('RT-TIMELESS-POINTS'));

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -55,7 +55,6 @@ Juttle.extend_options = function(opts, location) {
                 } );
             } else {
                 throw errors.compileError('RT-INVALID-SINK-OPTIONS-ERROR', {
-                    procName: '',
                     location: location
                 });
             }

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -54,7 +54,9 @@ var put = oops_fanin.extend({
             };
         }
     },
-    procName:  'put',
+    procName: function() {
+        return 'put';
+    },
     process: function(points) {
         var k, row, expr = this.expr;
         var out = [];

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -4,16 +4,11 @@ var _ = require('underscore');
 var source = require('./source');
 var adapters = require('../adapters');
 var values = require('../values');
-var JuttleLogger = require('../../logger');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var Promise = require('bluebird');
 
 var Read = source.extend({
-    procName: 'read',
-
     initialize: function(options, params) {
-        this.params = params;
-
         this.lag = _.has(options, 'lag') ? options.lag : JuttleMoment.duration(0, 's');
         if (! this.lag.duration) {
             throw this.compile_error('RT-DURATION-ERROR', {
@@ -29,9 +24,6 @@ var Read = source.extend({
                 value: values.inspect(options.every)
             });
         }
-
-        this.logger_name = this.logger_name.replace('read', 'read-' + params.adapter.name);
-        this.logger = JuttleLogger.getLogger(this.logger_name);
 
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
         if (!adapter.read) {
@@ -79,7 +71,6 @@ var Read = source.extend({
             throw err;
         }
 
-        this.procName += ' ' + adapter.name;
         this.validate_options(adapter.read.allowedOptions(), adapter.read.requiredOptions());
 
         var defaultTimeRange = this.adapter.defaultTimeRange();
@@ -95,6 +86,10 @@ var Read = source.extend({
         });
 
         this.nextTick = this.program.now;
+    },
+
+    procName: function() {
+        return 'read-' + this.params.adapter.name;
     },
 
     // Set the initial time parameters for read from the adapter and

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -219,12 +219,14 @@ var _reduce = __reduce.extend({
             // not specified, but -on was specified with a non-null
             // value.
             throw this.compile_error('RT-ON-NO-EVERY-ERROR', {
-                proc: this.procName
+                proc: this.procName()
             });
         }
         this.has_first_mark = false;
     },
-    procName: 'reduce',
+    procName: function() {
+        return 'reduce';
+    },
     process: function(points) {
         this.process_points(points);
     },
@@ -292,7 +294,7 @@ var _ereduce = __ereduce.extend({
             if (options.on.duration) {
                 if (options.on.gt(options.every)) {
                     throw this.compile_error('RT-ON-EVERY-ERROR', {
-                        proc: this.procName
+                        proc: this.procName()
                     });
                 }
                 this.on = (new JuttleMoment(0)).add(options.on);
@@ -310,7 +312,9 @@ var _ereduce = __ereduce.extend({
         }
         this.init_warnings();
     },
-    procName: 'reduce',
+    procName: function() {
+        return 'reduce';
+    },
     first_epoch: function(epoch) {
         // don't run on the first epoch (called by advance)
     },

--- a/lib/runtime/procs/remove.js
+++ b/lib/runtime/procs/remove.js
@@ -12,7 +12,9 @@ var remove = fanin.extend({
     initialize: function (options) {
         this.columns = options.columns || [];
     },
-    procName:  'remove',
+    procName: function() {
+        return 'remove';
+    },
     process: function (points) {
         var pt, k, m, fld;
         var cols = this.columns;

--- a/lib/runtime/procs/sequence.js
+++ b/lib/runtime/procs/sequence.js
@@ -23,7 +23,9 @@ var sequence = fanin.extend({
         });
         this.groups = new Groups(this, options);
     },
-    procName:  'sequence',
+    procName: function() {
+        return 'sequence';
+    },
 
     // For each incoming point, look up group buffer
     // evaluate filters[buffer.len] on point

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -21,7 +21,9 @@ var skip = fanin.extend({
         this.n = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'skip',
+    procName: function() {
+        return 'skip';
+    },
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -14,7 +14,7 @@ var skip = fanin.extend({
     initialize: function(options) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
-                procName: 'skip',
+                proc: 'skip',
                 argument: 'argument'
             });
         }

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -24,7 +24,9 @@ var sort = fanin.extend({
         this.groups = new Groups(this, options);
         this.n_pts = 0;
     },
-    procName:  'sort',
+    procName: function() {
+        return 'sort';
+    },
     _run: function(time) {
         var self = this;
         _.each(this.groups.table, function(row) {

--- a/lib/runtime/procs/split.js
+++ b/lib/runtime/procs/split.js
@@ -21,7 +21,9 @@ var split = fanin.extend({
         }
         this.arrays = (options.arrays === undefined) ? true : Boolean(options.arrays);
     },
-    procName: 'split',
+    procName: function() {
+        return 'split';
+    },
     process: function(points) {
         var out = [];
         var i, j, k, field;

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -22,7 +22,9 @@ var tail = fanin.extend({
         this.limit = options.arg;
         this.groups = new Groups(this, options);
     },
-    procName:  'tail',
+    procName: function() {
+        return 'tail';
+    },
     process: function(points) {
         var k, row;
         for (k = 0; k < points.length; ++k) {

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -15,7 +15,7 @@ var tail = fanin.extend({
     initialize: function(options) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
-                procName: 'tail',
+                proc: 'tail',
                 argument: 'limit'
             });
         }

--- a/lib/runtime/procs/unbatch.js
+++ b/lib/runtime/procs/unbatch.js
@@ -9,7 +9,9 @@ var INFO = {
 
 // unbatch, simply forwards everything except marks
 var unbatch = fanin.extend({
-    procName:  'unbatch',
+    procName: function() {
+        return 'unbatch';
+    },
     process: function(points) {
         this.emit(points);
     },

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -18,7 +18,9 @@ var uniq = fanin.extend({
         this.fields = options.arg || [];
         this.groups = new Groups(this, options);
     },
-    procName:  'uniq',
+    procName: function() {
+        return 'uniq';
+    },
     process: function(points) {
         var toEmit = [];
 

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -14,7 +14,9 @@ var view = sink.extend({
         this.channel = 'view' + (Juttle.channels++);
     },
 
-    procName: 'view',
+    procName: function() {
+        return 'view';
+    },
 
     // When views get points/marks/ticks, they emit events on
     // the related program object. Program users will subscribe for

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -2,18 +2,10 @@
 
 var sink = require('./sink');
 var adapters = require('../adapters');
-var JuttleLogger = require('../../logger');
 var Promise = require('bluebird');
 
 var Write = sink.extend({
-    procName: 'write',
-
     initialize: function(options, params) {
-        this.params = params;
-
-        this.logger_name = this.logger_name.replace('write', 'write-' + params.adapter);
-        this.logger = JuttleLogger.getLogger(this.logger_name);
-
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
         if (!adapter.write) {
             throw this.compile_error('JUTTLE-UNSUPPORTED-ADAPTER-MODE', {
@@ -62,7 +54,6 @@ var Write = sink.extend({
         }
 
         this.adapter = new adapter.write(options, params);
-        this.procName += ' ' + adapter.name;
 
         this.adapter.on('error', (err) => {
             this.trigger('error', err);
@@ -73,6 +64,10 @@ var Write = sink.extend({
         });
 
         this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
+    },
+
+    procName: function() {
+        return 'write-' + this.params.adapter.name;
     },
 
     start: function() {

--- a/test/adapters/file/read.spec.js
+++ b/test/adapters/file/read.spec.js
@@ -33,7 +33,7 @@ describe('read file adapter tests', function () {
             throw new Error('this should have failed');
         })
         .catch(function(err) {
-            expect(err.message).equal('unknown read file option foo.');
+            expect(err.message).equal('unknown read-file option foo.');
         });
     });
 

--- a/test/adapters/file/read.spec.js
+++ b/test/adapters/file/read.spec.js
@@ -96,7 +96,7 @@ describe('read file adapter tests', function () {
     });
 
     it('fails when you do not provide a file to read', function() {
-        var message = 'missing read file required option file.';
+        var message = 'missing read-file required option file.';
         var failing_read = check_juttle({
             program: 'read file'
         });

--- a/test/adapters/file/write.spec.js
+++ b/test/adapters/file/write.spec.js
@@ -35,7 +35,7 @@ describe('write file adapter tests', function () {
     });
 
     it('fails when you provide an unknown option', function() {
-        var message = 'unknown write file option foo.';
+        var message = 'unknown write-file option foo.';
         var failing_write = check_juttle({
             program: 'emit -limit 1 | write file -file "' + tmp_file + '" -foo "bar"'
         });

--- a/test/adapters/file/write.spec.js
+++ b/test/adapters/file/write.spec.js
@@ -26,7 +26,7 @@ describe('write file adapter tests', function () {
     });
 
     it('fails when you do not provide a file to write', function() {
-        var message = 'missing write file required option file.';
+        var message = 'missing write-file required option file.';
         var failing_write = check_juttle({
             program: 'write file'
         });

--- a/test/adapters/http.spec.js
+++ b/test/adapters/http.spec.js
@@ -393,7 +393,7 @@ describe('HTTP adapter tests', function() {
                 throw Error('The previous statement should have failed');
             })
             .catch(function(err) {
-                expect(err.toString()).to.contain('missing read http required option url');
+                expect(err.toString()).to.contain('missing read-http required option url');
             });
         });
 
@@ -624,7 +624,7 @@ describe('HTTP adapter tests', function() {
                 throw Error('The previous statement should have failed');
             })
             .catch(function(err) {
-                expect(err.toString()).to.contain('missing write http required option url');
+                expect(err.toString()).to.contain('missing write-http required option url');
             });
         });
 

--- a/test/adapters/http.spec.js
+++ b/test/adapters/http.spec.js
@@ -405,7 +405,7 @@ describe('HTTP adapter tests', function() {
                 throw Error('The previous statement should have failed');
             })
             .catch(function(err) {
-                expect(err.toString()).to.contain('unknown read http option unknown.');
+                expect(err.toString()).to.contain('unknown read-http option unknown.');
             });
         });
 
@@ -636,7 +636,7 @@ describe('HTTP adapter tests', function() {
                 throw Error('The previous statement should have failed');
             })
             .catch(function(err) {
-                expect(err.toString()).to.contain('unknown write http option unknown.');
+                expect(err.toString()).to.contain('unknown write-http option unknown.');
             });
         });
 

--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -366,7 +366,7 @@ describe('read http_server', function() {
             throw new Error('the previous statement should have failed');
         })
         .catch(function(err) {
-            expect(err.toString()).to.contain('unknown read http_server option unknown.');
+            expect(err.toString()).to.contain('unknown read-http_server option unknown.');
         });
     });
 });

--- a/test/adapters/stdio/read.stdio.spec.js
+++ b/test/adapters/stdio/read.stdio.spec.js
@@ -44,7 +44,7 @@ describe('read stdio adapter tests', function() {
             throw Error('Previous statement should have failed');
         })
         .catch(function(err) {
-            expect(err.toString()).to.contain('Error: unknown read stdio option foo.');
+            expect(err.toString()).to.contain('Error: unknown read-stdio option foo.');
         });
     });
 

--- a/test/adapters/stdio/write.stdio.spec.js
+++ b/test/adapters/stdio/write.stdio.spec.js
@@ -32,7 +32,7 @@ describe('write stdio adapter tests', function() {
             throw Error('Previous statement should have failed');
         })
         .catch(function(err) {
-            expect(err.toString()).to.contain('Error: unknown write stdio option foo.');
+            expect(err.toString()).to.contain('Error: unknown write-stdio option foo.');
         });
     });
 

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -97,10 +97,10 @@ describe('adapter API tests', function () {
         })
         .then(function(result) {
             var first_node = result.prog.graph.head[0];
-            expect(first_node.procName).equal('read test');
+            expect(first_node.procName()).equal('read-test');
 
             var second_node = first_node.out_.default[0].proc;
-            expect(second_node.procName).equal('view');
+            expect(second_node.procName()).equal('view');
             expect(result.sinks.table).deep.equal([{count: 1}]);
             expect(result.prog.graph.adapter.count).equal(true);
         });
@@ -124,10 +124,10 @@ describe('adapter API tests', function () {
         })
         .then(function(result) {
             var first_node = result.prog.graph.head[0];
-            expect(first_node.procName).equal('read test');
+            expect(first_node.procName()).equal('read-test');
 
             var second_node = first_node.out_.default[0].proc;
-            expect(second_node.procName).equal('view');
+            expect(second_node.procName()).equal('view');
 
             expect(result.sinks.table).deep.equal([{count: 1}]);
             expect(result.prog.graph.adapter.limit).equal(1);

--- a/test/runtime/deactivate.spec.js
+++ b/test/runtime/deactivate.spec.js
@@ -15,7 +15,7 @@ describe('Program deactivation', function() {
         base.prototype.teardown_ = base.prototype.teardown;
         emit.prototype.teardown_ = emit.prototype.teardown;
 
-        base.prototype.teardown = emit.prototype.teardown = function() { teardowns.push(this.procName); };
+        base.prototype.teardown = emit.prototype.teardown = function() { teardowns.push(this.procName()); };
     });
     after(function() {
         base.prototype.teardown = base.prototype.teardown_;

--- a/test/runtime/named-outputs.spec.js
+++ b/test/runtime/named-outputs.spec.js
@@ -26,7 +26,7 @@ describe('Juttle named outputs', function() {
             .then(function(program) {
                 var emit = program.get_sources()[0];
                 var sink = program.get_sinks()[0];
-                var put = _.filter(program.get_nodes(), function(n) { return n.procName === 'put'; })[0];
+                var put = _.filter(program.get_nodes(), function(n) { return n.procName() === 'put'; })[0];
                 emit.shortcut(sink, put, 's1');
                 return program;
             }).then(function(program) {
@@ -40,7 +40,7 @@ describe('Juttle named outputs', function() {
             .then(function(program) {
                 var emit = program.get_sources()[0];
                 var sink = program.get_sinks()[0];
-                var reduce = _.filter(program.get_nodes(), function(n) { return n.procName === 'reduce'; })[0];
+                var reduce = _.filter(program.get_nodes(), function(n) { return n.procName() === 'reduce'; })[0];
                 emit.shortcut(sink, reduce, 's1');
                 return program;
             }).then(function(program) {
@@ -54,7 +54,7 @@ describe('Juttle named outputs', function() {
             .then(function(program) {
                 var emit = program.get_sources()[0];
                 var sinks = program.get_sinks();
-                var reduce = _.filter(program.get_nodes(), function(n) { return n.procName === 'reduce'; })[0];
+                var reduce = _.filter(program.get_nodes(), function(n) { return n.procName() === 'reduce'; })[0];
                 emit.shortcut(sinks[0], reduce, 's1');
                 emit.shortcut(sinks[1], reduce, 's1');
                 return program;

--- a/test/runtime/object-literals.spec.js
+++ b/test/runtime/object-literals.spec.js
@@ -96,7 +96,7 @@ describe('Juttle Object Literal Tests', function() {
                 done(new Error('Received unexpected response!'));
             })
             .catch(function(error) {
-                expect(error.message).to.equal(' called with non-object argument to -o/-options');
+                expect(error.message).to.equal('view called with non-object argument to -o/-options');
                 done();
             });
     });

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -231,7 +231,7 @@ function run_juttle(prog, options) {
         var promises = _.map(prog.get_sinks(), function(sink) {
             // non-visual sinks don't implement pub/sub channel but instead have
             // a done() promise to indicate when they are at eof.
-            if (sink.procName !== 'view') {
+            if (sink.procName() !== 'view') {
                 return sink.isDone
                     .then(function() {
                         return sink;


### PR DESCRIPTION
Change procName from a prototype property on the procs into a function. For most procs it just returns the name of the proc itself, but for read and write it includes the name of the adapter as well.

This was proposed in #334 -- I decided to just stick with `procName()` as the function instead of `displayName()` since in writing it, it just seemed like `display` felt out of place. I don't feel _too_ strongly about it though.

FWIW I tried to just use `name()` but the test views use a `name` property already and I didn't feel like changing that all as well.

As part of this change, updated a few error message strings so they consistently use `proc` as the template parameter.

