### PR TITLE
Write table properly for multiple tables.

### DIFF
--- a/lib/views/table.js
+++ b/lib/views/table.js
@@ -229,8 +229,8 @@ var TableView = View.extend({
                 table.push(values.map(self._valueFormatter.bind(self)));
             });
 
-            if (self.title) {
-                self.fstream.write(self.title + '\n');
+            if (self.options.title) {
+                self.fstream.write(self.options.title + '\n');
             }
             self.fstream.write(table.toString() + '\n');
         } else {

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -259,6 +259,27 @@ describe('Juttle CLI Tests', function() {
                 });
         });
 
+        it('properly shows titles for multiple tables', function() {
+            return runJuttle(['-e', 'emit -from :2015-01-01: -limit 1 | (put sink = 1 | view table -title "Table1"; put sink = 2 | view table -title "Table2")'])
+                .then(function(result) {
+                    expect(result.stdout).equals(
+'Table1\n' +
+'┌──────────────────────────┬──────┐\n' +
+'│ time                     │ sink │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:00.000Z │ 1    │\n' +
+'└──────────────────────────┴──────┘\n' +
+'Table2\n' +
+'┌──────────────────────────┬──────┐\n' +
+'│ time                     │ sink │\n' +
+'├──────────────────────────┼──────┤\n' +
+'│ 2015-01-01T00:00:00.000Z │ 2    │\n' +
+'└──────────────────────────┴──────┘\n');
+                    expect(result.code).to.equal(0);
+                    expect(result.stderr).to.equal('');
+                });
+        });
+
         it('interleaves output from multiple table views in progressive mode', function() {
             return runJuttle(['-e', 'emit -from :2015-01-01: -limit 2 | (put sink = 1 | view table -progressive true; put sink = 2 | view table -progressive true)'])
                 .then(function(result) {


### PR DESCRIPTION
The bug was actually that table titles were not being written when
-progressive was set to false. It just happens that when specifying
multiple tables, -progressive gets set to false by default.

Use the right option (self.options.title) instead of self.title.

Also add a test to cover this so we'll know if it breaks again.

This fixes #350.

@dmehra 