### PR TITLE
Implement StaticFilterCompiler

### DIFF
--- a/lib/compiler/filters/static-filter-compiler.js
+++ b/lib/compiler/filters/static-filter-compiler.js
@@ -1,0 +1,81 @@
+'use strict';
+
+let ASTVisitor = require('../ast-visitor');
+let errors = require('../../errors');
+
+// Base class for compilers that transform filter expression ASTs into native
+// queries. To be inherited and extended by adapters.
+class StaticFilterCompiler extends ASTVisitor {
+    compile(ast) {
+        return this.visit(ast);
+    }
+
+    visitNullLiteral(node) {
+        this.featureNotSupported(node, 'null');
+    }
+
+    visitBooleanLiteral(node) {
+        this.featureNotSupported(node, 'booleans');
+    }
+
+    visitNumberLiteral(node) {
+        this.featureNotSupported(node, 'numbers');
+    }
+
+    visitInfinityLiteral(node) {
+        this.featureNotSupported(node, 'Infinity');
+    }
+
+    visitNaNLiteral(node) {
+        this.featureNotSupported(node, 'NaN');
+    }
+
+    visitStringLiteral(node) {
+        this.featureNotSupported(node, 'strings');
+    }
+
+    visitRegExpLiteral(node) {
+        this.featureNotSupported(node, 'regular expressions');
+    }
+
+    visitMomentLiteral(node) {
+        this.featureNotSupported(node, 'moments');
+    }
+
+    visitDurationLiteral(node) {
+        this.featureNotSupported(node, 'durations');
+    }
+
+    visitArrayLiteral(node) {
+        this.featureNotSupported(node, 'arrays');
+    }
+
+    visitObjectLiteral(node) {
+        this.featureNotSupported(node, 'objects');
+    }
+
+    visitField(node) {
+        this.featureNotSupported(node, 'fields');
+    }
+
+    visitUnaryExpression(node) {
+        this.featureNotSupported(node, `the "${node.operator}" operator`);
+    }
+
+    visitBinaryExpression(node) {
+        this.featureNotSupported(node, `the "${node.operator}" operator`);
+    }
+
+    visitFulltextFilterTerm(node) {
+        this.featureNotSupported(node, 'fulltext search');
+    }
+
+    featureNotSupported(node, feature) {
+        throw errors.compileError('FILTER-FEATURE-NOT-SUPPORTED', {
+            feature: feature,
+            location: node.location
+        });
+    }
+}
+
+module.exports = StaticFilterCompiler;

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -118,5 +118,6 @@
   "INVALID-VIEW": "program refers to invalid client view \"{view}\"",
   "OPTION-SHOULD-BE-POSITIVE-INTEGER": "option {option} should be a positive integer",
   "OPTION-VALUE-EXCEEDED": "option {option} exceeded limit of {value}{extra}",
-  "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}"
+  "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
+  "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context."
 }

--- a/test/compiler/filters/filter-js-compiler.spec.js
+++ b/test/compiler/filters/filter-js-compiler.spec.js
@@ -4,12 +4,10 @@ var chai = require('chai');
 var expect = chai.expect;
 
 var Filter = require('../../../lib/runtime/types/filter');
-var FilterSimplifier = require('../../../lib/compiler/filters/filter-simplifier');
 var JuttleMoment = require('../../../lib/runtime/types/juttle-moment');
-var SemanticPass = require('../../../lib/compiler/semantic');
 var _ = require('underscore');
 var errors = require('../../../lib/errors');
-var parser = require('../../../lib/parser');
+var processFilter = require('./process-filter');
 
 var FilterJSCompiler = require('../../../lib/compiler/filters/filter-js-compiler.js');
 
