### PR TITLE
pass pname in proc params and attach params to proc instance

### DIFF
--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -212,26 +212,21 @@ var GraphCompiler = CodeGenerator.extend({
         return code;
     },
     gen_params: function(params) {
-        var code = '';
+        var code = '{';
         var comma = '';
-        if (typeof params === 'string') {
-            code += params;
-        } else {
-            code += '{';
-            _.each(params, function(val, name) {
-                var e;
-                code += comma;
-                if (name[0] !== '$') {
-                    e = val;
-                } else {
-                    e = JSON.stringify(val);
-                    name = name.substring(1);
-                }
-                code+= name + ':' + e;
-                comma = ',\n ';
-            } );
-            code += '}';
-        }
+        _.each(params, function(val, name) {
+            var e;
+            code += comma;
+            if (name[0] !== '$') {
+                e = val;
+            } else {
+                e = JSON.stringify(val);
+                name = name.substring(1);
+            }
+            code+= name + ':' + e;
+            comma = ',\n ';
+        } );
+        code += '}';
         return code;
     },
 
@@ -420,7 +415,7 @@ var GraphCompiler = CodeGenerator.extend({
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);
 
-        return this.gen_proc(ast, 'filter', '{predicate: ' + code + '}');
+        return this.gen_proc(ast, 'filter', {predicate: code});
     },
     gen_SequenceProc: function(ast) {
         var checker = new DynamicFilterChecker();
@@ -433,7 +428,7 @@ var GraphCompiler = CodeGenerator.extend({
         });
         var code = '[' + filters.join (',') + ']';
 
-        return this.gen_proc(ast, 'sequence', '{predicates: ' + code + '}');
+        return this.gen_proc(ast, 'sequence', {predicates: code});
     },
     gen_SortProc: function(ast) {
         return this.gen_proc(ast, 'sort');
@@ -441,7 +436,7 @@ var GraphCompiler = CodeGenerator.extend({
     gen_View: function(ast) {
         // silly special case for ast.name due to sink's special-case parsing
         // and AST.
-        var proc = this.gen_proc(ast, 'view', '{name: "'+ast.name+'"}');
+        var proc = this.gen_proc(ast, 'view', {$name: ast.name});
 
         this.emit('views.push({name: "' + ast.name + '",' +
                   'channel: ' + proc + '.channel,' +
@@ -503,11 +498,12 @@ var GraphCompiler = CodeGenerator.extend({
             return expr.left.type === 'Field' ? expr.left.name : expr.left.expression.value;
         });
 
-        return this.gen_proc(ast, which,
-                             '{ expr:' + expr + ',' +
-                             ' funcMaker:' + maker + ',' +
-                             ' reducer_index:' + JSON.stringify(reducer_index) + ',' +
-                             ' lhs:' + JSON.stringify(lhs) + '}');
+        return this.gen_proc(ast, which, {
+            expr: expr,
+            funcMaker: maker,
+            $reducer_index: reducer_index,
+            $lhs: lhs
+        });
     },
 
     gen_ReduceProc: function(ast) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -178,6 +178,8 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_proc: function(ast, procName, params) {
         var pname = ast.pname;
+        params = params || {};
+        params.$pname = pname;
         var soptions = this.gen_options(ast.options,
                                         ast.location,
                                         params);

--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -13,6 +13,7 @@ var base = Base.extend({
     //
     initialize: function(options, params, location, program) {
         this.options = options;
+        this.params = params;
         var job_id;
         this.out_ = {};
         // linkage for building flowgraph in place


### PR DESCRIPTION
Pretty much just mooching off of @demmer's work in https://github.com/juttle/juttle/pull/334 and the to-be-reviewed https://github.com/juttle/juttle/pull/364.

Previously, `pname` was attached to proc instances at `this.pname`, but that was removed in https://github.com/juttle/juttle/pull/154.

I was using the proc's `pname` in [juttle-flowgraph-viz](https://github.com/juttle/juttle-flowgraph-viz) when monkey-patching [emit](https://github.com/juttle/juttle-flowgraph-viz/blob/848f5333611165568c36d5d9d1d8d3f33453d553/src/app.js#L16-L25) to do a "join" between the node emitting the points and its entry in the flowgraph JSON.

@dmajda cc @demmer 
