### PR TITLE
logging: configure log targets through DEBUG environment variable

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -1,17 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-
 /* eslint no-console: 0 */
-var JuttleLogger = require('../lib/logger');
-var log4js = require('log4js');
 
-// Set up logging to use log4js loggers
-JuttleLogger.getLogger = log4js.getLogger;
-if (! process.env.DEBUG) {
-    log4js.setGlobalLogLevel('info');
-}
-
-var logger = log4js.getLogger('cli');
+// Initialize logging before loading any other juttle files.
+require('../lib/cli/log-setup')();
+var logger = require('../lib/logger').getLogger('cli');
 
 // Node will return errors on process.stdout if the standard output is
 // piped to a program that doesn't read all of the output (for
@@ -46,7 +39,6 @@ var optimize = require('../lib/compiler/optimize');
 var implicit_views = require('../lib/compiler/flowgraph/implicit_views');
 
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
-
 function usage() {
     console.log('usage: juttle [--version] [--adapters] [--mode <mode>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]');
     console.log('     --version show juttle CLI version');

--- a/lib/cli/log-setup.js
+++ b/lib/cli/log-setup.js
@@ -1,0 +1,36 @@
+'use strict';
+let JuttleLogger = require('../logger');
+let log4js = require('log4js');
+let _ = require('underscore');
+
+// Initialize the Juttle Logger to use log4js. By default all targets are set to
+// info level, but individual targets (or all targets) can be enabled at debug
+// level with the DEBUG environment letiable.
+function logSetup() {
+    JuttleLogger.getLogger = log4js.getLogger;
+
+    let levels = {
+        '[all]': 'info'
+    };
+
+    // Handle node.js style debug configuration where DEBUG is a
+    // comma-separated list of debug targets, or '*' to enable all
+    // debugging.
+    let DEBUG = process.env.DEBUG;
+    if (DEBUG) {
+        let targets = DEBUG.split(',');
+        _.each(targets, function(target) {
+            if (target === '*') { target = '[all]'; }
+            levels[target] = 'debug';
+        });
+    }
+
+    log4js.configure({
+        levels: levels,
+        appenders: [{type: 'console'}]
+    });
+
+    JuttleLogger.getLogger('cli').debug('set logging levels to', levels);
+}
+
+module.exports = logSetup;

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -422,4 +422,47 @@ describe('Juttle CLI Tests', function() {
             });
         });
     });
+
+    describe('logging', function() {
+        it('logs at info level by default', function() {
+            return runJuttle([
+                '-e', 'emit -from :2016-01-01: -limit 1 | view text -format "jsonl"'
+            ])
+            .then(function(result) {
+                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
+                expect(result.stdout).to.not.match(/\[DEBUG\]/);
+                expect(result.stdout).to.not.match(/\[INFO\]/);
+            });
+        });
+
+        it('logs at debug level for all targets with DEBUG=*', function() {
+            return runJuttle(
+                ['-e', 'emit -from :2016-01-01: -limit 1 | view text -format "jsonl"'],
+                {
+                    env: {DEBUG: '*'}
+                }
+            )
+            .then(function(result) {
+                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
+                expect(result.stdout).to.match(/\[DEBUG\] cli/);
+                expect(result.stdout).to.match(/\[DEBUG\] juttle-adapter/);
+                expect(result.stdout).to.match(/\[DEBUG\] proc-emit/);
+            });
+        });
+
+        it('logs at debug level for named targets with DEBUG=cli,juttle-adapter', function() {
+            return runJuttle(
+                ['-e', 'emit -from :2016-01-01: -limit 1 | view text -format "jsonl"'],
+                {
+                    env: {DEBUG: 'cli,juttle-adapter'}
+                }
+            )
+            .then(function(result) {
+                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
+                expect(result.stdout).to.match(/\[DEBUG\] cli/);
+                expect(result.stdout).to.match(/\[DEBUG\] juttle-adapter/);
+                expect(result.stdout).to.not.match(/\[DEBUG\] proc-emit/);
+            });
+        });
+    });
 });

--- a/test/cli/util.js
+++ b/test/cli/util.js
@@ -5,6 +5,7 @@ var Promise = require('bluebird');
 
 var spawn = require('child-process-promise').spawn;
 var juttleBin = 'bin/juttle';
+var _ = require('underscore');
 
 module.exports.runJuttle = function(args, options) {
 
@@ -12,9 +13,10 @@ module.exports.runJuttle = function(args, options) {
         var stdout = '';
         var stderr = '';
 
+        options = options || {};
         var spawnOptions;
 
-        if (options && options.stdin) {
+        if (options.stdin) {
             spawnOptions = {
                 stdio : ['pipe', 'pipe', 'pipe']
             };
@@ -22,6 +24,10 @@ module.exports.runJuttle = function(args, options) {
             spawnOptions = {
                 stdio : [undefined, 'pipe', 'pipe']
             };
+        }
+
+        if (options.env) {
+            spawnOptions.env = _.extend({}, process.env, options.env);
         }
 
         return spawn(juttleBin,


### PR DESCRIPTION
If the DEBUG environment variable is present, support setting the
named targets to debug level, or * for all targets.

Fixes #373.