### PR TITLE
Simplify Filter AST

### DIFF
--- a/lib/compiler/ast-transformer.js
+++ b/lib/compiler/ast-transformer.js
@@ -1,0 +1,46 @@
+'use strict';
+
+let ASTVisitor = require('./ast-visitor');
+let _ = require('underscore');
+
+// Base class for implementing AST transformers.
+//
+// AST transformer is a special kind of AST visitor, where each visit* method
+// returns a node which then replaces the node the method was called on in the
+// AST.
+//
+// To implement a transformer, create a class derived from ASTTransformer and
+// override visit* methods for node types you are interested in. The default
+// implementation of visit* methods visits child nodes (passing around
+// arguments) and returns a clone of the node the method was called on with
+// child nodes replaced by their transformed versions.
+class ASTTransformer extends ASTVisitor {
+    transform(ast) {
+        return this.visit(ast);
+    }
+}
+
+_.each(ASTVisitor.NODE_CHILDREN, (props, type) => {
+    // A function expression needs to be used here instead of an arrow function,
+    // otherwise "this" will have a wrong value inside the defined method.
+    ASTVisitor.prototype['visit' + type] = function(node) {
+        let extraArgs = Array.prototype.slice.call(arguments, 1);
+
+        return _.mapObject(node, (value, prop) => {
+            let transform = _.indexOf(props, prop) !== -1;
+            if (!transform) {
+                return value;
+            }
+
+            if (_.isArray(value)) {
+                return _.map(value, (element) =>
+                    element !== null ? this.visit.apply(this, [element].concat(extraArgs)) : null
+                );
+            } else {
+                return value !== null ? this.visit.apply(this, [value].concat(extraArgs)) : null;
+            }
+        });
+    };
+});
+
+module.exports = ASTTransformer;

--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -111,6 +111,8 @@ class ASTVisitor {
     }
 }
 
