### PR TITLE
Make reduce -every emit marks at the end of epoch

### DIFF
--- a/lib/runtime/procs/periodic-fanin.js
+++ b/lib/runtime/procs/periodic-fanin.js
@@ -141,8 +141,7 @@ class periodic_fanin extends oops_fanin {
             if (!this.epoch) {
                 this.first_epoch(this.next_epoch);
             } else {
-                var out = this.advance_epoch(this.next_epoch);
-                this.emit(out);
+                this.other_epoch(this.next_epoch);
             }
 
             this.epoch = this.next_epoch;
@@ -188,6 +187,12 @@ class periodic_fanin extends oops_fanin {
         var out = this.advance_epoch(epoch);
         this.emit(out);
     }
+
+    other_epoch(epoch) {
+        var out = this.advance_epoch(epoch);
+        this.emit(out);
+    }
+
     advance_epoch(epoch) {
         throw new Error('write me!');
     }

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -97,6 +97,7 @@ class reduce_base extends periodic_fanin {
         if (this.to && this.to.lte(time)) {
             var out = this.advance_epoch(this.to);
             this.emit(out);
+            this.emit_mark(this.to);
         }
         return false;
     }
@@ -321,15 +322,21 @@ class reduce_every extends reduce_base {
     //
     // mark() and process() are from periodic. tick() from reduce_runner_funcs
     //
-    emit_mark(time) {
-        // this should ever happen, but let's be sure.
-        throw new Error('ereduce: somebody called emit_mark!');
+
+    other_epoch(epoch) {
+        super.other_epoch(epoch);
+        this.emit_mark(epoch);
     }
+
+    //
+    // mark() and process() are from periodic. tick() from reduce_runner_funcs
+    //
     periodic_eof(from) {
         if (this.batch_size) {
             // run once more for a trailing partial batch of points
             var out = this.advance_epoch(this.next_epoch);
             this.emit(out);
+            this.emit_mark(this.next_epoch);
         }
         this.emit_eof();
     }

--- a/lib/stdlib/predict.juttle
+++ b/lib/stdlib/predict.juttle
@@ -250,6 +250,7 @@ export sub predict(field = "value", over = :w:, every=null, pct=0.5, nonneg=true
                    detrend=true, deseason=true, denoise=true, revise=true) {
     const __every = every ?? subdivide_duration(over);
     reduce -every __every time= Date.quantize(first(time), __every), *field = percentile(field, pct)
+    | unbatch
     | trend -field field -every __every -over over -revise revise
     | put T = detrend ? T : 0
     | put __detrend = *field  - T

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
@@ -18,10 +18,12 @@ resetting in order to replay the correct window of points at each epoch.
     emit -from Date.new(0) -limit 8
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -70,12 +72,14 @@ results are same as group A's plus 10.
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2 ;
-        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2 ;
+            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;
@@ -184,10 +188,12 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     emit -from Date.new(0) -limit 4 -every :4s:
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -258,12 +264,14 @@ a group witness affects reset/teardown, and this is not true in a non-groupby se
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
-        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
+            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;
@@ -419,10 +427,12 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     emit -from Date.new(0) -limit 4 -every :8s:
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -529,12 +539,14 @@ a non-groupby setting.
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
-        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        (
+            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
+            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
+        ) | unbatch;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -187,8 +187,8 @@ reduce -every without teardown (-reset false)
     { "min": 1, "time": "1970-01-01T00:00:00.005Z"}
     { "min": 1, "time": "1970-01-01T00:00:00.010Z"}
 
-reduce -every ignores upstream batches and does not emit any
------------------------------------------------------------
+reduce -every emits marks at batch boundaries
+---------------------------------------------
 
 ### Juttle
 
@@ -196,13 +196,16 @@ reduce -every ignores upstream batches and does not emit any
     | batch :.001s:
     | reduce -every :0.002s: a=count()
     | put c=count()
-    | view result
+    | view result -marks true -times true
 
 ### Output
 
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.002Z"}
-    {"a": 2, "c": 2, "time": "1970-01-01T00:00:00.004Z"}
-    {"a": 2, "c": 3, "time": "1970-01-01T00:00:00.006Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.002Z"}
+    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.004Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.004Z"}
+    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.006Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.006Z"}
 
 cascade of every-driven reducers
 ----------------------------------

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -493,11 +493,13 @@ complains about out-of-order assignment to the `time` field in -every mode
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 6 | reduce -reset false -every :s: time = last(time) - 2 * count() * :s: | view result
+    emit -from Date.new(0) -limit 4 | reduce -reset false -every :s: time = last(time) - 2 * count() * :s: | view result
 
 ### Warnings
 
-   * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1969-12-31T23:59:58.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:56.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:55.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped
 
 complains about out-of-order assignment to the `time` field in batch mode
 -----------------------------------------------------
@@ -521,11 +523,12 @@ complains about out-of-order assignment to the `time` field with -every
 
 ### Warnings
 
-   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
+   * out-of-order assignment of time 1970-01-01T00:00:00.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped
 
 ### Output
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
-    { time: "1970-01-01T00:00:00.000Z", n: 3 }
 
 emits grouped results in order when time is assigned
 -----------------------------------------------------

--- a/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
@@ -37,6 +37,7 @@ reduce + put delta pattern works like reduce delta sorta-aughta
     | put n = count()
     | filter n < 4 or n > 5
     | reduce -every :0.1s: n = last(n)
+    | unbatch
     | put delta = delta("n", "empty")
     | remove n
     | view result


### PR DESCRIPTION
`reduce -every` emits marks at the end of each epoch. This also requires changes for sort and tests that depend on the old behavior.