### PR TITLE
Kill Juttle.adapters

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -27,6 +27,7 @@ var Promise = require('bluebird');
 var views = require('../lib/views');
 var read_config = require('../lib/config/read-config');
 
+var adapters = require('../lib/runtime/adapters');
 var LocationStripper = require('../lib/cli/location-stripper');
 var ViewManager = require('../lib/views/view-mgr.js');
 var CliErrors = require('../lib/cli/errors');
@@ -110,19 +111,18 @@ var view_classes = {
     file: views.FileView
 };
 
-var Juttle = require('../lib/runtime').Juttle;
-Juttle.adapters.configure(config.adapters);
+adapters.configure(config.adapters);
 
 if (opts.adapters) {
-    Juttle.adapters.list().forEach(function(info) {
+    adapters.list().forEach(function(info) {
         console.log(info.adapter, info.version, info.path);
     });
     process.exit(0);
 }
 
 if (process.env.JUTTLE_LOAD_TEST_ADAPTERS) {
-    Juttle.adapters.register('test', require('../test/runtime/test-adapter')());
-    Juttle.adapters.register('testTimeseries', require('../test/runtime/test-adapter-timeseries')());
+    adapters.register('test', require('../test/runtime/test-adapter')());
+    adapters.register('testTimeseries', require('../test/runtime/test-adapter-timeseries')());
 }
 
 function format_js(code) {

--- a/lib/compiler/optimize/optimize.js
+++ b/lib/compiler/optimize/optimize.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('underscore');
+var adapters = require('../../runtime/adapters');
 var utils = require('./optimize_utils');
 var optimize_head = require('./optimize_head');
 var optimize_tail = require('./optimize_tail');
@@ -34,7 +35,7 @@ function optimize_read(source_node, graph, Juttle) {
 
     var optimization_info = {};
 
-    var adapter = Juttle.adapters.get(source_node.adapter.name, source_node.adapter.location);
+    var adapter = adapters.get(source_node.adapter.name, source_node.adapter.location);
     if (!adapter) {
         throw new Error('unknown adapter');
     }

--- a/lib/runtime/procs/procs.js
+++ b/lib/runtime/procs/procs.js
@@ -1,12 +1,8 @@
 'use strict';
 
-var adapters = require('../adapters');
-
 // Juttle namespace
 
 var Juttle = {
 };
-
-Juttle.adapters = adapters;
 
 module.exports = Juttle;

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -9,7 +9,7 @@ var expect = require('chai').expect;
 var log4js = require('log4js');
 var JuttleLogger = require('../../../lib/logger');
 var utils = require('../../../lib/runtime').utils;
-var Juttle = require('../../../lib/runtime/index').Juttle;
+var adapters = require('../../../lib/runtime/adapters');
 var JuttleMoment = require('../../../lib/runtime/types/juttle-moment');
 var compiler = require('../../../lib/compiler');
 var Scheduler = require('../../../lib/runtime/scheduler').Scheduler;
@@ -22,7 +22,7 @@ var View = require('../../../lib/views/view.js');
 JuttleLogger.getLogger = log4js.getLogger;
 
 // Configure the test adapter
-Juttle.adapters.configure({
+adapters.configure({
     test: {
         path: path.resolve(__dirname, '../test-adapter')
     },


### PR DESCRIPTION
Just use the `adapters` module directly where it is needed.

This is a little step on the path leading to dismantling the `Juttle` global object.

**This change will require adapting the adapters.**

Part of work on #97.