### PR TITLE
adapters: remove the read/write shims for legacy adapters

### DIFF
--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -41,29 +41,6 @@ var Read = source.extend({
             });
         }
 
-        // This block is a temporary hack until all the adapters are converted
-        // over to use the new API.
-        //
-        // Before instantiating the adapter, check if it is actually an
-        // implementation of a proc. If so, then it is a "legacy" adapter and
-        // needs to be shimmed so that all the methods that it might call to
-        // output points actually delegate to this class' implementation which
-        // is the one that's actually wired into the flowgraph.
-        if (adapter.read.__super__ && adapter.read.__super__.constructor === source) {
-            this.logger.debug('instantiating legacy adapter:', params.adapter.name);
-            this.adapter = new adapter.read(options, params, this.location, this.program);
-
-            this.adapter.emit = _.bind(this.emit, this);
-            this.adapter.emit_tick = _.bind(this.emit_tick, this);
-            this.adapter.emit_eof = _.bind(this.emit_eof, this);
-            this.adapter.trigger = _.bind(this.trigger, this);
-
-            this.start = _.bind(this.adapter.start, this.adapter);
-            this.teardown = _.bind(this.adapter.teardown, this.adapter);
-
-            return;
-        }
-
         this.handleTimeOptions(options);
 
         params.now = this.program.now;

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -22,45 +22,6 @@ var Write = sink.extend({
             });
         }
 
-        // This is a temporary hack until all the adapters are converted over to
-        // use the new API.
-        //
-        // Before instantiating the adapter, check if it is actually an
-        // implementation of a proc. If so, then it is a "legacy" adapter and
-        // needs to be shimmed so that all the methods that it might call to
-        // output points actually delegate to this class' implementation which
-        // is the one that's actually wired into the flowgraph.
-        if (adapter.write.__super__ && adapter.write.__super__.constructor === sink) {
-            this.logger.debug('instantiating legacy adapter:', params.adapter);
-            this.writer = new adapter.write(options, params, this.location, this.program);
-
-            this.writer.ins = this.ins;
-
-            this.process = function(points) {
-                this.writer.process(points);
-            };
-
-            this.mark = function(time) {
-                this.writer.mark(time);
-            };
-
-            this.tick = function(time) {
-                this.writer.tick(time);
-            };
-
-            this.eof = function() {
-                this.writer.eof();
-            };
-
-            this.start = function() {
-                this.writer.start();
-            };
-
-            this.writer.isDone = this.isDone;
-            this.writer.done = this.done;
-            return;
-        }
-
         this.adapter = new adapter.write(options, params);
         this.procName += ' ' + adapter.name;
 


### PR DESCRIPTION
All adapters should already be converted or should be converted
soon to use the new adapter API, so remove the hacks in read / write
that supported the "old" contract in which adapters directly
implement source / sink procs.

Connects to #369