+ASTVisitor.NODE_CHILDREN = NODE_CHILDREN;
+
 // BEGIN DEBUGGING FUNCTIONS
 
 function checkNode(node) {

--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -48,6 +48,7 @@ var NODE_CHILDREN = {
     /* Filter expressions */
     ExpressionFilterTerm:     ['expression'],
     SimpleFilterTerm:         ['expression'],
+    FulltextFilterTerm:       ['text'],
 
     /* Procs (sorted alphabetically) */
     FieldListArgProc:         ['options', 'columns', 'groupby'],

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -203,21 +203,8 @@ class FilterJSCompiler extends ASTVisitor {
             + this.visit(node.consequent);
     }
 
-    visitExpressionFilterTerm(node) {
-        return this.visit(node.expression);
-    }
-
-    visitSimpleFilterTerm(node) {
-        switch (node.expression.type) {
-            case 'StringLiteral':
-                throw errors.compileError('NO-FREE-TEXT');
-
-            case 'FilterLiteral':
-                return this.visit(node.expression);
-
-            default:
-                throw new Error('Invalid node type: ' + node.expression.type + '.');
-        }
+    visitFulltextFilterTerm(node) {
+        throw errors.compileError('NO-FREE-TEXT');
     }
 }
 

--- a/lib/compiler/filters/filter-simplifier.js
+++ b/lib/compiler/filters/filter-simplifier.js
@@ -1,0 +1,35 @@
+'use strict';
+
+let ASTTransformer = require('../ast-transformer');
+let _ = require('underscore');
+
+// Simplifies filter expression AST before it is passed to a compiler. This is
+// mostly to reduce boilerplate code in adapters.
+class FilterSimplifier extends ASTTransformer {
+    simplify(ast) {
+        return this.transform(ast);
+    }
+
+    visitExpressionFilterTerm(node) {
+        return this.visit(node.expression);
+    }
+
+    visitSimpleFilterTerm(node) {
+        switch (node.expression.type) {
+            case 'StringLiteral':
+                return _.chain(node)
+                    .clone()
+                    .extend({ type: 'FulltextFilterTerm', text: node.expression.value })
+                    .omit('expression')
+                    .value();
+
+            case 'FilterLiteral':
+                return this.visit(node.expression.ast);
+
+            default:
+                throw new Error('Invalid node type: ' + node.expression.type + '.');
+        }
+    }
+}
+
+module.exports = FilterSimplifier;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -3,6 +3,7 @@
 var _ = require('underscore');
 var CodeGenerator = require('./code-generator');
 var filters = require('./filters');
+var FilterSimplifier = require('./filters/filter-simplifier');
 var StaticFilterChecker = filters.StaticFilterChecker;
 var DynamicFilterChecker = filters.DynamicFilterChecker;
 var FilterJSCompiler = filters.FilterJSCompiler;
@@ -440,6 +441,9 @@ class GraphCompiler extends CodeGenerator {
         if (ast.filter) {
             var checker = new StaticFilterChecker();
             checker.check(ast.filter);
+
+            var simplifier = new FilterSimplifier();
+            ast.filter = simplifier.simplify(ast.filter);
         }
 
         var params = {
@@ -457,6 +461,9 @@ class GraphCompiler extends CodeGenerator {
         var checker = new DynamicFilterChecker();
         checker.check(ast.filter);
 
+        var simplifier = new FilterSimplifier();
+        ast.filter = simplifier.simplify(ast.filter);
+
         var compiler = new FilterJSCompiler();
         var code = compiler.compile(ast.filter);
 
@@ -466,6 +473,8 @@ class GraphCompiler extends CodeGenerator {
         var checker = new DynamicFilterChecker();
         _.each (ast.filters, (filter) => { checker.check(filter);});
 
+        var simplifier = new FilterSimplifier();
+        ast.filters = _.map(ast.filters, (filter) => simplifier.simplify(filter));
 
         var filters = _.map(ast.filters, function(filter) {
             var compiler = new FilterJSCompiler();

--- a/test/compiler/ast-transformer.spec.js
+++ b/test/compiler/ast-transformer.spec.js
@@ -1,0 +1,122 @@
+'use strict';
+
+let chai = require('chai');
+let expect = chai.expect;
+
+let _ = require('underscore');
+
+let ASTTransformer = require('../../lib/compiler/ast-transformer');
+
+describe('ASTTransformer', () => {
+    describe('transform', () => {
+        class SimpleTransformer extends ASTTransformer {
+            visitNumberLiteral(node) {
+                return _.extend(_.clone(node), { value: 2 * node.value });
+            }
+        }
+
+        class ArgPassingTransformer extends ASTTransformer {
+            constructor() {
+                super();
+
+                this.args = [];
+            }
+
+            visitUnaryExpression(node) {
+                return _.extend(_.clone(node), {
+                    argument: this.visit(node.argument, 1, 2, 3)
+                });
+            }
+
+            visitArrayLiteral(node) {
+                return _.extend(_.clone(node), {
+                    elements: _.map(node.elements, (element, index) =>
+                        this.visit(element, index * 3 + 1, index * 3 + 2, index * 3 + 3)
+                    )
+                });
+            }
+
+            visitNumberLiteral(node) {
+                this.args.push(arguments);
+
+                return _.extend(_.clone(node), { value: 2 * node.value });
+            }
+        }
+
+        it('transforms toplevel nodes', () => {
+            let transformer = new SimpleTransformer();
+            let ast = { type: 'NumberLiteral', value: 5 };
+
+            expect(transformer.transform(ast)).to.deep.equal({
+                type: 'NumberLiteral',
+                value: 10
+            });
+        });
+
+        it('transforms nested nodes (simple)', () => {
+            let transformer = new SimpleTransformer();
+            let ast = {
+                type: 'UnaryExpression',
+                argument: { type: 'NumberLiteral', value: 5 }
+            };
+
+            expect(transformer.transform(ast)).to.deep.equal({
+                type: 'UnaryExpression',
+                argument: { type: 'NumberLiteral', value: 10 }
+            });
+        });
+
+        it('passes additional arguments for nested nodes (simple)', () => {
+            let transformer = new ArgPassingTransformer();
+            let ast = {
+                type: 'UnaryExpression',
+                argument: { type: 'NumberLiteral', value: 5 }
+            };
+
+            transformer.transform(ast);
+
+            expect(transformer.args).to.have.length(1);
+            expect(Array.prototype.slice.call(transformer.args[0], 1)).to.deep.equal([1, 2, 3]);
+        });
+
+        it('transforms nested nodes (array)', () => {
+            let transformer = new ArgPassingTransformer();
+            let ast = {
+                type: 'ArrayLiteral',
+                elements: [
+                    { type: 'NumberLiteral', value: 1 },
+                    { type: 'NumberLiteral', value: 2 },
+                    { type: 'NumberLiteral', value: 3 }
+                ]
+            };
+
+            expect(transformer.transform(ast)).to.deep.equal({
+                type: 'ArrayLiteral',
+                elements: [
+                    { type: 'NumberLiteral', value: 2 },
+                    { type: 'NumberLiteral', value: 4 },
+                    { type: 'NumberLiteral', value: 6 }
+                ]
+            });
+        });
+
+        it('passes additional arguments for nested nodes (array)', () => {
+            let transformer = new ArgPassingTransformer();
+            let ast = {
+                type: 'ArrayLiteral',
+                elements: [
+                    { type: 'NumberLiteral', value: 1 },
+                    { type: 'NumberLiteral', value: 2 },
+                    { type: 'NumberLiteral', value: 3 }
+                ]
+            };
+
+            transformer.transform(ast);
+
+            expect(transformer.args).to.have.length(3);
+            expect(Array.prototype.slice.call(transformer.args[0], 1)).to.deep.equal([1, 2, 3]);
+            expect(Array.prototype.slice.call(transformer.args[1], 1)).to.deep.equal([4, 5, 6]);
+            expect(Array.prototype.slice.call(transformer.args[2], 1)).to.deep.equal([7, 8, 9]);
+        });
+    });
+});

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -4,6 +4,7 @@ var chai = require('chai');
 var expect = chai.expect;
 
 var Filter = require('../../../lib/runtime/types/filter');
+var FilterSimplifier = require('../../../lib/compiler/filters/filter-simplifier');
 var JuttleMoment = require('../../../lib/runtime/types/juttle-moment');
 var SemanticPass = require('../../../lib/compiler/semantic');
 var _ = require('underscore');
@@ -22,6 +23,9 @@ function filterPoints(filter, points) {
     // references.
     var semantic = new SemanticPass();
     ast = semantic.sa_expr(ast);
+
+    var simplifier = new FilterSimplifier();
+    ast = simplifier.simplify(ast);
 
     var compiler = new FilterJSCompiler();
     var fn = eval(compiler.compile(ast));

--- a/test/compiler/filters/filter-simplifier.spec.js
+++ b/test/compiler/filters/filter-simplifier.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+let chai = require('chai');
+let expect = chai.expect;
+
+let parser = require('../../../lib/parser');
+
+let FilterSimplifier = require('../../../lib/compiler/filters/filter-simplifier');
+
+describe('FilterSimplifier', () => {
+    describe('simplify', () => {
+        it('replaces ExpressionFilterTerms by their expressions', () => {
+            let simplifier = new FilterSimplifier();
+            let ast = parser.parseFilter('a < 5');
+
+            expect(ast.ast.type).to.equal('ExpressionFilterTerm');
+
+            let simplifiedAst = simplifier.simplify(ast);
+
+            expect(simplifiedAst.ast).to.deep.equal(ast.ast.expression);
+        });
+
+        it('replaces SimpleFilterTerms with a String child by FulltextFilterTerms', () => {
+            let simplifier = new FilterSimplifier();
+            let ast = parser.parseFilter('"abcd"');
+
+            expect(ast.ast.type).to.equal('SimpleFilterTerm');
+
+            let simplifiedAst = simplifier.simplify(ast);
+
+            expect(simplifiedAst.ast).to.deep.equal({
+                type: 'FulltextFilterTerm',
+                text: ast.ast.expression.value,
+                location: ast.ast.location
+            });
+        });
+
+        // SimpleFilterTerm nodes with a FilterLiteral child can't be tested
+        // because there is no filter literal syntax.
+    });
+});


### PR DESCRIPTION
Simplify filter expression AST before it is passed to a compiler. More specifically:

  1. Remove `ExpressionFilterTerm` nodes (which the compiler typically just passes-through).

  2. Replace `SimpleFilterTerm` nodes which contain `StringLiteral` (and thus represent FTS) with structurally simpler `FulltextFilterTerm` nodes.

  3. Replace `SimpleFilterTerm` nodes which contain `FilterLiteral` (and thus represent embedded filter expression coming from an input ) with the actual `FilterLiteral` AST (effectively inlining the literal).

These transformations are done using `FilterSimplifier`, which is an instance of newly introduced `ASTTransformer` — a special kind of visitor which transforms the tree.

Part of work on #320.