### PR TITLE
clean up inheritance

### DIFF
--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -2,11 +2,8 @@
 
 var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
-var fanin = require('./fanin');
-var periodic_funcs = require('./periodic_funcs');
+var periodic_fanin = require('./periodic-fanin');
 var values = require('../values');
-
-var periodic_fanin = fanin.extend(periodic_funcs);
 
 //
 // batch input by time by inserting marks into the stream as each

--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -23,7 +23,7 @@ var INFO = {
 };
 
 var batch = periodic_fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['arg', 'every', 'on'];
         this.validate_options(allowed_options);
 

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -19,7 +19,7 @@ var INFO = {
 };
 
 var emit = source.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         var NOW = this.program.now;
         var allowedOptions = _.union(_.keys(INFO.options), _.keys(INFO._options));
         this.validate_options(allowedOptions);

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -8,7 +8,7 @@ var ExtBase = require('extendable-base');
 var DEQueue = require('double-ended-queue');
 
 var Input = ExtBase.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         this.from = options.proc;       // input node
         this.queue = new DEQueue();
     },
@@ -48,7 +48,7 @@ var fanin = base.extend({
     // add input-merging behavior to base behavior so everyone
     // knows what to do with multiple inputs in a flowgraph (consume
     // their points in time order, and de-dup marks and ticks)
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         this.last_mark = JuttleMoment.epsMoment(-Infinity) ;
         this.last_tick = JuttleMoment.epsMoment(-Infinity) ;
         this.last_emitted = JuttleMoment.epsMoment(-Infinity) ;

--- a/lib/runtime/procs/filter.js
+++ b/lib/runtime/procs/filter.js
@@ -9,7 +9,7 @@ var INFO = {
 };
 
 var filter = fanin.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.predicate = params.predicate;
     },
     procName: function() {

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -11,7 +11,7 @@ var INFO = {
 };
 
 var head = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
                 proc: 'head',

--- a/lib/runtime/procs/join.js
+++ b/lib/runtime/procs/join.js
@@ -137,7 +137,7 @@ var Groups = require('../groups');
 var timeless_time = new JuttleMoment(-Infinity); // timeless points get this timestamp
 
 var Input = ExtBase.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         this.from = options.proc;     // input node
         this.i = options.i;           // index in inputs[]
         this.batched = false; // is this input in batching mode?
@@ -232,7 +232,7 @@ var INFO = {
 // sent by an input. Everything else fans out from that.
 //
 var join = base.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['zip', 'nearest', 'once', 'outer', 'table', 'columns'];
         this.validate_options(allowed_options);
         this.joinfields = options.columns || [];

--- a/lib/runtime/procs/keep.js
+++ b/lib/runtime/procs/keep.js
@@ -8,7 +8,7 @@ var INFO = {
 };
 
 var keep = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         this.columns = options.columns || [];
     },
     procName: function() {

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -7,7 +7,7 @@ var errors = require('../errors');
 var oops_fanin = fanin.extend({
     // watch for out-of-order points and points with non-moment times when emitting
     initialize: function(options, params) {
-        if (params.lhs.indexOf('time') >= 0) {
+        if (params && params.lhs && params.lhs.indexOf('time') >= 0) {
             this.watch_oops = true; // true enables out-of-order checks during emit
             this.last_output_time = JuttleMoment.epsMoment(-Infinity); // only updated if watch_oops
         } else {

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -6,7 +6,7 @@ var errors = require('../errors');
 
 var oops_fanin = fanin.extend({
     // watch for out-of-order points and points with non-moment times when emitting
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         if (params && params.lhs && params.lhs.indexOf('time') >= 0) {
             this.watch_oops = true; // true enables out-of-order checks during emit
             this.last_output_time = JuttleMoment.epsMoment(-Infinity); // only updated if watch_oops

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -4,7 +4,7 @@ var fanin = require('./fanin');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var errors = require('../errors');
 
-var oops_funcs = {
+var oops_fanin = fanin.extend({
     // watch for out-of-order points and points with non-moment times when emitting
     initialize: function(options, params) {
         if (params.lhs.indexOf('time') >= 0) {
@@ -65,6 +65,6 @@ var oops_funcs = {
         }
         fanin.prototype.emit_tick.call(this, time, output_name);
     }
-};
+});
 
-module.exports = oops_funcs;
+module.exports = oops_fanin;

--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -16,7 +16,7 @@ var INFO = {
 };
 
 var pace = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['x', 'every', 'from'];
         this.validate_options(allowed_options);
 

--- a/lib/runtime/procs/periodic-fanin.js
+++ b/lib/runtime/procs/periodic-fanin.js
@@ -2,10 +2,11 @@
 
 var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
+var oops_fanin = require('./oops-fanin');
 
 var BATCH_OF_BATCHES = 1000;
 
-var periodic_funcs = {
+var periodic_fanin = oops_fanin.extend({
     // mixin functions so batch and windowed reduce can share the ability
     // to track periodic intervals in timeseries and trigger actions
     // when crossing epoch boundaries. Mixers need to define process_points(),
@@ -14,7 +15,7 @@ var periodic_funcs = {
     // to keep you on your toes, these mixins swallow eof() so derived
     // classes that implement eof() will break.  instead, this class
     // calls periodic_eof() so implement that instead.
-    initialize: function(options) {
+    initialize: function(options, params) {
         this.epoch = this.next_epoch = undefined;
         this.dead = false;
         this.periodic = true; // is this mixin mixed in?
@@ -186,6 +187,6 @@ var periodic_funcs = {
     advance_epoch: function(epoch) {
         throw new Error('write me!');
     }
-};
+});
 
-module.exports = periodic_funcs;
+module.exports = periodic_fanin;

--- a/lib/runtime/procs/periodic-fanin.js
+++ b/lib/runtime/procs/periodic-fanin.js
@@ -15,7 +15,7 @@ var periodic_fanin = oops_fanin.extend({
     // to keep you on your toes, these mixins swallow eof() so derived
     // classes that implement eof() will break.  instead, this class
     // calls periodic_eof() so implement that instead.
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.epoch = this.next_epoch = undefined;
         this.dead = false;
         this.periodic = true; // is this mixin mixed in?

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -17,7 +17,7 @@ var INFO = {
 };
 
 var put = oops_fanin.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         var self = this;
         var allowed_options = ['acc', 'groupby', 'over', 'from', 'reset'];
         this.validate_options(allowed_options);

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -2,8 +2,7 @@
 
 var _ = require('underscore');
 var windowMaker = require('./windowmaker');
-var fanin = require('./fanin');
-var oops_funcs = require('./oops_funcs');
+var oops_fanin = require('./oops-fanin');
 var errors = require('../../errors');
 var Groups = require('../groups');
 var values = require('../values');
@@ -17,7 +16,6 @@ var INFO = {
     }
 };
 
-var oops_fanin = fanin.extend(oops_funcs);
 var put = oops_fanin.extend({
     initialize: function(options, params) {
         var self = this;

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -8,7 +8,7 @@ var JuttleMoment = require('../../runtime/types/juttle-moment');
 var Promise = require('bluebird');
 
 var Read = source.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.lag = _.has(options, 'lag') ? options.lag : JuttleMoment.duration(0, 's');
         if (! this.lag.duration) {
             throw this.compile_error('RT-DURATION-ERROR', {

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -29,7 +29,7 @@ var INFO = {
 var reduce_base = periodic_fanin.extend({
     // basic reducer runner functions to feed points to reducers and
     // evaluate at epochs.
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         var self = this;
         // call this from initialize() if you mix in these functions.
         if (options.over && !options.over.duration) {
@@ -204,7 +204,7 @@ var reduce_base = periodic_fanin.extend({
 // reduce driven by upstream batches or EOF.
 // Mix in grouping and reduce runner behaviors
 var reduce_batch = reduce_base.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
 
@@ -268,7 +268,7 @@ var reduce_batch = reduce_base.extend({
 // marks (except to advance time) and does not emit marks with its results.
 // Mix in periodic, grouping, and reduce runner behaviors
 var reduce_every = reduce_base.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
 

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -3,16 +3,13 @@
 var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var windowMaker = require('./windowmaker');
-var pfuncs = require('./periodic_funcs');
-var oops_fanin = require('./oops-fanin');
-var fanin = require('./fanin');
+var periodic_fanin = require('./periodic-fanin');
 var errors = require('../../errors');
 var Promise = require('bluebird');
 var utils = require('../juttle-utils');
 var Groups = require('../groups');
 var values = require('../values');
 
-var periodic_fanin = oops_fanin.extend(pfuncs);
 var EMIT_BATCH_SIZE = 20000;
 
 var INFO = {
@@ -29,7 +26,7 @@ var INFO = {
     }
 };
 
-var reduce_runner_funcs = {
+var reduce_base = periodic_fanin.extend({
     // basic reducer runner functions to feed points to reducers and
     // evaluate at epochs.
     initialize: function(options, params) {
@@ -201,16 +198,18 @@ var reduce_runner_funcs = {
         }
         this.emit_tick(time);
     }
-};
+});
 
 
 // reduce driven by upstream batches or EOF.
 // Mix in grouping and reduce runner behaviors
-var __reduce = oops_fanin.extend(reduce_runner_funcs);
-var _reduce = __reduce.extend({
+var reduce_batch = reduce_base.extend({
     initialize: function(options, params) {
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
+
+        // Disable the base class periodic behavior
+        this.periodic = false;
 
         if (options.on) {
             // if we are here, it is because -every is null (likely a
@@ -268,8 +267,7 @@ var _reduce = __reduce.extend({
 // timestamps cross epoch boundaries. It ignores any received batch
 // marks (except to advance time) and does not emit marks with its results.
 // Mix in periodic, grouping, and reduce runner behaviors
-var __ereduce = periodic_fanin.extend(reduce_runner_funcs);
-var _ereduce = __ereduce.extend({
+var reduce_every = reduce_base.extend({
     initialize: function(options, params) {
         var allowed_options = ['acc', 'every', 'forget', 'from', 'groupby', 'on', 'over', 'reset', 'to', 'no_groupby_warning'];
         this.validate_options(allowed_options);
@@ -340,7 +338,7 @@ var _ereduce = __ereduce.extend({
 // data-driven reducer with its own epochs is decided by the presence
 // of an -every option to reduce.
 function reduce(options, params, location, program) {
-    return options.every? new _ereduce(options, params, location, program) : new _reduce(options, params, location, program);
+    return options.every? new reduce_every(options, params, location, program) : new reduce_batch(options, params, location, program);
 }
 
 reduce.info = INFO;

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
 var windowMaker = require('./windowmaker');
 var pfuncs = require('./periodic_funcs');
-var oops_funcs = require('./oops_funcs');
+var oops_fanin = require('./oops-fanin');
 var fanin = require('./fanin');
 var errors = require('../../errors');
 var Promise = require('bluebird');
@@ -12,7 +12,6 @@ var utils = require('../juttle-utils');
 var Groups = require('../groups');
 var values = require('../values');
 
-var oops_fanin = fanin.extend(oops_funcs);
 var periodic_fanin = oops_fanin.extend(pfuncs);
 var EMIT_BATCH_SIZE = 20000;
 

--- a/lib/runtime/procs/remove.js
+++ b/lib/runtime/procs/remove.js
@@ -9,7 +9,7 @@ var INFO = {
 };
 
 var remove = fanin.extend({
-    initialize: function (options) {
+    initialize: function(options, params, location, program) {
         this.columns = options.columns || [];
     },
     procName: function() {

--- a/lib/runtime/procs/sequence.js
+++ b/lib/runtime/procs/sequence.js
@@ -13,7 +13,7 @@ var INFO = {
 };
 
 var sequence = fanin.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.seqno = 0;
         this.predicates = params.predicates;
         this.seq_fieldname = '_seqno';

--- a/lib/runtime/procs/sink.js
+++ b/lib/runtime/procs/sink.js
@@ -10,7 +10,7 @@ var SINK_INFO = {
 
 // base class for all sinks (both client-side views and adapter write procs)
 var sink = fanin.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         // To indicate when the sink is finished, stash a completion trigger in
         // this.done() that resolves the `isDone` promise.
         //

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -11,7 +11,7 @@ var INFO = {
 };
 
 var skip = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
                 proc: 'skip',

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -13,7 +13,7 @@ var INFO = {
 };
 
 var sort = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         //
         // XXX 'sortby' should be a list of fields like group-by
         // where the list comprises subkeys for subsorts

--- a/lib/runtime/procs/source.js
+++ b/lib/runtime/procs/source.js
@@ -21,7 +21,7 @@ var INFO = {
 };
 
 var source = base.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.queue = [];
         this.queueSize = options.queueSize || 100000;
 

--- a/lib/runtime/procs/split.js
+++ b/lib/runtime/procs/split.js
@@ -11,7 +11,7 @@ var INFO = {
 
 var split = fanin.extend({
     // the wickham 'melt' operation. now with array exploding!
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         var allowed_options = ['arrays', 'columns'];
         this.validate_options(allowed_options);
 

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -12,7 +12,7 @@ var INFO = {
 };
 
 var tail = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         if (options.arg && !utils.isInteger(options.arg)) {
             throw this.compile_error('RT-INTEGER-REQUIRED-ERROR', {
                 proc: 'tail',

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -14,7 +14,7 @@ var INFO = {
    Emits each data point that differs from the one
    that came before it. Swallows other points. */
 var uniq = fanin.extend({
-    initialize: function(options) {
+    initialize: function(options, params, location, program) {
         this.fields = options.arg || [];
         this.groups = new Groups(this, options);
     },

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -9,7 +9,7 @@ var INFO = {
 };
 
 var view = sink.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         this.name = params.name;
         this.channel = 'view' + (Juttle.channels++);
     },

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -5,7 +5,7 @@ var adapters = require('../adapters');
 var Promise = require('bluebird');
 
 var Write = sink.extend({
-    initialize: function(options, params) {
+    initialize: function(options, params, location, program) {
         var adapter = adapters.get(params.adapter.name, params.adapter.location);
         if (!adapter.write) {
             throw this.compile_error('JUTTLE-UNSUPPORTED-ADAPTER-MODE', {

--- a/lib/views/file.js
+++ b/lib/views/file.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var FileView = TextView.extend({
     name: 'file',
 
-    initialize: function(options) {
+    initialize: function(options, env) {
         this.options.format = 'json';
         this.filename = options.filename;
 

--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -9,7 +9,7 @@ var values = require('../runtime/values');
 var TableView = View.extend({
     name: 'table',
 
-    initialize: function(options) {
+    initialize: function(options, env) {
 
         this.options = _.defaults({}, options, {
             columnOrder: ['time', 'name', 'value']

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -9,7 +9,7 @@ var values = require('../runtime/values');
 var TextView = View.extend({
     name: 'text',
 
-    initialize: function(options) {
+    initialize: function(options, env) {
 
         this.options = _.clone(options);
         this.options.format = this.options.format || 'json';


### PR DESCRIPTION
All these changes were previously reviewed as part of the move to ES6 classes in #326.

This set of changes cleans up the inheritance of reduce to no longer use mixins and normalizes the constructor arguments for procs / views.
