### PR TITLE
program: don't delete this.graph in deactivate

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -33,7 +33,6 @@ var Program = Base.extend({
             for (k = 0; k < this.graph.head.length; ++k) {
                 this.graph.head[k].deactivate(this.visitGen);
             }
-            delete this.graph;
         }
     },
     _eval: function() {


### PR DESCRIPTION
There's no need to delete this.graph here (as far as I can tell), and by not deleting
it we enable tests that call deactivate() to validate graphs.
@juttle/developers @dmajda 