### PR TITLE
Filters AST cleanups (part 1)

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -21,7 +21,7 @@ var NODE_CHILDREN = {
     /* Literals */
     NullLiteral:              [],
     BooleanLiteral:           [],
-    NumericLiteral:           [],
+    NumberLiteral:            [],
     InfinityLiteral:          [],
     NaNLiteral:               [],
     StringLiteral:            [],

--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -26,7 +26,7 @@ var NODE_CHILDREN = {
     NaNLiteral:               [],
     StringLiteral:            [],
     MultipartStringLiteral:   ['parts'],
-    RegularExpressionLiteral: [],
+    RegExpLiteral:            [],
     MomentLiteral:            [],
     DurationLiteral:          [],
     FilterLiteral:            ['ast'],

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -609,7 +609,7 @@ var Build = CodeGenerator.extend({
             case 'BooleanLiteral':
             case 'StringLiteral':
             case 'MultipartStringLiteral':
-            case 'NumericLiteral':
+            case 'NumberLiteral':
             case 'InfinityLiteral':
             case 'NaNLiteral':
             case 'RegularExpressionLiteral':

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -612,7 +612,7 @@ var Build = CodeGenerator.extend({
             case 'NumberLiteral':
             case 'InfinityLiteral':
             case 'NaNLiteral':
-            case 'RegularExpressionLiteral':
+            case 'RegExpLiteral':
             case 'FilterLiteral':
             case 'ArrayLiteral':
             case 'ByList':

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -37,7 +37,7 @@ var CodeGenerator = Base.extend({
         return 'null';
     },
     gen_RegExpLiteral: function(ast) {
-        return '/'+ ast.value +'/'+ ast.flags;
+        return '/'+ ast.pattern +'/'+ ast.flags;
     },
     gen_ObjectLiteral: function(ast) {
         var self = this;

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -36,7 +36,7 @@ var CodeGenerator = Base.extend({
     gen_NullLiteral: function() {
         return 'null';
     },
-    gen_RegularExpressionLiteral: function(ast) {
+    gen_RegExpLiteral: function(ast) {
         return '/'+ ast.value +'/'+ ast.flags;
     },
     gen_ObjectLiteral: function(ast) {

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -64,7 +64,7 @@ var CodeGenerator = Base.extend({
         return 'new juttle.types.JuttleMoment("' + ast.value + '")';
     },
     gen_FilterLiteral: function(ast) {
-        return 'new juttle.types.Filter(' + JSON.stringify(ast.ast) + ',' + JSON.stringify(ast.text) + ')';
+        return 'new juttle.types.Filter(' + JSON.stringify(ast.ast) + ',' + JSON.stringify(ast.source) + ')';
     },
     gen_ToString: function(ast) {
         return 'juttle.ops.str(' + this.gen_expr(ast.expression) + ')';

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -11,7 +11,7 @@ var CodeGenerator = Base.extend({
         } );
         return '[' + exprs.join(',') + ']';
     },
-    gen_NumericLiteral: function(ast) {
+    gen_NumberLiteral: function(ast) {
         return ast.value.toString();
     },
     gen_InfinityLiteral: function(ast) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -76,7 +76,7 @@ var FilterJSCompiler = ASTVisitor.extend({
         return '(' + _.map(node.parts, this.visit, this).join(' + ') + ')';
     },
 
-    visitRegularExpressionLiteral: function(node) {
+    visitRegExpLiteral: function(node) {
         return 'new RegExp(' + JSON.stringify(node.value) + ', ' + JSON.stringify(node.flags) + ')';
     },
 

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -56,7 +56,7 @@ var FilterJSCompiler = ASTVisitor.extend({
         return String(node.value);
     },
 
-    visitNumericLiteral: function(node) {
+    visitNumberLiteral: function(node) {
         return String(node.value);
     },
 
@@ -101,7 +101,7 @@ var FilterJSCompiler = ASTVisitor.extend({
 
         var hasSimpleKeys = _.every(node.properties, function(property) {
             return property.key.type === 'StringLiteral'
-                || property.key.type === 'NumericLiteral';
+                || property.key.type === 'NumberLiteral';
         });
 
         var propertiesCode = _.map(node.properties, function(property) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -77,7 +77,7 @@ var FilterJSCompiler = ASTVisitor.extend({
     },
 
     visitRegExpLiteral: function(node) {
-        return 'new RegExp(' + JSON.stringify(node.value) + ', ' + JSON.stringify(node.flags) + ')';
+        return 'new RegExp(' + JSON.stringify(node.pattern) + ', ' + JSON.stringify(node.flags) + ')';
     },
 
     visitMomentLiteral: function(node) {

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -30,11 +30,11 @@ var checks = {
         }
     },
 
-    isRegularExpressionLiteral: {
+    isRegExpLiteral: {
         displayName: 'regexp',
 
         test: function(node) {
-            return node.type === 'RegularExpressionLiteral';
+            return node.type === 'RegExpLiteral';
         }
     },
 
@@ -78,12 +78,12 @@ var ALLOWED_OP_FORMS = {
 
     '=~': [
         { left: checks.isField, right: checks.isStringLiteral },
-        { left: checks.isField, right: checks.isRegularExpressionLiteral },
+        { left: checks.isField, right: checks.isRegExpLiteral },
     ],
 
     '!~': [
         { left: checks.isField, right: checks.isStringLiteral },
-        { left: checks.isField, right: checks.isRegularExpressionLiteral },
+        { left: checks.isField, right: checks.isRegExpLiteral },
     ],
 
     '<': [

--- a/lib/compiler/filters/static-filter-checker.js
+++ b/lib/compiler/filters/static-filter-checker.js
@@ -44,7 +44,7 @@ var checks = {
         test: function(node) {
             return node.type === 'NullLiteral'
                 || node.type === 'BooleanLiteral'
-                || node.type === 'NumericLiteral'
+                || node.type === 'NumberLiteral'
                 || node.type === 'InfinityLiteral'
                 || node.type === 'NaNLiteral'
                 || node.type === 'StringLiteral'

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -580,7 +580,7 @@ var GraphCompiler = CodeGenerator.extend({
             case 'BinaryExpression':
             case 'CalendarExpression':
             case 'NullLiteral':
-            case 'NumericLiteral':
+            case 'NumberLiteral':
             case 'InfinityLiteral':
             case 'NaNLiteral':
             case 'BooleanLiteral':

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -586,7 +586,7 @@ var GraphCompiler = CodeGenerator.extend({
             case 'BooleanLiteral':
             case 'StringLiteral':
             case 'MultipartStringLiteral':
-            case 'RegularExpressionLiteral':
+            case 'RegExpLiteral':
             case 'FilterLiteral':
             case 'ArrayLiteral':
             case 'Variable':

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -890,7 +890,7 @@ var SemanticPass = Base.extend({
         ast.d = ast.key.d && ast.value.d;
         return ast;
     },
-    sa_RegularExpressionLiteral: function(ast) {
+    sa_RegExpLiteral: function(ast) {
         ast.d = true;
         return ast;
     },
@@ -1139,7 +1139,7 @@ var SemanticPass = Base.extend({
             case 'BinaryExpression':
             case 'UnaryExpression':
             case 'MultipartStringLiteral':
-            case 'RegularExpressionLiteral':
+            case 'RegExpLiteral':
             case 'ArrayLiteral':
             case 'ByList':
             case 'SortByList':

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1125,7 +1125,7 @@ var SemanticPass = Base.extend({
         switch (ast.type) {
             case 'NullLiteral':
             case 'BooleanLiteral':
-            case 'NumericLiteral':
+            case 'NumberLiteral':
             case 'InfinityLiteral':
             case 'NaNLiteral':
             case 'StringLiteral':

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -358,7 +358,7 @@ NumericLiteral 'number'
 
 ValueNumericLiteral 'number'
     = sign:([+-] __)? literal:(HexIntegerLiteral / DecimalLiteral) {
-          return createNode('NumericLiteral', location(), {
+          return createNode('NumberLiteral', location(), {
               value: extractOptional(sign, 0) === '-' ? -literal.value : literal.value
           });
       }
@@ -371,17 +371,17 @@ ValueNumericLiteral 'number'
 
 DecimalLiteral
     = parts:$(DecimalIntegerLiteral '.' DecimalDigits? ExponentPart?) {
-          return createNode('NumericLiteral', location(), {
+          return createNode('NumberLiteral', location(), {
               value: parseFloat(parts)
           });
       }
     / parts:$('.' DecimalDigits ExponentPart?)     {
-          return createNode('NumericLiteral', location(), {
+          return createNode('NumberLiteral', location(), {
               value: parseFloat(parts)
           });
       }
     / parts:$(DecimalIntegerLiteral ExponentPart?) {
-          return createNode('NumericLiteral', location(), {
+          return createNode('NumberLiteral', location(), {
               value: parseFloat(parts)
           });
       }
@@ -409,7 +409,7 @@ SignedInteger
 
 HexIntegerLiteral
     = '0' [xX] digits:$HexDigit+ {
-          return createNode('NumericLiteral', location(), {
+          return createNode('NumberLiteral', location(), {
               value: parseInt('0x' + digits)
           });
       }
@@ -1507,7 +1507,7 @@ SingleArgByProc
           var arg = extractOptional(arg, 2);
 
           if (!arg) {
-              arg = createNode('NumericLiteral', null, { value: 1 });
+              arg = createNode('NumberLiteral', null, { value: 1 });
           }
 
           // Allow e.g. "head -3" as a syntax sugar for "head 3" to placate

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -524,7 +524,7 @@ UnicodeEscapeSequence
 
 RegularExpressionLiteral 'regular expression'
     = '/' body:RegularExpressionBody '/' flags:RegularExpressionFlags {
-          return createNode('RegularExpressionLiteral', location(), {
+          return createNode('RegExpLiteral', location(), {
               value:  body,
               flags: flags
           });

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -525,7 +525,7 @@ UnicodeEscapeSequence
 RegularExpressionLiteral 'regular expression'
     = '/' body:RegularExpressionBody '/' flags:RegularExpressionFlags {
           return createNode('RegExpLiteral', location(), {
-              value:  body,
+              pattern:  body,
               flags: flags
           });
       }

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1478,7 +1478,7 @@ Filter
     = ast:FilterExpression {
           return createNode('FilterLiteral', ast.location, {
               ast: ast,
-              text: text()
+              source: text()
           });
       }
 

--- a/lib/runtime/types/filter.js
+++ b/lib/runtime/types/filter.js
@@ -4,9 +4,9 @@ var Base = require('extendable-base');
 
 // Represents a filter expression in Jutttle runtime.
 var Filter = Base.extend({
-    constructor: function(ast, text) {
+    constructor: function(ast, source) {
         this.ast = ast;
-        this.text = text;
+        this.source = source;
     }
 });
 

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -50,7 +50,7 @@ var ValueBuilder = ASTVisitor.extend({
         return node.value;
     },
 
-    visitRegularExpressionLiteral: function(node) {
+    visitRegExpLiteral: function(node) {
         return new RegExp(node.value, node.flags);
     },
 
@@ -492,7 +492,7 @@ var values = {
 
             case 'RegExp':
                 return {
-                    type: 'RegularExpressionLiteral',
+                    type: 'RegExpLiteral',
                     value: value.source,
                     flags: value.toString().match(/\/(\w*)$/)[1]
                 };

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -51,7 +51,7 @@ var ValueBuilder = ASTVisitor.extend({
     },
 
     visitRegExpLiteral: function(node) {
-        return new RegExp(node.value, node.flags);
+        return new RegExp(node.pattern, node.flags);
     },
 
     visitMomentLiteral: function(node) {
@@ -493,7 +493,7 @@ var values = {
             case 'RegExp':
                 return {
                     type: 'RegExpLiteral',
-                    value: value.source,
+                    pattern: value.source,
                     flags: value.toString().match(/\/(\w*)$/)[1]
                 };
 

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -34,7 +34,7 @@ var ValueBuilder = ASTVisitor.extend({
         return node.value;
     },
 
-    visitNumericLiteral: function(node) {
+    visitNumberLiteral: function(node) {
         return node.value;
     },
 
@@ -483,7 +483,7 @@ var values = {
                 } else if (value === -Infinity) {
                     return { type: 'InfinityLiteral', negative: true };
                 } else {
-                    return { type: 'NumericLiteral', value: value };
+                    return { type: 'NumberLiteral', value: value };
                 }
                 break;   // silence ESLint
 

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -63,7 +63,7 @@ var ValueBuilder = ASTVisitor.extend({
     },
 
     visitFilterLiteral: function(node) {
-        return new Filter(node.ast, node.text);
+        return new Filter(node.ast, node.source);
     },
 
     visitArrayLiteral: function(node) {
@@ -371,7 +371,7 @@ var values = {
                 return value.valueOf();
 
             case 'Filter':
-                return value.text;
+                return value.source;
 
             case 'Array':
                 return _.map(value, this.toJSONCompatible, this);
@@ -404,7 +404,7 @@ var values = {
                 return value.valueOf();
 
             case 'Filter':
-                return value.text;
+                return value.source;
 
             case 'Array':
             case 'Object':
@@ -441,7 +441,7 @@ var values = {
                 // can't use it and we need to use a pseudo-syntax here. If
                 // filters ever become representable in source, this code should
                 // be changed to match that representation.
-                return 'filter(' + value.text + ')';
+                return 'filter(' + value.source + ')';
 
             case 'Array':
                 if (_.isEmpty(value)) { return '[]'; }
@@ -504,7 +504,7 @@ var values = {
                 return { type: 'DurationLiteral', value: value.valueOf() };
 
             case 'Filter':
-                return { type: 'FilterLiteral', ast: value.ast, text: value.text };
+                return { type: 'FilterLiteral', ast: value.ast, source: value.source };
 
             case 'Array':
                 return { type: 'ArrayLiteral', elements: _.map(value, values.toAST) };

--- a/test/cli/location-stripper.spec.js
+++ b/test/cli/location-stripper.spec.js
@@ -21,7 +21,7 @@ describe('LocationStripper', function() {
             expect(ast.elements[0].elements[0]).not.to.have.property('location');
             // ProcOption(id = "limit")
             expect(ast.elements[0].elements[0].options[0]).not.to.have.property('location');
-            // NumericLiteral(value = 5)
+            // NumberLiteral(value = 5)
             expect(ast.elements[0].elements[0].options[0].expr).not.to.have.property('location');
         });
     });

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -134,7 +134,7 @@ describe('FilterJSCompiler', function() {
         expect('a == "${"ab" + "cd"}"').to.filter(POINTS_VALUES, [ { a: 'abcd' } ]);
     });
 
-    it('compiles RegularExpressionLiteral correctly', function() {
+    it('compiles RegExpLiteral correctly', function() {
         expect('a == /abcd/').to.filter(POINTS_VALUES, [ { a: /abcd/ } ]);
         expect('a == /abcd/gim').to.filter(POINTS_VALUES, [ { a: /abcd/gim } ]);
     });

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -51,7 +51,7 @@ describe('FilterJSCompiler', function() {
             type: 'BinaryExpression',
             operator: '<',
             left: { type: 'Variable', name: 'a' },
-            right: { type: 'NumericLiteral', value: 5 }
+            right: { type: 'NumberLiteral', value: 5 }
         }
     };
 
@@ -110,7 +110,7 @@ describe('FilterJSCompiler', function() {
         expect('a == false').to.filter(POINTS_VALUES, [ { a: false } ]);
     });
 
-    it('compiles NumericLiteral correctly', function() {
+    it('compiles NumberLiteral correctly', function() {
         expect('a == 5').to.filter(POINTS_VALUES, [ { a: 5 } ]);
     });
 

--- a/test/compiler/inputs.spec.js
+++ b/test/compiler/inputs.spec.js
@@ -98,7 +98,7 @@ describe('Juttle inputs', function() {
                                                  type: 'BinaryExpression',
                                                  operator: '<',
                                                  left: { type: 'Variable', name: 'c' },
-                                                 right: { type: 'NumericLiteral', value: 2 }
+                                                 right: { type: 'NumberLiteral', value: 2 }
                                              }
                                          },
                                          'c < 2'

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -115,7 +115,7 @@ describe('Juttle parser', function() {
                     value: '1970-01-01T00:00:00.000Z'
                 },
                 display_limit: {
-                    type: 'NumericLiteral',
+                    type: 'NumberLiteral',
                     location: {
                         filename: 'main',
                         start: { offset: 22, line: 1, column: 23 },

--- a/test/runtime/types/filter.spec.js
+++ b/test/runtime/types/filter.spec.js
@@ -13,7 +13,7 @@ describe('Filter', function() {
                     type: 'BinaryExpression',
                     operator: '==',
                     left: { type: 'Field', name: 'a' },
-                    right: { type: 'NumericLiteral', value: 5 }
+                    right: { type: 'NumberLiteral', value: 5 }
                 }
             };
             var text = 'a == 5';

--- a/test/runtime/types/filter.spec.js
+++ b/test/runtime/types/filter.spec.js
@@ -16,11 +16,11 @@ describe('Filter', function() {
                     right: { type: 'NumberLiteral', value: 5 }
                 }
             };
-            var text = 'a == 5';
-            var filter = new Filter(ast, text);
+            var source = 'a == 5';
+            var filter = new Filter(ast, source);
 
             expect(filter.ast).to.eq(ast);
-            expect(filter.text).to.eq(text);
+            expect(filter.source).to.eq(source);
         });
     });
 });

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -519,11 +519,11 @@ describe('Values tests', function () {
         },
         {
             value: /abcd/i,
-            ast: { type: 'RegExpLiteral', value: 'abcd', flags: 'i' }
+            ast: { type: 'RegExpLiteral', pattern: 'abcd', flags: 'i' }
         },
         {
             value: /abcd/gim,
-            ast: { type: 'RegExpLiteral', value: 'abcd', flags: 'gim' }
+            ast: { type: 'RegExpLiteral', pattern: 'abcd', flags: 'gim' }
         },
         {
             value: new JuttleMoment('2015-01-01T00:00:05.000Z'),

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -519,11 +519,11 @@ describe('Values tests', function () {
         },
         {
             value: /abcd/i,
-            ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'i' }
+            ast: { type: 'RegExpLiteral', value: 'abcd', flags: 'i' }
         },
         {
             value: /abcd/gim,
-            ast: { type: 'RegularExpressionLiteral', value: 'abcd', flags: 'gim' }
+            ast: { type: 'RegExpLiteral', value: 'abcd', flags: 'gim' }
         },
         {
             value: new JuttleMoment('2015-01-01T00:00:05.000Z'),

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -13,7 +13,7 @@ describe('Values tests', function () {
             type: 'BinaryExpression',
             operator: '<',
             left: { type: 'Variable', name: 'a' },
-            right: { type: 'NumericLiteral', value: 5 }
+            right: { type: 'NumberLiteral', value: 5 }
         }
     };
 
@@ -499,7 +499,7 @@ describe('Values tests', function () {
         },
         {
             value: 5,
-            ast: { type: 'NumericLiteral', value: 5 }
+            ast: { type: 'NumberLiteral', value: 5 }
         },
         {
             value: Infinity,
@@ -542,9 +542,9 @@ describe('Values tests', function () {
             ast: {
                 type: 'ArrayLiteral',
                 elements: [
-                    { type: 'NumericLiteral', value: 1 },
-                    { type: 'NumericLiteral', value: 2 },
-                    { type: 'NumericLiteral', value: 3 }
+                    { type: 'NumberLiteral', value: 1 },
+                    { type: 'NumberLiteral', value: 2 },
+                    { type: 'NumberLiteral', value: 3 }
                 ]
             }
         },
@@ -556,17 +556,17 @@ describe('Values tests', function () {
                     {
                         type: 'ObjectProperty',
                         key: { type: 'StringLiteral', value: 'a' },
-                        value: { type: 'NumericLiteral', value: 1 }
+                        value: { type: 'NumberLiteral', value: 1 }
                     },
                     {
                         type: 'ObjectProperty',
                         key: { type: 'StringLiteral', value: 'b' },
-                        value: { type: 'NumericLiteral', value: 2 }
+                        value: { type: 'NumberLiteral', value: 2 }
                     },
                     {
                         type: 'ObjectProperty',
                         key: { type: 'StringLiteral', value: 'c' },
-                        value: { type: 'NumericLiteral', value: 3 }
+                        value: { type: 'NumberLiteral', value: 3 }
                     }
                 ]
             }

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -535,7 +535,7 @@ describe('Values tests', function () {
         },
         {
             value: new Filter(FILTER_AST, 'a < 5'),
-            ast: { type: 'FilterLiteral', ast: FILTER_AST, text: 'a < 5' }
+            ast: { type: 'FilterLiteral', ast: FILTER_AST, source: 'a < 5' }
         },
         {
             value: [ 1, 2, 3 ],


### PR DESCRIPTION
Small cleanups of AST nodes representing literals. They can get passed to adapters as part of filter expression AST so they form a part of the adapter API. The idea of this PR is to stabilize this part of the API and reduce need of future changes here.

Part of work on #319.