@@ -17,18 +15,8 @@ var FilterJSCompiler = require('../../../lib/compiler/filters/filter-js-compiler
 var juttle = require('../../../lib/runtime/runtime');   // eslint-disable-line
 
 function filterPoints(filter, points) {
-    var ast = parser.parseFilter(filter).ast;
-
-    // We need to run the semantic pass to convert Variable nodes to field
-    // references.
-    var semantic = new SemanticPass();
-    ast = semantic.sa_expr(ast);
-
-    var simplifier = new FilterSimplifier();
-    ast = simplifier.simplify(ast);
-
     var compiler = new FilterJSCompiler();
-    var fn = eval(compiler.compile(ast));
+    var fn = eval(compiler.compile(processFilter(filter)));
 
     return _.filter(points, fn);
 }

--- a/test/compiler/filters/process-filter.js
+++ b/test/compiler/filters/process-filter.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var FilterSimplifier = require('../../../lib/compiler/filters/filter-simplifier');
+var SemanticPass = require('../../../lib/compiler/semantic');
+var parser = require('../../../lib/parser');
+
+// Converts a filter into an AST and processes it by running the semantic pass
+// and the filter simplifier so that it is ready to be compiled.
+function processFilter(filter) {
+    var ast = parser.parseFilter(filter).ast;
+
+    // We need to run the semantic pass to convert Variable nodes to field
+    // references.
+    var semantic = new SemanticPass();
+    ast = semantic.sa_expr(ast);
+
+    var simplifier = new FilterSimplifier();
+    ast = simplifier.simplify(ast);
+
+    return ast;
+}
+
+module.exports = processFilter;

--- a/test/compiler/filters/static-filter-compiler.spec.js
+++ b/test/compiler/filters/static-filter-compiler.spec.js
@@ -1,0 +1,159 @@
+'use strict';
+
+let chai = require('chai');
+let expect = chai.expect;
+
+let errors = require('../../../lib/errors');
+let processFilter = require('./process-filter');
+
+let StaticFilterCompiler = require('../../../lib/compiler/filters/static-filter-compiler');
+
+
+// A compiler which doesn't implement any method.
+class EmptyCompiler extends StaticFilterCompiler {
+}
+
+// A compiler which compiles only NumberLiterals inside BinaryExpressions.
+class NumberLiteralCompiler extends StaticFilterCompiler {
+    visitNumberLiteral() {
+    }
+
+    visitBinaryExpression(node) {
+        this.compile(node.left);
+        this.compile(node.right);
+    }
+}
+
+// A compiler which compiles only Fields inside BinaryExpressions.
+class FieldCompiler extends StaticFilterCompiler {
+    visitField() {
+    }
+
+    visitBinaryExpression(node) {
+        this.compile(node.left);
+        this.compile(node.right);
+    }
+}
+
+chai.use((chai, utils) => {
+    let Assertion = chai.Assertion;
+
+    // In method definitions, function expressions need to be used instead of
+    // arrow functions, otherwise "this" will have a wrong value inside defined
+    // methods.
+
+    Assertion.addMethod('failToCompile', function(compilerClass, message) {
+        let compiler = new compilerClass();
+
+        new Assertion(() => {
+            compiler.compile(processFilter(this._obj));
+        }).to.throw(errors.CompileError, message);
+    });
+});
+
+describe('StaticFilterCompiler', () => {
+    it('doesn\'t compile NullLiteral', () => {
+        expect('a < null').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support null in this context.'
+        );
+    });
+
+    it('doesn\'t compile BooleanLiteral', () => {
+        expect('a < true').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support booleans in this context.'
+        );
+    });
+
+    it('doesn\'t compile NumberLiteral', () => {
+        expect('a < 5').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support numbers in this context.'
+        );
+    });
+
+    it('doesn\'t compile InfinityLiteral', () => {
+        expect('a < Infinity').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support Infinity in this context.'
+        );
+    });
+
+    it('doesn\'t compile NaNLiteral', () => {
+        expect('a < NaN').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support NaN in this context.'
+        );
+    });
+
+    it('doesn\'t compile StringLiteral', () => {
+        expect('a < "abcd"').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support strings in this context.'
+        );
+    });
+
+    it('doesn\'t compile RegExpLiteral', () => {
+        expect('a < /abcd/').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support regular expressions in this context.'
+        );
+    });
+
+    it('doesn\'t compile MomentLiteral', () => {
+        expect('a < :2015-01-01T00:00:05.000Z:').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support moments in this context.'
+        );
+    });
+
+    it('doesn\'t compile DurationLiteral', () => {
+        expect('a < :00:00:05.000:').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support durations in this context.'
+        );
+    });
+
+    it('doesn\'t compile ArrayLiteral', () => {
+        expect('a < [ 1, 2, 3 ]').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support arrays in this context.'
+        );
+    });
+
+    it('doesn\'t compile ObjectLiteral', () => {
+        expect('a < { a: 1, b: 2, c: 3 }').to.failToCompile(
+            FieldCompiler,
+            'Filters do not support objects in this context.'
+        );
+    });
+
+    it('doesn\'t compile Field', () => {
+        expect('a < 5').to.failToCompile(
+            NumberLiteralCompiler,
+            'Filters do not support fields in this context.'
+        );
+    });
+
+    it('doesn\'t compile UnaryExpression', () => {
+        expect('NOT a < 5').to.failToCompile(
+            EmptyCompiler,
+            'Filters do not support the "NOT" operator in this context.'
+        );
+    });
+
+    it('doesn\'t compile BinaryExpression', () => {
+        expect('a < 5 AND b > 6').to.failToCompile(
+            EmptyCompiler,
+            'Filters do not support the "AND" operator in this context.'
+        );
+    });
+
+    it('doesn\'t compile FulltextFilterTerm', () => {
+        expect('"abcd"').to.failToCompile(
+            EmptyCompiler,
+            'Filters do not support fulltext search in this context.'
+        );
+    });
+});


### PR DESCRIPTION
`StaticFilterCompiler` is a base class for compilers that transform filter expression ASTs into native queries, to be inherited and extended by adapters.

Part of work on #320.