### PR TITLE
enable append for file adapter on write

### DIFF
--- a/docs/adapters/file.md
+++ b/docs/adapters/file.md
@@ -85,6 +85,7 @@ Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
 `-file`           | File path on the local filesystem, absolute or relative to the current working directory  | Yes
 `-format`         | Input input format: `csv` for [CSV](https://tools.ietf.org/html/rfc4180) data, `json` for [JSON](https://tools.ietf.org/html/rfc7159) data, or `jsonl` for [JSON lines](http://jsonlines.org/) data | No; defaults to `json`
+`-append`         | Specifies if the data should be appended to the file or if the file should be overwritten | No, defaults to `false`
 
 If the file already exists it will be truncated and overwritten.
 

--- a/lib/adapters/file/write.js
+++ b/lib/adapters/file/write.js
@@ -11,10 +11,11 @@ class WriteFile extends AdapterWrite {
 
         this.filename = options.file;
         this.format = options.format ? options.format : 'json'; // default to json
+        this.append = options.append;
     }
 
     static allowedOptions() {
-        return ['file', 'format'];
+        return ['file', 'format', 'append'];
     }
 
     static requiredOptions() {
@@ -22,8 +23,29 @@ class WriteFile extends AdapterWrite {
     }
 
     start() {
-        var stream = fs.createWriteStream(this.filename);
-        this.serializer = serializers.getSerializer(this.format, stream, {});
+        var options = {};
+        var stream;
+       
+        if (this.append) {
+            try {
+                fs.accessSync(this.filename);
+                options.append = true;
+                if (this.format === 'csv') { 
+                    // we need to provide the input stream for the csv format
+                    options.input = fs.createReadStream(this.filename);
+                }
+            } catch (err) { 
+                if (!err.toString().match(/ENOENT/))  {
+                    throw err;
+                }
+            }
+        }
+
+        stream = fs.createWriteStream(this.filename, {
+            flags: options.append ? 'a' : 'w'
+        });
+
+        this.serializer = serializers.getSerializer(this.format, stream, options);
 
         this.serializer.on('error', (err) => {
             // during write no fatal errors


### PR DESCRIPTION
fixes #286

simple change to make `-append` option available for the file adapter
which only works currently with csv and jsonl.