### PR TITLE
Consolidate Juttle runtime: Kill Juttle.channels

### DIFF
--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -88,6 +88,7 @@ var GraphCompiler = CodeGenerator.extend({
     },
     gen_now: function(now) {
         this.emit('program.now = ' + 'new juttle.types.JuttleMoment("' + now + '");');
+        this.emit('program.channels = 0;');
     },
     gen_functionDefs: function(fns) {
         var k;

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -5,7 +5,6 @@ var adapters = require('../adapters');
 // Juttle namespace
 
 var Juttle = {
-    channels:0
 };
 
 Juttle.adapters = adapters;

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var sink = require('./sink');
-var Juttle = require('./procs');
 
 var INFO = {
     type: 'view',
@@ -11,7 +10,7 @@ var INFO = {
 var view = sink.extend({
     initialize: function(options, params, location, program) {
         this.name = params.name;
-        this.channel = 'view' + (Juttle.channels++);
+        this.channel = 'view' + (program.channels++);
     },
 
     procName: function() {


### PR DESCRIPTION
Move `Juttle.channels` to program (the object generated by compiler and passed to procs).

This is a little step on the path leading to dismantling the `Juttle` global object.

Part of work on #97.