### PR TITLE
filters: allow property accesses

### DIFF
--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -18,7 +18,7 @@ var checks = {
         displayName: 'field',
 
         test: function(node) {
-            return node.type === 'Field';
+            return node.type === 'Field' || checks.isMemberAccess.test(node);
         }
     },
 
@@ -50,6 +50,19 @@ var checks = {
                 || node.type === 'StringLiteral'
                 || node.type === 'MomentLiteral'
                 || node.type === 'DurationLiteral';
+        }
+    },
+
+    isMemberAccess: {
+        displayName: 'property access',
+
+        test: function(node) {
+            var hasRightType = node.type === 'MemberExpression';
+            var fieldNameIsSimple = node.property && checks.isSimpleLiteral.test(node.property);
+            var accessIsFieldOrNest = node.object && (checks.isField.test(node.object) ||
+                checks.isMemberAccess.test(node.object));
+
+            return hasRightType && fieldNameIsSimple && accessIsFieldOrNest;
         }
     },
 

--- a/lib/compiler/filters/static-filter-compiler.js
+++ b/lib/compiler/filters/static-filter-compiler.js
@@ -58,6 +58,10 @@ class StaticFilterCompiler extends ASTVisitor {
         this.featureNotSupported(node, 'fields');
     }
 
+    visitMemberExpression(node) {
+        this.featureNotSupported(node, 'nested fields');
+    }
+
     visitUnaryExpression(node) {
         this.featureNotSupported(node, `the "${node.operator}" operator`);
     }

--- a/test/compiler/filters/static-filter-compiler.spec.js
+++ b/test/compiler/filters/static-filter-compiler.spec.js
@@ -136,6 +136,13 @@ describe('StaticFilterCompiler', () => {
         );
     });
 
+    it('doesn\'t compile MemberExpression', () => {
+        expect('a.b < 5').to.failToCompile(
+            NumberLiteralCompiler,
+            'Filters do not support nested fields in this context.'
+        );
+    });
+
     it('doesn\'t compile UnaryExpression', () => {
         expect('NOT a < 5').to.failToCompile(
             EmptyCompiler,

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -2,6 +2,8 @@
 
 var juttle_test_utils = require('./specs/juttle-test-utils');
 var check_juttle = juttle_test_utils.check_juttle;
+
+var Promise = require('bluebird');
 var expect = require('chai').expect;
 var path = require('path');
 var _ = require('underscore');
@@ -261,6 +263,32 @@ describe('adapter API tests', function () {
 
             var expected = [{from: '(null)', to: '(null)'}];
             expect(result.sinks.table).deep.equal(expected);
+        });
+    });
+
+    it('accepts filter expressions including nested objects', function() {
+        var operators = [ '==', '!=', '=~', '!~', '<', '>', '<=', '>=' ];
+        return Promise.map(operators, function(op) {
+            return check_juttle({
+                program: `read test -key "nothing" field["x"] ${op} "1"`
+            })
+            .then(function(result) {
+                expect(result.errors).deep.equal([]);
+            });
+        })
+        .then(function() {
+            return check_juttle({
+                program: `read test -key "nothing" field["x"] in [1]`
+            });
+        })
+        .then(function(result) {
+            expect(result.errors).deep.equal([]);
+            return check_juttle({
+                program: `read test -key "nothing" field.x.y = 1`
+            });
+        })
+        .then(function(result) {
+            expect(result.errors).deep.equal([]);
         });
     });
 });

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -29,7 +29,7 @@ Regression test for PROD-6797.
 ### Juttle
 
     const field = "a";
-    
+
     emit -from Date.new(0) -limit 1 | put a = 5 | filter *field == 5 | view result
 
 ### Output
@@ -222,3 +222,25 @@ Regression test for PROD-6797.
 ### Errors
 
   * Cannot filter on "time" in read. Use -to, -from, or -last instead.
+
+## Produces an error when filtering on a dynamic field
+
+### Juttle
+
+    function f() {}
+    read test f()[1] < 5
+
+### Errors
+
+  * Invalid filter term. Valid forms are: "field < value", "value < field".
+
+## Produces an error when filtering on a dynamic property of a field
+
+### Juttle
+
+    function f() {}
+    read test field[f()] < 5
+
+### Errors
+
+  * Invalid filter term. Valid forms are: "field < value", "value < field".


### PR DESCRIPTION
The static filter checker rejects any read filters that
have property accesses. But these can be handled in some
cases (at least by Elastic), so let's allow them.

@juttle/developers 