### PR TITLE
package.json: change scripts/peg.js to run in prepublish not postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bin": "bin/juttle",
   "repository": "juttle/juttle",
   "scripts": {
-    "postinstall": "node scripts/peg.js",
+    "prepublish": "node scripts/peg.js",
     "shrinkwrap": "npm-shrinkwrap"
   },
   "dependencies": {
@@ -77,5 +77,23 @@
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"
-  }
+  },
+  "files": [
+      "AUTHORS.md",
+      "CHANGELOG.md",
+      "CONTRIBUTING.md",
+      "LICENSE",
+      "NOTICE",
+      "README.md",
+      "bin",
+      "docs",
+      "examples",
+      "extlib",
+      "gulpfile.js",
+      "index.js",
+      "lib",
+      "package.json",
+      "scripts",
+      "test"
+  ]
 }


### PR DESCRIPTION
To workaround an npm problem in which it sometimes refuses to run the
postinstall script, change the package so that it generates the parser
in the prepublish phase and not postinstall.

This also required explicitly enumerating the files to be put into the
package since by default it omits anything that's in .gitignore, but we
want it to include the generated files in the package.