### PR TITLE
no more prototype properties

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,9 +12,8 @@ var messages = require('./messages');
 // Don't throw this exception directly, use its subclasses and related helpers
 // instead.
 var JuttleError = Base.inherits(Error, {
-    name: 'JuttleError',
-
     initialize: function(message, code, info) {
+        this.name = 'JuttleError';
         this.message = message;
         this.code = code;
         this.info = info;
@@ -29,7 +28,9 @@ var JuttleError = Base.inherits(Error, {
 //
 // Don't throw this exception directly, use the syntaxError helper instead.
 var SyntaxError_ = JuttleError.extend({
-    name: 'SyntaxError',
+    initialize: function(message, code, info) {
+        this.name = 'SyntaxError';
+    }
 });
 
 // Exception thrown when Juttle program compilation fails. Compilation includes
@@ -38,7 +39,9 @@ var SyntaxError_ = JuttleError.extend({
 //
 // Don't throw this exception directly, use the compileError helper instead.
 var CompileError = JuttleError.extend({
-    name: 'CompileError',
+    initialize: function(message, code, info) {
+        this.name = 'CompileError';
+    }
 });
 
 // Exception thrown when Juttle program fails at runtime. Runtime is the time
@@ -46,7 +49,9 @@ var CompileError = JuttleError.extend({
 //
 // Don't throw this exception directly, use the runtimeError helper instead.
 var RuntimeError = JuttleError.extend({
-    name: 'RuntimeError',
+    initialize: function(message, code, info) {
+        this.name = 'RuntimeError';
+    }
 });
 
 // Build a SyntaxError with given code and info. Its message will be created

--- a/lib/runtime/types/juttle-moment.js
+++ b/lib/runtime/types/juttle-moment.js
@@ -7,6 +7,9 @@ var epoch = moment.utc(0);
 var Moment = Object.getPrototypeOf(epoch);
 require('moment-duration-format'); // momentjs plugin, no reference needed
 
+const SIMPLE_DURATION = /^([+-])?(\d*([Mdhms]|ms)|Infinity)$/;
+const FORMATTED_DURATION = /^([+-]?\d+\/)?([+-]?\d+\.)?([+-]?\d+):(\d+):([\d.]+)$/;
+
 var JuttleMoment = Base.extend({
 
     // Because this is called "constructor" instead of "initialize",
@@ -118,10 +121,8 @@ var JuttleMoment = Base.extend({
         }
     },
 
-    SIMPLE_DURATION: /^([+-])?(\d*([Mdhms]|ms)|Infinity)$/,
-    FORMATTED_DURATION: /^([+-]?\d+\/)?([+-]?\d+\.)?([+-]?\d+):(\d+):([\d.]+)$/,
     parseDuration: function(dur, optunits) {
-        var simple = _.isString(dur) && dur.match(this.SIMPLE_DURATION);
+        var simple = _.isString(dur) && dur.match(SIMPLE_DURATION);
         if (simple) {
             // simple durations are like "Nunitabbrev"
             var N = parseFloat(simple[2]) * (simple[1] === '-' ? -1 : 1);
@@ -138,7 +139,7 @@ var JuttleMoment = Base.extend({
         } else if (_.isString(dur)) {
             // parse "M/d.h:m:s.msecs. M may have a different sign from
             // the remaining duration
-            var s = dur.match(this.FORMATTED_DURATION);
+            var s = dur.match(FORMATTED_DURATION);
             if (s === null) {
                 throw new Error('Unable to parse as formatted duration: '+ dur);
             }

--- a/lib/views/file.js
+++ b/lib/views/file.js
@@ -6,9 +6,8 @@ var fs = require('fs');
 // A file view is a text view with no arguments other than
 // format 'json' and writing to a file.
 var FileView = TextView.extend({
-    name: 'file',
-
     initialize: function(options, env) {
+        this.name = 'file';
         this.options.format = 'json';
         this.filename = options.filename;
 

--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -7,9 +7,8 @@ var View = require('./view.js');
 var values = require('../runtime/values');
 
 var TableView = View.extend({
-    name: 'table',
-
     initialize: function(options, env) {
+        this.name = 'table';
 
         this.options = _.defaults({}, options, {
             columnOrder: ['time', 'name', 'value']

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -7,10 +7,8 @@ var View = require('./view.js');
 var values = require('../runtime/values');
 
 var TextView = View.extend({
-    name: 'text',
-
     initialize: function(options, env) {
-
+        this.name = 'text';
         this.options = _.clone(options);
         this.options.format = this.options.format || 'json';
 

--- a/lib/views/view.js
+++ b/lib/views/view.js
@@ -17,15 +17,11 @@ var View = Base.extend({
     },
 
     warn: function(msg) {
-        var self = this;
-
-        self.events.emit('warning', 'view ' + self.name + ': ' + msg);
+        this.events.emit('warning', 'view ' + this.name + ': ' + msg);
     },
 
     error: function(msg) {
-        var self = this;
-
-        self.events.emit('error', 'view ' + self.name + ': ' + msg);
+        this.events.emit('error', 'view ' + this.name + ': ' + msg);
     },
 
     // The subclass should override one or more of these callbacks to
@@ -41,8 +37,7 @@ var View = Base.extend({
     },
 
     eof: function() {
-        var self = this;
-        self.events.emit('end');
+        this.events.emit('end');
     }
 
 });

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -57,14 +57,6 @@ var html = {
     }
 };
 
-function skip() {
-    return '';
-}
-
-function pass(s) {
-    return s;
-}
-
 /*
  * Renderer passed to marked that renders a Markdown spec into a JavaScript one.
  *
@@ -283,24 +275,66 @@ var SpecRenderer = Base.extend({
         return '';
     },
 
-    blockquote: skip,
-    hr: skip,
-    html: skip,
-    list: skip,
-    paragraph: skip,
-    table: skip,
-    tablecell: skip,
-    tablerow: skip,
+    blockquote: function() {
+        return '';
+    },
+
+    hr: function() {
+        return '';
+    },
+
+    html: function() {
+        return '';
+    },
+
+    list: function() {
+        return '';
+    },
+
+    paragraph: function() {
+        return '';
+    },
+
+    table: function() {
+        return '';
+    },
+
+    tablecell: function() {
+        return '';
+    },
+
+    tablerow: function() {
+        return '';
+    },
 
     /* Inline-level Methods */
+    codespan: function pass(s) {
+        return s;
+    },
 
-    codespan: pass,
-    br: skip,
-    del: pass,
-    em: pass,
-    image: skip,
-    link: skip,
-    strong: pass
+    br: function() {
+        return '';
+    },
+
+    del: function pass(s) {
+        return s;
+    },
+
+    em: function pass(s) {
+        return s;
+    },
+
+    image: function() {
+        return '';
+    },
+
+    link: function() {
+        return '';
+    },
+
+    strong: function pass(s) {
+        return s;
+    }
 });
 
 /*


### PR DESCRIPTION
Clean up various places in the code we use properties attached to the prototype or mixins of functions directly attached to the prototype instead of regular class inheritance.

This is to pave the way for ES6 classes (#326) without requiring the use of getter functions.

@dmajda 