### PR TITLE
fix flakey grok test

### DIFF
--- a/test/adapters/parsers/csv.spec.js
+++ b/test/adapters/parsers/csv.spec.js
@@ -95,26 +95,26 @@ describe('parsers/csv', function() {
 
         return serializer.done()
         .then(() => {
-            stream.end();
+            stream.end(function() {
+                var csv = parsers.getParser('csv', {
+                    optimization: {
+                        type: 'head',
+                        limit: 1
+                    }
+                });
 
-            var csv = parsers.getParser('csv', {
-                optimization: {
-                    type: 'head',
-                    limit: 1
-                }
-            });
-
-            var results = [];
-            return csv.parseStream(fs.createReadStream(tmpFilename), function(result) {
-                results.push(result);
-            })
-            .then(function() {
-                expect(results.length).to.be.equal(2); // 1 point + empty batch
-                expect(csv.totalRead).to.be.lessThan(40);
-                expect(csv.totalParsed).to.equal(2); // we always parse one ahead
-            })
-            .finally(function() {
-                fs.unlinkSync(tmpFilename);
+                var results = [];
+                return csv.parseStream(fs.createReadStream(tmpFilename), function(result) {
+                    results.push(result);
+                })
+                .then(function() {
+                    expect(results.length).to.be.equal(2); // 1 point + empty batch
+                    expect(csv.totalRead).to.be.lessThan(40);
+                    expect(csv.totalParsed).to.equal(2); // we always parse one ahead
+                })
+                .finally(function() {
+                    fs.unlinkSync(tmpFilename);
+                });
             });
         });
     });

--- a/test/adapters/parsers/grok.spec.js
+++ b/test/adapters/parsers/grok.spec.js
@@ -97,7 +97,7 @@ describe('parsers/grok', function() {
         });
     });
 
-    withGrokIt('stops emitting values after the optimization.limit', function() {
+    withGrokIt('stops emitting values after the optimization.limit', function(done) {
         // the read ahead buffer of the parser will always read more points
         // that we actually want to parse but lets make sure this does not // read the whole file by writing out enough data
         var tmpFilename = tmp.tmpNameSync();
@@ -107,27 +107,28 @@ describe('parsers/grok', function() {
                          parseInt(Math.random()*64*1024) +
                          ']: ' + Array(1024).join('X') + '\n');
         }
-        stream.end();
+        stream.end(function() { 
+            var parser = parsers.getParser('grok', {
+                pattern: '%{SYSLOGLINE}',
+                optimization: {
+                    type: 'head',
+                    limit: 1
+                }
+            });
 
-        var parser = parsers.getParser('grok', {
-            pattern: '%{SYSLOGLINE}',
-            optimization: {
-                type: 'head',
-                limit: 1
-            }
-        });
-
-        var results = [];
-        return parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
-            results.push(result);
-        })
-        .then(function() {
-            expect(results.length).to.be.equal(2); // 1 point + empty batch
-            expect(parser.totalRead).to.be.lessThan(500);
-            expect(parser.totalParsed).to.equal(2); // always parse one ahead
-        })
-        .finally(function() {
-            fs.unlinkSync(tmpFilename);
+            var results = [];
+            parser.parseStream(fs.createReadStream(tmpFilename), function(result) {
+                results.push(result);
+            })
+            .then(function() {
+                expect(results.length).to.be.equal(2); // 1 point + empty batch
+                expect(parser.totalRead).to.be.lessThan(500);
+                expect(parser.totalParsed).to.equal(2); // always parse one ahead
+            })
+            .finally(function() {
+                fs.unlinkSync(tmpFilename);
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
fixes #403

we were not waiting for the callback from the `stream.end()` call and
therefore there was a very small window of time where we could have
partially written out data to the file and would fail to read back all
of the expected data.