### PR TITLE
adapters: support an explicit eof bit in the read return

### DIFF
--- a/lib/adapters/stdio/read.js
+++ b/lib/adapters/stdio/read.js
@@ -4,7 +4,6 @@ var _ = require('underscore');
 var AdapterRead = require('../../runtime/adapter-read');
 var parsers = require('../parsers');
 var errors = require('../../errors');
-var JuttleMoment = require('../../runtime/types/juttle-moment');
 
 class ReadStdio extends AdapterRead {
     constructor(options, params) {
@@ -56,7 +55,7 @@ class ReadStdio extends AdapterRead {
         .then(() => {
             return {
                 points: this.points,
-                readEnd: new JuttleMoment(Infinity)
+                eof: true
             };
         });
     }

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -160,11 +160,12 @@ var Read = source.extend({
             this.readState = result.state;
 
             // The adapter indicates that it's completed reading all points up
-            // to the given end time by returning the ending time in readEnd.
+            // to the given end time by either returning eof:true or returning
+            // the ending time in readEnd.
             var nextRead;
-            if (result.readEnd) {
+            if (result.eof || result.readEnd) {
                 // Once the full read time range has been read, we're all done
-                if (result.readEnd.isEnd() || (this.to && result.readEnd.eq(this.to))) {
+                if (result.eof || result.readEnd.isEnd() || (this.to && result.readEnd.eq(this.to))) {
                     this.logger.debug('read done');
                     this.emit_eof();
                     return;

--- a/test/runtime/test-adapter.js
+++ b/test/runtime/test-adapter.js
@@ -11,7 +11,6 @@ var _ = require('underscore');
 var store = {};
 var AdapterRead = require('../../lib/runtime/adapter-read');
 var AdapterWrite = require('../../lib/runtime/adapter-write');
-var JuttleMoment = require('../../lib/runtime/types/juttle-moment');
 var errors = require('../../lib/errors');
 
 function TestAdapter(config) {
@@ -82,7 +81,7 @@ function TestAdapter(config) {
 
             return Promise.resolve({
                 points: points,
-                readEnd: new JuttleMoment(Infinity)
+                eof: true
             });
         }
     }


### PR DESCRIPTION
Instead of requiring the adapter to create an infinite JuttleMoment
to indicate that it's done reading, also check for an eof bit in the
read() response.