### PR TITLE
Use chai 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "body-parser": "^1.14.1",
-    "chai": "^1.10.0",
+    "chai": "^3.5.0",
     "child-process-promise": "^1.1.0",
     "express": "^4.13.3",
     "find-free-port": "^1.0.2",

--- a/test/adapters/file/read.spec.js
+++ b/test/adapters/file/read.spec.js
@@ -49,7 +49,7 @@ describe('read file adapter tests', function () {
                     expect(points).to.have.length(6);
                     _.each(points, function(point, index) {
                         expect(point.time).to.equal('2015-01-01T00:00:0' + (index + 1) + '.000Z');
-                        expect(point['undefined']).to.be.undefined();
+                        expect(point['undefined']).to.be.undefined;
                     });
                 });
             });

--- a/test/adapters/http.spec.js
+++ b/test/adapters/http.spec.js
@@ -455,7 +455,7 @@ describe('HTTP adapter tests', function() {
                 expect(result.errors).deep.equals([]);
                 expect(result.warnings).deep.equals([]);
                 expect(result.sinks.table.length).equal(1);
-                expect(result.sinks.table[0].time).to.not.be.undefined();
+                expect(result.sinks.table[0].time).to.not.be.undefined;
             });
         });
 
@@ -559,7 +559,7 @@ describe('HTTP adapter tests', function() {
                     expect(result.errors).deep.equals([]);
                     expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(100);
-                    expect(result.sinks.table[0].time).to.not.be.undefined();
+                    expect(result.sinks.table[0].time).to.not.be.undefined;
                     expect(result.sinks.table[0].fizz).to.be.equal('buzz');
                 });
             });
@@ -591,7 +591,7 @@ describe('HTTP adapter tests', function() {
                     expect(result.errors).deep.equals([]);
                     expect(result.warnings).deep.equals([]);
                     expect(result.sinks.table.length).equal(100);
-                    expect(result.sinks.table[0].time).to.not.be.undefined();
+                    expect(result.sinks.table[0].time).to.not.be.undefined;
                     expect(result.sinks.table[0].fizz).to.be.equal('buzz');
                 });
             });
@@ -699,7 +699,7 @@ describe('HTTP adapter tests', function() {
             .then(function(result) {
                 expect(result.errors).deep.equals([]);
                 expect(result.warnings).deep.equals([]);
-                expect(result.sinks.table).to.be.undefined();
+                expect(result.sinks.table).to.be.undefined;
             });
         });
 

--- a/test/adapters/parsers/csv.spec.js
+++ b/test/adapters/parsers/csv.spec.js
@@ -14,7 +14,7 @@ describe('parsers/csv', function() {
 
     it('can instantiate a csv parser', function() {
         var csv = parsers.getParser('csv');
-        expect(csv).to.not.be.undefined();
+        expect(csv).to.not.be.undefined;
     });
 
     it('fails when given an invalid CSV stream', function() {

--- a/test/adapters/parsers/grok.spec.js
+++ b/test/adapters/parsers/grok.spec.js
@@ -18,7 +18,7 @@ describe('parsers/grok', function() {
 
     withGrokIt('can instantiate a grok parser', function() {
         var parser = parsers.getParser('grok');
-        expect(parser).to.not.be.undefined();
+        expect(parser).to.not.be.undefined;
     });
 
     withGrokIt('can read an empty file', function() {

--- a/test/adapters/parsers/json.spec.js
+++ b/test/adapters/parsers/json.spec.js
@@ -14,7 +14,7 @@ describe('parsers/json', function() {
 
     it('can instantiate a json parser', function() {
         var json = parsers.getParser('json');
-        expect(json).to.not.be.undefined();
+        expect(json).to.not.be.undefined;
     });
 
     it('fails when given an invalid JSON stream', function() {

--- a/test/adapters/parsers/jsonl.spec.js
+++ b/test/adapters/parsers/jsonl.spec.js
@@ -12,7 +12,7 @@ describe('parsers/jsonl', function() {
 
     it('can instantiate a jsonl parser', function() {
         var jsonl = parsers.getParser('jsonl');
-        expect(jsonl).to.not.be.undefined();
+        expect(jsonl).to.not.be.undefined;
     });
 
     it('fails when given an invalid JSONL stream', function() {

--- a/test/adapters/serializers/csv.spec.js
+++ b/test/adapters/serializers/csv.spec.js
@@ -12,7 +12,7 @@ describe('serializers/csv', function() {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
         var serializer = serializers.getSerializer('csv', stream);
-        expect(serializer).to.not.be.undefined();
+        expect(serializer).to.not.be.undefined;
     });
 
     it('can write no points to a provided stream', function(done) {

--- a/test/adapters/serializers/json.spec.js
+++ b/test/adapters/serializers/json.spec.js
@@ -12,7 +12,7 @@ describe('serializers/json', function() {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
         var serializer = serializers.getSerializer('json', stream);
-        expect(serializer).to.not.be.undefined();
+        expect(serializer).to.not.be.undefined;
     });
 
     it('can write no points to a provided stream', function(done) {

--- a/test/adapters/serializers/jsonl.spec.js
+++ b/test/adapters/serializers/jsonl.spec.js
@@ -12,7 +12,7 @@ describe('serializers/jsonl', function() {
         var tmpFilename = tmp.tmpNameSync();
         var stream = fs.createWriteStream(tmpFilename);
         var serializer = serializers.getSerializer('jsonl', stream);
-        expect(serializer).to.not.be.undefined();
+        expect(serializer).to.not.be.undefined;
     });
 
     it('can write no points to a provided stream', function(done) {

--- a/test/adapters/stochastic.spec.js
+++ b/test/adapters/stochastic.spec.js
@@ -384,7 +384,7 @@ describe('stochastic -source "logs"', function() {
             expect(res.errors).to.have.length(0);
             expect(res.warnings).to.have.length(0);
             _.each(res.sinks.result, function(point) {
-                expect(point.time).to.not.be.undefined();
+                expect(point.time).to.not.be.undefined;
                 expect(point.count).to.greaterThan(0);
             });
         });


### PR DESCRIPTION
I wanted to use [`.keys`](http://chaijs.com/api/bdd/#keys) in a test and found I couldn’t because we use an awfully old version of `chai`.