### PR TITLE
Rename the “ast” parameter to “node” in various compiler passes

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -113,66 +113,66 @@ class Build extends CodeGenerator {
     // of the code
     // XXX generalize this (google a deepcopy routine)
     //
-    build_code_ast(ast) {
+    build_code_ast(node) {
         var s;
         var self = this;
-        if (ast === null || typeof(ast) !== 'object') {
-            return JSON.stringify(ast);
+        if (node === null || typeof(node) !== 'object') {
+            return JSON.stringify(node);
         }
-        if (ast.type === 'Eval') {
-            return 'builder.value_ast(' + ast.expr + ')';
-        }
-
-        if (ast.type === 'function_uname') {
-            return 'builder.uname("' + ast.uname + '")';
+        if (node.type === 'Eval') {
+            return 'builder.value_ast(' + node.expr + ')';
         }
 
-        if (Array.isArray(ast)) {
+        if (node.type === 'function_uname') {
+            return 'builder.uname("' + node.uname + '")';
+        }
+
+        if (Array.isArray(node)) {
             s = '[\n' +
-                _.map(ast, function(el) { return self.build_code_ast(el); }).join(' ,') +
+                _.map(node, function(el) { return self.build_code_ast(el); }).join(' ,') +
                 ']\n';
         } else {
             s = '{\n' +
-                _.map(ast, function(val, key) {
+                _.map(node, function(val, key) {
                     return key + ': ' + self.build_code_ast(val);
                 }).join(' ,') +
                 '}';
         }
         return s;
     }
-    gen_BuiltinProc(ast) {
-        return this.gen_proc(ast);
+    gen_BuiltinProc(node) {
+        return this.gen_proc(node);
     }
-    gen_proc(ast) {
+    gen_proc(node) {
         var code;
-        ast.pname = {type:'Eval', expr:'builder.alloc_pname()' };
-        code = 'var ' + ast.uname + ' = ';
-        this.build_options(ast);
-        code += this.build_code_ast(ast) + ';';
-        code += 'builder.add_node(' + ast.uname + ');\n';
+        node.pname = {type:'Eval', expr:'builder.alloc_pname()' };
+        code = 'var ' + node.uname + ' = ';
+        this.build_options(node);
+        code += this.build_code_ast(node) + ';';
+        code += 'builder.add_node(' + node.uname + ');\n';
         this.emit(code);
-        return ast.uname;
+        return node.uname;
     }
-    gen_sub_call(ast) {
+    gen_sub_call(node) {
         var code = '';
         var self = this;
-        var subname = ast.op.type === 'Variable' ? ast.op.name : ast.op.object.name + '.' + ast.op.property.value;
-        code += 'var ' + ast.uname + ' = ' + ast.uname_sub + '.apply(';
+        var subname = node.op.type === 'Variable' ? node.op.name : node.op.object.name + '.' + node.op.property.value;
+        code += 'var ' + node.uname + ' = ' + node.uname_sub + '.apply(';
         code += 'null, ';
         code += 'builder.build_sub_args(';
-        code += JSON.stringify(ast.sub_sig) + ', [';
-        code += _.map(ast.options, function(option) {
+        code += JSON.stringify(node.sub_sig) + ', [';
+        code += _.map(node.options, function(option) {
             return '{ id: "' + option.id + '", ' + 'value: ' + self.gen_expr(option.expr) + ', location:' + JSON.stringify(option.location) + '}';
         }).join(', ');
         code += '], ';
         code += '"' + subname + '",\n';
-        code += JSON.stringify(ast.location) + '));\n';
+        code += JSON.stringify(node.location) + '));\n';
         this.emit(code);
-        return ast.uname;
+        return node.uname;
     }
-    build_options(ast) {
+    build_options(node) {
         var that = this;
-        ast.options = _.map(ast.options, function(option) {
+        node.options = _.map(node.options, function(option) {
             // when we finally set 'd' bit everywhere properly, we should be
             // able to uncomment this line without it throwing
             // if (!val.d) throw new Error ("All proc options should have 'd'!");
@@ -186,8 +186,8 @@ class Build extends CodeGenerator {
     }
 
     // statements that can appear inside subs or at the top level
-    gen_statement(ast, opts) {
-        switch (ast.type) {
+    gen_statement(node, opts) {
+        switch (node.type) {
             case 'SubDef':
             case 'FunctionDef':
             case 'ReducerDef':
@@ -199,38 +199,38 @@ class Build extends CodeGenerator {
             case 'SequentialGraph':
             case 'ImportStatement':
             case 'ParallelGraph':
-                return this['gen_' + ast.type](ast, opts);
+                return this['gen_' + node.type](node, opts);
             default:
-                throw new Error('unrecognized statement type ' + ast.type);
+                throw new Error('unrecognized statement type ' + node.type);
         }
     }
-    gen_ModuleDef(ast) {
+    gen_ModuleDef(node) {
         //
         // just spit out the module elements in the main scope since
         // the semantic pass flattened out all the module contents
         // with unames
         //
         var self = this;
-        _.each(ast.elements, function(stmt) {
-            self.gen_statement(stmt, {path_info: {mod: ast.name, sub: []}});
+        _.each(node.elements, function(stmt) {
+            self.gen_statement(stmt, {path_info: {mod: node.name, sub: []}});
         } );
     }
-    gen_SubDef(ast, opts) {
+    gen_SubDef(node, opts) {
         opts = opts || {};
         opts.path_info = opts.path_info || {};
         var flowgraph, returnVal;
-        var args = _.pluck(ast.args, 'uname');
-        this.emit('var ' + ast.uname + '= function(' + args.join(', ') + ') {\n');
-        this.gen_fill_args(ast.args, true);
+        var args = _.pluck(node.args, 'uname');
+        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
+        this.gen_fill_args(node.args, true);
 
         var self = this;
 
         // This could also be a top-level program (type 'MainModuleDef') in
         // which case we don't want to record a sub name
-        if (ast.type === 'SubDef') {
-            opts.path_info.sub.push(ast.name);
+        if (node.type === 'SubDef') {
+            opts.path_info.sub.push(node.name);
         }
-        flowgraph = _.chain(ast.elements)
+        flowgraph = _.chain(node.elements)
             .map(function(stmt) { return self.gen_statement(stmt, opts); })
             .filter(function(g) { return g !== undefined; } )
             .value();
@@ -246,8 +246,8 @@ class Build extends CodeGenerator {
     }
 
     // statements that can appear inside functions or reducers
-    gen_function_statement(ast) {
-        switch (ast.type) {
+    gen_function_statement(node) {
+        switch (node.type) {
             case 'StatementBlock':
             case 'FunctionDef':
             case 'ConstStatement':
@@ -257,10 +257,10 @@ class Build extends CodeGenerator {
             case 'IfStatement':
             case 'ReturnStatement':
             case 'ErrorStatement':
-                return this['gen_' + ast.type](ast);
+                return this['gen_' + node.type](node);
 
             default:
-                throw new Error('unrecognized function statement type ' + ast.type);
+                throw new Error('unrecognized function statement type ' + node.type);
         }
     }
     gen_fill_args(args, define_consts) {
@@ -290,19 +290,19 @@ class Build extends CodeGenerator {
             }
         }
     }
-    gen_FunctionDef(ast) {
-        var k, elems = ast.elements;
-        var args = _.pluck(ast.args, 'uname');
-        this.emit('var ' + ast.uname + '= function(' + args.join(', ') + ') {\n');
-        this.gen_fill_args(ast.args, false);
+    gen_FunctionDef(node) {
+        var k, elems = node.elements;
+        var args = _.pluck(node.args, 'uname');
+        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
+        this.gen_fill_args(node.args, false);
         for (k = 0; k < elems.length; ++k) {
             this.gen_function_statement(elems[k]);
         }
         this.emit('return null;\n');
         this.emit('};\n');
-        this.emit(ast.uname + '.location = ' + JSON.stringify(ast.location) + ';\n');
+        this.emit(node.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
 
-        ast = this.build_reify(ast);
+        node = this.build_reify(node);
 
         // Define const statements outside of the function's scope so that
         // they are avaialble in the add_function call below.
@@ -311,33 +311,33 @@ class Build extends CodeGenerator {
         //XXX should only do add_functions for functions that are referenced
         //from stream context, otherwise, they should just go away after
         // this pass because they aren't needed at runtime
-        this.emit('builder.add_function(' + this.build_code_ast(ast) + ');\n');
+        this.emit('builder.add_function(' + this.build_code_ast(node) + ');\n');
     }
-    build_reify(ast) {
+    build_reify(node) {
         var self = this;
-        if (ast === null || typeof(ast) !== 'object') {
-            return ast;
+        if (node === null || typeof(node) !== 'object') {
+            return node;
         }
-        if (ast.type === 'Variable' && ast.symbol.type === 'const' && ast.d) {
-            return this.build_reifier_expr(ast);
+        if (node.type === 'Variable' && node.symbol.type === 'const' && node.d) {
+            return this.build_reifier_expr(node);
         }
-        _.each(ast, function(val, name) {
-            ast[name] = self.build_reify(val);
+        _.each(node, function(val, name) {
+            node[name] = self.build_reify(val);
         });
-        return ast;
+        return node;
     }
-    gen_ReducerDef(ast) {
-        ast = this.build_reify(ast);
+    gen_ReducerDef(node) {
+        node = this.build_reify(node);
 
         // Define const statements outside of the reducer's scope so that they
         // are avaialble in the add_reducer call below.
-        this.define_consts(ast.elements);
+        this.define_consts(node.elements);
 
-        this.emit('builder.add_reducer(' + this.build_code_ast(ast) + ');\n');
+        this.emit('builder.add_reducer(' + this.build_code_ast(node) + ');\n');
     }
-    gen_StatementBlock(ast) {
-        for (var k = 0; k < ast.elements.length; ++k) {
-            this.gen_function_statement(ast.elements[k]);
+    gen_StatementBlock(node) {
+        for (var k = 0; k < node.elements.length; ++k) {
+            this.gen_function_statement(node.elements[k]);
         }
     }
     stitch(flowgraph) {
@@ -358,7 +358,7 @@ class Build extends CodeGenerator {
     }
 
     // elements of a flowgraph
-    gen_proc_element(ast) {
+    gen_proc_element(node) {
         // XXX
         var methods = {
             ParallelGraph: this.gen_ParallelGraph,
@@ -374,20 +374,20 @@ class Build extends CodeGenerator {
             SortProc: this.gen_SortProc,
             WriteProc: this.gen_WriteProc
         };
-        if (methods.hasOwnProperty(ast.type)) {
-            return methods[ast.type].call(this, ast);
+        if (methods.hasOwnProperty(node.type)) {
+            return methods[node.type].call(this, node);
         }
 
-        throw new Error('unrecognized processor or sub: ' + ast.type);
+        throw new Error('unrecognized processor or sub: ' + node.type);
     }
 
-    gen_SequentialGraph(ast) {
+    gen_SequentialGraph(node) {
         var k, next, first;
-        var elements = ast.elements;
+        var elements = node.elements;
         var code = '';
 
         // ignore top-level flowgraphs in modules
-        if (ast.outer_module) {
+        if (node.outer_module) {
             return;
         }
 
@@ -400,13 +400,13 @@ class Build extends CodeGenerator {
         return first;
     }
 
-    gen_ParallelGraph(ast) {
+    gen_ParallelGraph(node) {
         var k;
-        var elements = ast.elements;
+        var elements = node.elements;
         var flowgraph = [];
 
         // ignore top-level flowgraphs in modules
-        if (ast.outer_module) {
+        if (node.outer_module) {
             return;
         }
         flowgraph = [ this.gen_proc_element(elements[0]) ];
@@ -415,94 +415,94 @@ class Build extends CodeGenerator {
         }
         return this.stitch(flowgraph);
     }
-    gen_EmptyStatement(ast) {
+    gen_EmptyStatement(node) {
     }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    gen_AssignmentStatement(ast) {
-        var code = this.gen_assignment_lhs(ast.left);
+    gen_AssignmentStatement(node) {
+        var code = this.gen_assignment_lhs(node.left);
         //XXX need to handle op's other than "="
-        code +=  ' = ' + this.gen_expr(ast.expr) + ';\n';
+        code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
     // this type of assignment lives in places where there can be
     // points or reducers
-    gen_AssignmentExpression(ast) {
-        var code = this.gen_assignment_lhs(ast.left);
-        code += ' ' + ast.operator + ' ';
-        code += this.gen_expr(ast.right);
+    gen_AssignmentExpression(node) {
+        var code = this.gen_assignment_lhs(node.left);
+        code += ' ' + node.operator + ' ';
+        code += this.gen_expr(node.right);
         return code;
     }
 
-    gen_VarStatement(ast) {
-        var k, decls = ast.declarations;
+    gen_VarStatement(node) {
+        var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_var_decl(decls[k]));
         }
     }
-    gen_ConstStatement(ast) {
-        var k, decls = ast.declarations;
+    gen_ConstStatement(node) {
+        var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_const_decl(decls[k]));
         }
     }
-    gen_ImportStatement(ast, functions) {
+    gen_ImportStatement(node, functions) {
         // do nothing
     }
 
-    gen_IfStatement(ast) {
+    gen_IfStatement(node) {
         this.emit('if (');
         this.emit('juttle.values.ensureBoolean('
-            + this.gen_expr(ast.condition)
+            + this.gen_expr(node.condition)
             + ', \'if statement: Invalid condition type (<type>).\')');
         this.emit(') {\n');
-        this.gen_function_statement(ast.ifStatement);
+        this.gen_function_statement(node.ifStatement);
         this.emit('}\n');
-        if (ast.elseStatement) {
+        if (node.elseStatement) {
             this.emit('else {\n');
-            this.gen_function_statement(ast.elseStatement);
+            this.gen_function_statement(node.elseStatement);
             this.emit('}\n');
         }
     }
-    gen_ReturnStatement(ast) {
-        this.emit('return (' + (ast.value ? this.gen_expr(ast.value) : 'null') + ');\n');
+    gen_ReturnStatement(node) {
+        this.emit('return (' + (node.value ? this.gen_expr(node.value) : 'null') + ');\n');
     }
-    gen_ErrorStatement(ast) {
+    gen_ErrorStatement(node) {
         this.emit('throw juttle.errors.runtimeError("CUSTOM-ERROR", {\n');
         this.emit('message: juttle.values.ensureString('
-            + this.gen_expr(ast.message)
+            + this.gen_expr(node.message)
             + ', \'error statement: Invalid message type (<type>).\'),\n');
-        this.emit('location: ' + JSON.stringify(ast.location) + '\n');
+        this.emit('location: ' + JSON.stringify(node.location) + '\n');
         this.emit('});');
     }
-    gen_SequenceProc(ast) {
+    gen_SequenceProc(node) {
         var self = this;
-        ast.filters = _.map(ast.filters, function(filter) { return self.build_reifier_expr(filter); });
-        return this.gen_proc(ast);
+        node.filters = _.map(node.filters, function(filter) { return self.build_reifier_expr(filter); });
+        return this.gen_proc(node);
     }
-    gen_FilterProc(ast) {
-        ast.filter = this.build_reifier_expr(ast.filter);
-        return this.gen_proc(ast);
+    gen_FilterProc(node) {
+        node.filter = this.build_reifier_expr(node.filter);
+        return this.gen_proc(node);
     }
-    gen_SortProc(ast) {
-        return this.gen_proc(ast);
+    gen_SortProc(node) {
+        return this.gen_proc(node);
     }
-    gen_View(ast) {
-        return this.gen_proc(ast);
+    gen_View(node) {
+        return this.gen_proc(node);
     }
-    gen_CalendarExpression(ast) {
-        if (ast.direction === 'up') {
-            return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
+    gen_CalendarExpression(node) {
+        if (node.direction === 'up') {
+            return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(node.expression) +', "'+ node.unit +'")';
         } else {
-            return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
+            return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(node.expression) +', "'+ node.unit +'")';
         }
     }
-    gen_ReadProc(ast) {
-        ast.filter = this.build_reifier_expr(ast.filter);
-        return this.gen_proc(ast);
+    gen_ReadProc(node) {
+        node.filter = this.build_reifier_expr(node.filter);
+        return this.gen_proc(node);
     }
-    gen_WriteProc(ast) {
-        return this.gen_proc(ast);
+    gen_WriteProc(node) {
+        return this.gen_proc(node);
     }
     gen_reducers(aName, reducers) {
         var k, uname, args;
@@ -520,60 +520,60 @@ class Build extends CodeGenerator {
         return code;
     }
 
-    gen_ReifierProc(ast) {
-        ast.pname = {type:'Eval', expr:'builder.alloc_pname()' };
-        ast.exprs = this.build_reifier_expr(ast.exprs);
-        var code = 'var ' + ast.uname + ' = ';
+    gen_ReifierProc(node) {
+        node.pname = {type:'Eval', expr:'builder.alloc_pname()' };
+        node.exprs = this.build_reifier_expr(node.exprs);
+        var code = 'var ' + node.uname + ' = ';
 
-        this.build_options(ast);
+        this.build_options(node);
 
-        code += this.build_code_ast(ast) + ';';
-        code += 'builder.add_node(' + ast.uname + ');\n';
+        code += this.build_code_ast(node) + ';';
+        code += 'builder.add_node(' + node.uname + ');\n';
         this.emit(code);
-        return ast.uname;
+        return node.uname;
     }
-    gen_ReduceProc(ast) {
-        return this.gen_ReifierProc(ast);
+    gen_ReduceProc(node) {
+        return this.gen_ReifierProc(node);
     }
-    gen_PutProc(ast) {
-        return this.gen_ReifierProc(ast);
+    gen_PutProc(node) {
+        return this.gen_ReifierProc(node);
     }
-    gen_FunctionProc(ast) {
-        return this.gen_sub_call(ast);
+    gen_FunctionProc(node) {
+        return this.gen_sub_call(node);
     }
-    gen_InputStatement(ast, opts) {
+    gen_InputStatement(node, opts) {
         var self = this;
-        var input_opts = '{ ' + _.map(ast.options, function(option) {
+        var input_opts = '{ ' + _.map(node.options, function(option) {
             return option.id + ': ' + self.gen_expr(option.expr);
         }).join(', ') + '}';
 
-        var uname = ast.uname;
+        var uname = node.uname;
         var code = this.gen_var(uname);
 
         code += uname;
         code += ' = ';
         code += 'builder.define_input(builder.input_bname("' + opts.path_info.mod + '",' +
                                                                JSON.stringify(opts.path_info.sub) + ',"' +
-                                                               ast.name + '"), "' +
-                                      ast.input_name + '", ' +
+                                                               node.name + '"), "' +
+                                      node.input_name + '", ' +
                                       input_opts + ', ' +
-                                      ast.static + ');\n';
+                                      node.static + ');\n';
 
         code += 'builder.set_const("' + uname + '",' + uname + ');\n';
         this.emit( code);
     }
-    gen_assignment_lhs(ast) {
-        switch (ast.type) {
+    gen_assignment_lhs(node) {
+        switch (node.type) {
             case 'UnaryExpression':
-                return this.gen_UnaryExpression(ast);
+                return this.gen_UnaryExpression(node);
             case 'MemberExpression':
-                return this.gen_MemberExpression(ast, { lhs: true });
+                return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return ast.uname;
+                return node.uname;
             case 'Field':
-                return this.gen_Field(ast);
+                return this.gen_Field(node);
             default:
-                throw new Error('unrecognized expression lhs ' + ast.type);
+                throw new Error('unrecognized expression lhs ' + node.type);
         }
     }
 
@@ -582,24 +582,24 @@ class Build extends CodeGenerator {
     // context and compile nodes that can be eval'd at build time (into AST
     // nodes of type 'Eval').
     //
-    build_reifier_expr(ast) {
+    build_reifier_expr(node) {
         var self = this;
-        if (ast === null || typeof(ast) !== 'object') {
-            return ast;
+        if (node === null || typeof(node) !== 'object') {
+            return node;
         }
-        if (ast.d) {
-            return {type:'Eval', expr:this.gen_expr(ast)};
+        if (node.d) {
+            return {type:'Eval', expr:this.gen_expr(node)};
         }
-        _.each(ast, function (val, key) {
+        _.each(node, function (val, key) {
             if (key === 'symbol') {
                 return;
             }
-            ast[key] = self.build_reifier_expr(val);
+            node[key] = self.build_reifier_expr(val);
         });
-        return ast;
+        return node;
     }
-    gen_expr(ast) {
-        switch (ast.type) {
+    gen_expr(node) {
+        switch (node.type) {
             case 'AssignmentExpression':
             case 'CallExpression':
             case 'BinaryExpression':
@@ -625,52 +625,52 @@ class Build extends CodeGenerator {
             case 'PostfixExpression':
             case 'MomentLiteral':
             case 'DurationLiteral':
-                return this['gen_' + ast.type](ast);
+                return this['gen_' + node.type](node);
 
             case 'MemberExpression':
-                return this.gen_MemberExpression(ast, {});
+                return this.gen_MemberExpression(node, {});
 
             default:
-                throw new Error('unrecognized expression type ' + ast.type);
+                throw new Error('unrecognized expression type ' + node.type);
         }
     }
 
-    gen_PostfixExpression(ast) {
-        var expr = this.gen_expr(ast.expression);
-        var op = ast.operator;
+    gen_PostfixExpression(node) {
+        var expr = this.gen_expr(node.expression);
+        var op = node.operator;
 
         return '(juttle.values.ensureNumber('
             + expr
             + ', \'"' + op + '" operator: Invalid operand type (<type>).\'),'
             + expr + op + ')';
     }
-    gen_CallExpression(ast) {
-        switch (ast.callee.symbol.type) {
+    gen_CallExpression(node) {
+        switch (node.callee.symbol.type) {
             case 'function':
                 var code, self=this;
-                code = 'juttle.ops.call(' + ast.fname.uname;
-                code += _.map(ast.arguments, function(arg) {
+                code = 'juttle.ops.call(' + node.fname.uname;
+                code += _.map(node.arguments, function(arg) {
                     return ', ' + self.gen_expr(arg);
                 }).join('');
                 code += ')';
                 return code;
 
             case 'reducer':
-                var result = 'fns[' + ast.reducer_call_index + '].result()';
-                if (ast.context === 'stream') {
+                var result = 'fns[' + node.reducer_call_index + '].result()';
+                if (node.context === 'stream') {
                     // put must consume the current point before calling result
-                    result = '(fns[' + ast.reducer_call_index + '].update(pt),' + result + ')';
+                    result = '(fns[' + node.reducer_call_index + '].update(pt),' + result + ')';
                 }
                 return result;
 
             default:
-                throw new Error('Invalid symbol type: ' + ast.callee.symbol.type + '.');
+                throw new Error('Invalid symbol type: ' + node.callee.symbol.type + '.');
         }
     }
 
-    gen_UnaryExpression(ast) {
-        var expr = this.gen_expr(ast.argument);
-        var op = ast.operator;
+    gen_UnaryExpression(node) {
+        var expr = this.gen_expr(node.argument);
+        var op = node.operator;
 
         switch (op) {
             case '*':
@@ -692,34 +692,34 @@ class Build extends CodeGenerator {
                 return 'juttle.ops.' + UNARY_OPS_TO_FUNCTIONS[op] + '(' + expr + ')';
         }
     }
-    gen_BinaryExpression(ast) {
-        var left = this.gen_expr(ast.left);
-        var right = this.gen_expr(ast.right);
+    gen_BinaryExpression(node) {
+        var left = this.gen_expr(node.left);
+        var right = this.gen_expr(node.right);
 
-        if (ast.operator === '&&' || ast.operator === '||') {
+        if (node.operator === '&&' || node.operator === '||') {
             return 'juttle.values.ensureBoolean('
                 + left
-                + ', \'"' + ast.operator + '" operator: Invalid operand type (<type>).\')'
-                + ' ' + ast.operator + ' '
+                + ', \'"' + node.operator + '" operator: Invalid operand type (<type>).\')'
+                + ' ' + node.operator + ' '
                 + 'juttle.values.ensureBoolean('
                 + right
-                + ', \'"' + ast.operator + '" operator: Invalid operand type (<type>).\')';
+                + ', \'"' + node.operator + '" operator: Invalid operand type (<type>).\')';
         } else {
             return 'juttle.ops.'
-                + BINARY_OPS_TO_FUNCTIONS[ast.operator]
+                + BINARY_OPS_TO_FUNCTIONS[node.operator]
                 + '(' + left + ', ' + right + ')';
         }
     }
-    gen_ConditionalExpression(ast) {
+    gen_ConditionalExpression(node) {
         return '(juttle.values.ensureBoolean('
-            + this.gen_expr(ast.test)
+            + this.gen_expr(node.test)
             + ', \'Ternary operator: Invalid operand type (<type>).\')?('
-            + this.gen_expr(ast.alternate) + '):('
-            + this.gen_expr(ast.consequent) + '))';
+            + this.gen_expr(node.alternate) + '):('
+            + this.gen_expr(node.consequent) + '))';
     }
-    gen_ByList(ast) {
-        var k, elem = ast.elements;
-        // ast.elements is an array of the comma separated expressions
+    gen_ByList(node) {
+        var k, elem = node.elements;
+        // node.elements is an array of the comma separated expressions
         // each element can be an identifier (which may be a variable
         // or may be coerced to a string), an expression that evaluates
         // to an array (which may be a single variable) or to an string.
@@ -749,15 +749,15 @@ class Build extends CodeGenerator {
                             // a concrete item in the by-list), but that is too
                             // hard with the current flattening code. Maybe
                             // after PROD-6645 gets resolved.
-                            +'location: ' + JSON.stringify(ast.location)
+                            +'location: ' + JSON.stringify(node.location)
                         +'});'
                     +'}'
                 +'});';
         code += 'return out;\n})()\n';
         return code;
     }
-    gen_SortByList(ast) {
-        var k, elem = ast.elements;
+    gen_SortByList(node) {
+        var k, elem = node.elements;
         var code = '(function() { var t, out = [];\n';
         for (k = 0; k < elem.length; k++) {
             var s = this.gen_expr(elem[k].expr);
@@ -777,36 +777,36 @@ class Build extends CodeGenerator {
         code += 'return out;\n})()\n';
         return code;
     }
-    gen_Variable(ast) {
-        switch (ast.symbol.type) {
+    gen_Variable(node) {
+        switch (node.symbol.type) {
             case 'const':
-                return 'builder.get_const("' + ast.uname + '")';
+                return 'builder.get_const("' + node.uname + '")';
             case 'import':
             case 'function':
             case 'reducer':
             case 'sub':
                 throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
-                    thing: SYMBOL_TYPE_NAMES[ast.symbol.type],
-                    location: ast.location
+                    thing: SYMBOL_TYPE_NAMES[node.symbol.type],
+                    location: node.location
                 });
             default:
-                return ast.uname;
+                return node.uname;
         }
     }
-    gen_Field(ast) {
-        return 'juttle.ops.pget(pt,' + JSON.stringify(ast.name) + ')';
+    gen_Field(node) {
+        return 'juttle.ops.pget(pt,' + JSON.stringify(node.name) + ')';
     }
-    gen_MemberExpression(ast, opts) {
-        if (!ast.computed) {
-            return ast.uname;
+    gen_MemberExpression(node, opts) {
+        if (!node.computed) {
+            return node.uname;
         } else {
             if (opts.lhs) {
-                return this.gen_expr(ast.object)
-                    + '[' + this.gen_expr(ast.property) + ']';
+                return this.gen_expr(node.object)
+                    + '[' + this.gen_expr(node.property) + ']';
             } else {
                 return 'juttle.ops.get('
-                    + this.gen_expr(ast.object) + ','
-                    + this.gen_expr(ast.property)
+                    + this.gen_expr(node.object) + ','
+                    + this.gen_expr(node.property)
                     + ')';
             }
         }

--- a/lib/compiler/code-generator.js
+++ b/lib/compiler/code-generator.js
@@ -2,31 +2,31 @@
 
 var _ = require('underscore');
 class CodeGenerator {
-    gen_ArrayLiteral(ast) {
+    gen_ArrayLiteral(node) {
         var self = this;
-        var exprs = _.map(ast.elements, function(element) {
+        var exprs = _.map(node.elements, function(element) {
             return self.gen_expr(element);
         } );
         return '[' + exprs.join(',') + ']';
     }
-    gen_NumberLiteral(ast) {
-        return ast.value.toString();
+    gen_NumberLiteral(node) {
+        return node.value.toString();
     }
-    gen_InfinityLiteral(ast) {
-        return (ast.negative ? '-' : '') + 'Infinity';
+    gen_InfinityLiteral(node) {
+        return (node.negative ? '-' : '') + 'Infinity';
     }
     gen_NaNLiteral() {
         return 'NaN';
     }
-    gen_BooleanLiteral(ast) {
-        return JSON.stringify(ast.value);
+    gen_BooleanLiteral(node) {
+        return JSON.stringify(node.value);
     }
-    gen_StringLiteral(ast) {
-        return JSON.stringify(ast.value);
+    gen_StringLiteral(node) {
+        return JSON.stringify(node.value);
     }
-    gen_MultipartStringLiteral(ast) {
+    gen_MultipartStringLiteral(node) {
         var self = this;
-        var exprs = _.map(ast.parts, function(part) {
+        var exprs = _.map(node.parts, function(part) {
             return self.gen_expr(part);
         });
         return '(' + exprs.join(' + ') + ')';
@@ -34,15 +34,15 @@ class CodeGenerator {
     gen_NullLiteral() {
         return 'null';
     }
-    gen_RegExpLiteral(ast) {
-        return '/'+ ast.pattern +'/'+ ast.flags;
+    gen_RegExpLiteral(node) {
+        return '/'+ node.pattern +'/'+ node.flags;
     }
-    gen_ObjectLiteral(ast) {
+    gen_ObjectLiteral(node) {
         var self = this;
-        var simple = _(ast.properties).any(function(property) {
+        var simple = _(node.properties).any(function(property) {
             return property.key.type === 'StringLiteral';
         });
-        var props = _(ast.properties).map(function(property) {
+        var props = _(node.properties).map(function(property) {
             return self.gen_ObjectProperty(property, simple);
         });
 
@@ -50,22 +50,22 @@ class CodeGenerator {
             ? '{' + props.join(', ') + '}'
             : 'juttle.values.buildObject([' + props.join(', ') + '])';
     }
-    gen_ObjectProperty(ast, simple) {
+    gen_ObjectProperty(node, simple) {
         return simple
-            ? this.gen_expr(ast.key) + ': ' + this.gen_expr(ast.value)
-            : '[' + this.gen_expr(ast.key) + ', ' + this.gen_expr(ast.value) + ']';
+            ? this.gen_expr(node.key) + ': ' + this.gen_expr(node.value)
+            : '[' + this.gen_expr(node.key) + ', ' + this.gen_expr(node.value) + ']';
     }
-    gen_DurationLiteral(ast) {
-        return 'juttle.types.JuttleMoment.duration("' + ast.value + '")';
+    gen_DurationLiteral(node) {
+        return 'juttle.types.JuttleMoment.duration("' + node.value + '")';
     }
-    gen_MomentLiteral(ast) {
-        return 'new juttle.types.JuttleMoment("' + ast.value + '")';
+    gen_MomentLiteral(node) {
+        return 'new juttle.types.JuttleMoment("' + node.value + '")';
     }
-    gen_FilterLiteral(ast) {
-        return 'new juttle.types.Filter(' + JSON.stringify(ast.ast) + ',' + JSON.stringify(ast.source) + ')';
+    gen_FilterLiteral(node) {
+        return 'new juttle.types.Filter(' + JSON.stringify(node.node) + ',' + JSON.stringify(node.source) + ')';
     }
-    gen_ToString(ast) {
-        return 'juttle.ops.str(' + this.gen_expr(ast.expression) + ')';
+    gen_ToString(node) {
+        return 'juttle.ops.str(' + this.gen_expr(node.expression) + ')';
     }
 }
 

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -327,8 +327,8 @@ class GraphCompiler extends CodeGenerator {
         this.emit('var ' + uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(ast.args);
         for (k = 0; k < ast.elements.length; ++k) {
-            var node = ast.elements[k];
-            this.gen_function_statement(node);
+            var element = ast.elements[k];
+            this.gen_function_statement(element);
         }
         //
         // return object literal of the special functions

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -174,22 +174,22 @@ class GraphCompiler extends CodeGenerator {
         code += ';\n';
         return code;
     }
-    gen_BuiltinProc(ast) {
+    gen_BuiltinProc(node) {
         // When everything is switched over, gen_proc can
-        // take ast.name from ast and we don't need to pass it as arg
-        return this.gen_proc(ast, ast.name);
+        // take node.name from node and we don't need to pass it as arg
+        return this.gen_proc(node, node.name);
     }
-    gen_proc(ast, procName, params) {
-        var pname = ast.pname;
+    gen_proc(node, procName, params) {
+        var pname = node.pname;
         params = params || {};
         params.$pname = pname;
-        var soptions = this.gen_options(ast.options,
-                                        ast.location,
+        var soptions = this.gen_options(node.options,
+                                        node.location,
                                         params);
         var code = 'var ' + pname + ' = ';
         code += 'new juttle.procs.' + procName + '('
             + soptions + ', '
-            + JSON.stringify(ast.location) + ', '
+            + JSON.stringify(node.location) + ', '
             + 'program'
             + ');\n';
         this.emit(code);
@@ -277,8 +277,8 @@ class GraphCompiler extends CodeGenerator {
     }
 
     // statements that can appear inside functions or reducers
-    gen_function_statement(ast) {
-        switch (ast.type) {
+    gen_function_statement(node) {
+        switch (node.type) {
             case 'StatementBlock':
             case 'FunctionDef':
             case 'ConstStatement':
@@ -288,10 +288,10 @@ class GraphCompiler extends CodeGenerator {
             case 'IfStatement':
             case 'ReturnStatement':
             case 'ErrorStatement':
-                return this['gen_' + ast.type](ast);
+                return this['gen_' + node.type](node);
 
             default:
-                throw new Error('unrecognized function statement type ' + ast.type);
+                throw new Error('unrecognized function statement type ' + node.type);
         }
     }
     gen_fill_args(args) {
@@ -303,31 +303,31 @@ class GraphCompiler extends CodeGenerator {
             }
         }
     }
-    gen_FunctionDef(ast) {
-        var k, elems = ast.elements;
-        var args = _.pluck(ast.args, 'uname');
-        if (ast.stream) {
+    gen_FunctionDef(node) {
+        var k, elems = node.elements;
+        var args = _.pluck(node.args, 'uname');
+        if (node.stream) {
             args.unshift('pt');
         }
-        this.emit('var ' + ast.uname + '= function(' + args.join(', ') + ') {\n');
-        this.emit('var ' + ast.sname + ' = ' + ast.uname + ';\n');
-        this.gen_fill_args(ast.args);
+        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
+        this.emit('var ' + node.sname + ' = ' + node.uname + ';\n');
+        this.gen_fill_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             this.gen_function_statement(elems[k]);
         }
         this.emit('return null;\n');
         this.emit('};\n');
-        this.emit(ast.uname + '.location = ' + JSON.stringify(ast.location) + ';\n');
+        this.emit(node.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
     }
 
-    gen_ReducerDef(ast) {
+    gen_ReducerDef(node) {
         var k, code;
-        var uname = ast.uname;
-        var args = _.pluck(ast.args, 'uname');
+        var uname = node.uname;
+        var args = _.pluck(node.args, 'uname');
         this.emit('var ' + uname + '= function(' + args.join(', ') + ') {\n');
-        this.gen_fill_args(ast.args);
-        for (k = 0; k < ast.elements.length; ++k) {
-            var element = ast.elements[k];
+        this.gen_fill_args(node.args);
+        for (k = 0; k < node.elements.length; ++k) {
+            var element = node.elements[k];
             this.gen_function_statement(element);
         }
         //
@@ -336,12 +336,12 @@ class GraphCompiler extends CodeGenerator {
         // the state variables of the reducer.
         //
         var mapping = _.map(['update', 'expire', 'reset', 'result'], function(name) {
-            var fn = ast[name + '_uname'];
+            var fn = node[name + '_uname'];
             if (fn === undefined && name !== 'expire' && name !== 'reset') {
                 throw errors.compileError('MISSING-FUNCTION-IN-REDUCER', {
                     function: name,
-                    reducer: ast.name,
-                    location: ast.location
+                    reducer: node.name,
+                    location: node.location
                 });
             }
             return name + ':' + fn;
@@ -351,14 +351,14 @@ class GraphCompiler extends CodeGenerator {
         this.emit('return ' + code + ';\n');
         this.emit('};\n');
     }
-    gen_StatementBlock(ast) {
-        for (var k = 0; k < ast.elements.length; ++k) {
-            this.gen_function_statement(ast.elements[k]);
+    gen_StatementBlock(node) {
+        for (var k = 0; k < node.elements.length; ++k) {
+            this.gen_function_statement(node.elements[k]);
         }
     }
 
     // elements of a flowgraph
-    gen_proc_element(ast) {
+    gen_proc_element(node) {
         // XXX
         var methods = {
             ParallelGraph: this.gen_ParallelGraph,
@@ -374,135 +374,135 @@ class GraphCompiler extends CodeGenerator {
             SortProc: this.gen_SortProc,
             WriteProc: this.gen_WriteProc
         };
-        if (methods.hasOwnProperty(ast.type)) {
-            return methods[ast.type].call(this, ast);
+        if (methods.hasOwnProperty(node.type)) {
+            return methods[node.type].call(this, node);
         }
 
-        throw new Error('unrecognized processor or sub: ' + ast.type);
+        throw new Error('unrecognized processor or sub: ' + node.type);
     }
 
-    gen_EmptyStatement(ast) {
+    gen_EmptyStatement(node) {
     }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    gen_AssignmentStatement(ast) {
-        var code = this.gen_assignment_lhs(ast.left);
+    gen_AssignmentStatement(node) {
+        var code = this.gen_assignment_lhs(node.left);
         //XXX need to handle op's other than "="
-        code +=  ' = ' + this.gen_expr(ast.expr) + ';\n';
+        code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
     // this type of assignment lives in places where there can be
     // points or reducers
-    gen_AssignmentExpression(ast) {
-        var code = this.gen_assignment_lhs(ast.left);
-        code += ' ' + ast.operator + ' ';
-        code += this.gen_expr(ast.right);
+    gen_AssignmentExpression(node) {
+        var code = this.gen_assignment_lhs(node.left);
+        code += ' ' + node.operator + ' ';
+        code += this.gen_expr(node.right);
         return code;
     }
 
-    gen_VarStatement(ast) {
-        var k, decls = ast.declarations;
+    gen_VarStatement(node) {
+        var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_var_decl(decls[k]));
         }
     }
-    gen_ConstStatement(ast) {
-        var k, decls = ast.declarations;
+    gen_ConstStatement(node) {
+        var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
             this.emit(this.gen_const_decl(decls[k]));
         }
     }
-    gen_IfStatement(ast) {
+    gen_IfStatement(node) {
         this.emit('if (');
         this.emit('juttle.values.ensureBoolean('
-            + this.gen_expr(ast.condition)
+            + this.gen_expr(node.condition)
             + ', \'if statement: Invalid condition type (<type>).\')');
         this.emit(') {\n');
-        this.gen_function_statement(ast.ifStatement);
+        this.gen_function_statement(node.ifStatement);
         this.emit('}\n');
-        if (ast.elseStatement) {
+        if (node.elseStatement) {
             this.emit('else {\n');
-            this.gen_function_statement(ast.elseStatement);
+            this.gen_function_statement(node.elseStatement);
             this.emit('}\n');
         }
     }
-    gen_ReturnStatement(ast) {
-        this.emit('return (' + (ast.value ? this.gen_expr(ast.value) : 'null') + ');\n');
+    gen_ReturnStatement(node) {
+        this.emit('return (' + (node.value ? this.gen_expr(node.value) : 'null') + ');\n');
     }
-    gen_ErrorStatement(ast) {
+    gen_ErrorStatement(node) {
         this.emit('throw juttle.errors.runtimeError(\'CUSTOM-ERROR\', {\n');
         this.emit('message: juttle.values.ensureString('
-            + this.gen_expr(ast.message)
+            + this.gen_expr(node.message)
             + ', \'error statement: Invalid message type (<type>).\'),\n');
-        this.emit('location: ' + JSON.stringify(ast.location) + '\n');
+        this.emit('location: ' + JSON.stringify(node.location) + '\n');
         this.emit('});');
     }
-    gen_ReadProc(ast) {
-        if (ast.filter) {
+    gen_ReadProc(node) {
+        if (node.filter) {
             var checker = new StaticFilterChecker();
-            checker.check(ast.filter);
+            checker.check(node.filter);
 
             var simplifier = new FilterSimplifier();
-            ast.filter = simplifier.simplify(ast.filter);
+            node.filter = simplifier.simplify(node.filter);
         }
 
         var params = {
-            $adapter: ast.adapter,
-            $filter_ast: ast.filter,
-            $optimization_info: ast.optimization_info
+            $adapter: node.adapter,
+            $filter_ast: node.filter,
+            $optimization_info: node.optimization_info
         };
 
-        return this.gen_proc(ast, 'read', params);
+        return this.gen_proc(node, 'read', params);
     }
-    gen_WriteProc(ast) {
-        return this.gen_proc(ast, 'write', {$adapter: ast.adapter});
+    gen_WriteProc(node) {
+        return this.gen_proc(node, 'write', {$adapter: node.adapter});
     }
-    gen_FilterProc(ast) {
+    gen_FilterProc(node) {
         var checker = new DynamicFilterChecker();
-        checker.check(ast.filter);
+        checker.check(node.filter);
 
         var simplifier = new FilterSimplifier();
-        ast.filter = simplifier.simplify(ast.filter);
+        node.filter = simplifier.simplify(node.filter);
 
         var compiler = new FilterJSCompiler();
-        var code = compiler.compile(ast.filter);
+        var code = compiler.compile(node.filter);
 
-        return this.gen_proc(ast, 'filter', {predicate: code});
+        return this.gen_proc(node, 'filter', {predicate: code});
     }
-    gen_SequenceProc(ast) {
+    gen_SequenceProc(node) {
         var checker = new DynamicFilterChecker();
-        _.each (ast.filters, (filter) => { checker.check(filter);});
+        _.each (node.filters, (filter) => { checker.check(filter);});
 
         var simplifier = new FilterSimplifier();
-        ast.filters = _.map(ast.filters, (filter) => simplifier.simplify(filter));
+        node.filters = _.map(node.filters, (filter) => simplifier.simplify(filter));
 
-        var filters = _.map(ast.filters, function(filter) {
+        var filters = _.map(node.filters, function(filter) {
             var compiler = new FilterJSCompiler();
             return compiler.compile(filter);
         });
         var code = '[' + filters.join (',') + ']';
 
-        return this.gen_proc(ast, 'sequence', {predicates: code});
+        return this.gen_proc(node, 'sequence', {predicates: code});
     }
-    gen_SortProc(ast) {
-        return this.gen_proc(ast, 'sort');
+    gen_SortProc(node) {
+        return this.gen_proc(node, 'sort');
     }
-    gen_View(ast) {
-        // silly special case for ast.name due to sink's special-case parsing
+    gen_View(node) {
+        // silly special case for node.name due to sink's special-case parsing
         // and AST.
-        var proc = this.gen_proc(ast, 'view', {$name: ast.name});
+        var proc = this.gen_proc(node, 'view', {$name: node.name});
 
-        this.emit('views.push({name: "' + ast.name + '",' +
+        this.emit('views.push({name: "' + node.name + '",' +
                   'channel: ' + proc + '.channel,' +
-                  'location: ' + JSON.stringify(ast.location) + '});\n');
+                  'location: ' + JSON.stringify(node.location) + '});\n');
 
         return proc;
     }
-    gen_CalendarExpression(ast) {
-        if (ast.direction === 'up') {
-            return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
+    gen_CalendarExpression(node) {
+        if (node.direction === 'up') {
+            return 'juttle.types.JuttleMoment.endOf('+ this.gen_expr(node.expression) +', "'+ node.unit +'")';
         } else {
-            return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(ast.expression) +', "'+ ast.unit +'")';
+            return 'juttle.types.JuttleMoment.startOf('+ this.gen_expr(node.expression) +', "'+ node.unit +'")';
         }
     }
     gen_reducers(aName, reducers) {
@@ -537,22 +537,22 @@ class GraphCompiler extends CodeGenerator {
 
         return code;
     }
-    gen_ReifierProc(ast, which) {
+    gen_ReifierProc(node, which) {
         var k;
 
         var maker, expr = 'function(pt, fns) {\n';
-        for (k = 0; k < ast.exprs.length; ++k) {
-            expr += this.gen_expr(ast.exprs[k]) + ';';
+        for (k = 0; k < node.exprs.length; ++k) {
+            expr += this.gen_expr(node.exprs[k]) + ';';
         }
         expr += '}';
 
-        maker = this.gen_reifier(ast.reducers);
-        var reducer_index = _.pluck(ast.reducers, 'index');
-        var lhs = ast.exprs.map(function(expr) {
+        maker = this.gen_reifier(node.reducers);
+        var reducer_index = _.pluck(node.reducers, 'index');
+        var lhs = node.exprs.map(function(expr) {
             return expr.left.type === 'Field' ? expr.left.name : expr.left.argument.value;
         });
 
-        return this.gen_proc(ast, which, {
+        return this.gen_proc(node, which, {
             expr: expr,
             funcMaker: maker,
             $reducer_index: reducer_index,
@@ -560,30 +560,30 @@ class GraphCompiler extends CodeGenerator {
         });
     }
 
-    gen_ReduceProc(ast) {
-        return this.gen_ReifierProc(ast, 'reduce');
+    gen_ReduceProc(node) {
+        return this.gen_ReifierProc(node, 'reduce');
     }
-    gen_PutProc(ast) {
-        return this.gen_ReifierProc(ast, 'put');
+    gen_PutProc(node) {
+        return this.gen_ReifierProc(node, 'put');
     }
-    gen_assignment_lhs(ast) {
-        switch (ast.type) {
+    gen_assignment_lhs(node) {
+        switch (node.type) {
             case 'UnaryExpression':
-                return this.gen_UnaryExpression(ast, { lhs: true });
+                return this.gen_UnaryExpression(node, { lhs: true });
             case 'MemberExpression':
-                return this.gen_MemberExpression(ast, { lhs: true });
+                return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return ast.uname;
+                return node.uname;
             case 'Field':
-                return this.gen_Field(ast, { lhs: true });
+                return this.gen_Field(node, { lhs: true });
             default:
-                throw new Error('unrecognized expression lhs ' + ast.type);
+                throw new Error('unrecognized expression lhs ' + node.type);
         }
     }
 
-    gen_expr(ast) {
+    gen_expr(node) {
 
-        switch (ast.type) {
+        switch (node.type) {
             case 'AssignmentExpression':
             case 'CallExpression':
             case 'BinaryExpression':
@@ -605,62 +605,62 @@ class GraphCompiler extends CodeGenerator {
             case 'PostfixExpression':
             case 'MomentLiteral':
             case 'DurationLiteral':
-                return this['gen_' + ast.type](ast);
+                return this['gen_' + node.type](node);
 
             case 'Field':
-                return this.gen_Field(ast, {});
+                return this.gen_Field(node, {});
 
             case 'UnaryExpression':
-                return this.gen_UnaryExpression(ast, {});
+                return this.gen_UnaryExpression(node, {});
 
             case 'MemberExpression':
-                return this.gen_MemberExpression(ast, {});
+                return this.gen_MemberExpression(node, {});
 
             default:
-                throw new Error('unrecognized expression type ' + ast.type +
-                            '\n' + JSON.stringify(ast, 0, 4));
+                throw new Error('unrecognized expression type ' + node.type +
+                            '\n' + JSON.stringify(node, 0, 4));
         }
     }
 
-    gen_PostfixExpression(ast) {
-        var expr = this.gen_expr(ast.expression);
-        var op = ast.operator;
+    gen_PostfixExpression(node) {
+        var expr = this.gen_expr(node.expression);
+        var op = node.operator;
 
         return '(juttle.values.ensureNumber('
             + expr
             + ', \'"' + op + '" operator: Invalid operand type (<type>).\'),'
             + expr + op + ')';
     }
-    gen_CallExpression(ast) {
-        switch (ast.callee.symbol.type) {
+    gen_CallExpression(node) {
+        switch (node.callee.symbol.type) {
             case 'function':
                 var k, code;
-                code = 'juttle.ops.call(' + ast.fname;
-                if (ast.arguments) {
-                    for (k = 0; k < ast.arguments.length; ++k) {
+                code = 'juttle.ops.call(' + node.fname;
+                if (node.arguments) {
+                    for (k = 0; k < node.arguments.length; ++k) {
                         code += ', ';
-                        code += this.gen_expr(ast.arguments[k]);
+                        code += this.gen_expr(node.arguments[k]);
                     }
                 }
                 code += ')';
                 return code;
 
             case 'reducer':
-                var result = 'fns[' + ast.reducer_call_index + '].result()';
-                if (ast.context === 'stream') {
+                var result = 'fns[' + node.reducer_call_index + '].result()';
+                if (node.context === 'stream') {
                     // put must consume the current point before calling result
-                    result = '(fns[' + ast.reducer_call_index + '].update(pt),' + result + ')';
+                    result = '(fns[' + node.reducer_call_index + '].update(pt),' + result + ')';
                 }
                 return result;
 
             default:
-                throw new Error('Invalid symbol type: ' + ast.callee.symbol.type + '.');
+                throw new Error('Invalid symbol type: ' + node.callee.symbol.type + '.');
         }
     }
 
-    gen_UnaryExpression(ast, opts) {
-        var expr = this.gen_expr(ast.argument);
-        var op = ast.operator;
+    gen_UnaryExpression(node, opts) {
+        var expr = this.gen_expr(node.argument);
+        var op = node.operator;
 
         switch (op) {
             case '*':
@@ -687,64 +687,64 @@ class GraphCompiler extends CodeGenerator {
                 return 'juttle.ops.' + UNARY_OPS_TO_FUNCTIONS[op] + '(' + expr + ')';
         }
     }
-    gen_BinaryExpression(ast) {
-        var left = this.gen_expr(ast.left);
-        var right = this.gen_expr(ast.right);
+    gen_BinaryExpression(node) {
+        var left = this.gen_expr(node.left);
+        var right = this.gen_expr(node.right);
 
-        if (ast.operator === '&&' || ast.operator === '||') {
+        if (node.operator === '&&' || node.operator === '||') {
             return 'juttle.values.ensureBoolean('
                 + left
-                + ', \'"' + ast.operator + '" operator: Invalid operand type (<type>).\')'
-                + ' ' + ast.operator + ' '
+                + ', \'"' + node.operator + '" operator: Invalid operand type (<type>).\')'
+                + ' ' + node.operator + ' '
                 + 'juttle.values.ensureBoolean('
                 + right
-                + ', \'"' + ast.operator + '" operator: Invalid operand type (<type>).\')';
+                + ', \'"' + node.operator + '" operator: Invalid operand type (<type>).\')';
         } else {
             return 'juttle.ops.'
-                + BINARY_OPS_TO_FUNCTIONS[ast.operator]
+                + BINARY_OPS_TO_FUNCTIONS[node.operator]
                 + '(' + left + ', ' + right + ')';
         }
     }
-    gen_ConditionalExpression(ast) {
+    gen_ConditionalExpression(node) {
         return '(juttle.values.ensureBoolean('
-            + this.gen_expr(ast.test)
+            + this.gen_expr(node.test)
             + ', \'Ternary operator: Invalid operand type (<type>).\')?('
-            + this.gen_expr(ast.alternate) + '):('
-            + this.gen_expr(ast.consequent) + '))';
+            + this.gen_expr(node.alternate) + '):('
+            + this.gen_expr(node.consequent) + '))';
     }
-    gen_Variable(ast) {
-        switch (ast.symbol.type) {
+    gen_Variable(node) {
+        switch (node.symbol.type) {
             case 'import':
             case 'function':
             case 'reducer':
             case 'sub':
                 throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
-                    thing: SYMBOL_TYPE_NAMES[ast.symbol.type],
-                    location: ast.location
+                    thing: SYMBOL_TYPE_NAMES[node.symbol.type],
+                    location: node.location
                 });
             default:
-                return ast.uname;
+                return node.uname;
         }
     }
-    gen_Field(ast, opts) {
-        var name = JSON.stringify(ast.name);
+    gen_Field(node, opts) {
+        var name = JSON.stringify(node.name);
         if (opts.lhs) {
             return 'pt[' + name + ']';
         } else {
             return 'juttle.ops.pget(pt,' + name + ')';
         }
     }
-    gen_MemberExpression(ast, opts) {
-        if (!ast.computed) {
-            return ast.uname;
+    gen_MemberExpression(node, opts) {
+        if (!node.computed) {
+            return node.uname;
         } else {
             if (opts.lhs) {
-                return this.gen_expr(ast.object)
-                    + '[' + this.gen_expr(ast.property) + ']';
+                return this.gen_expr(node.object)
+                    + '[' + this.gen_expr(node.property) + ']';
             } else {
                 return 'juttle.ops.get('
-                    + this.gen_expr(ast.object) + ','
-                    + this.gen_expr(ast.property)
+                    + this.gen_expr(node.object) + ','
+                    + this.gen_expr(node.property)
                     + ')';
             }
         }

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -126,11 +126,11 @@ class GraphCompiler extends CodeGenerator {
         return srcs;
     }
     gen_procs(procs) {
-        var k, i, first, node, from, out, shorts, srcs;
+        var k, i, first, proc, from, out, shorts, srcs;
         for (k = 0; k < procs.length; ++k) {
-            node = this.gen_proc_element(procs[k]);
+            proc = this.gen_proc_element(procs[k]);
             if (!first) {
-                first = node;
+                first = proc;
             }
         }
         for (k = 0; k < procs.length; ++k) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -293,24 +293,24 @@ class SemanticPass {
         return decl;
     }
     // a flowgraph node
-    sa_proc(ast, opts) {
+    sa_proc(node, opts) {
         var uname = this.scope.alloc_var();
         //XXX check options and parameters for unknowns and illegals
-        ast.uname = uname;
-        this.sa_options(ast.options, opts);
-        return ast;
+        node.uname = uname;
+        this.sa_options(node.options, opts);
+        return node;
     }
-    sa_sub_call(ast, sub) {
+    sa_sub_call(node, sub) {
         var that = this;
-        ast.uname = this.scope.alloc_var();
-        ast.uname_sub = sub.name;
-        ast.options = _.map(ast.options, function(opt) {
+        node.uname = this.scope.alloc_var();
+        node.uname_sub = sub.name;
+        node.options = _.map(node.options, function(opt) {
             return {id: opt.id, expr:that.sa_expr(opt.expr), location: opt.location};
         });
-        ast.sub_sig = _.map(sub.args, function(arg) {
+        node.sub_sig = _.map(sub.args, function(arg) {
             return { name: arg.name, required: !arg.default };
         });
-        return ast;
+        return node;
     }
     //XXX this one operates in place on the option expressions
     //  does not check params
@@ -333,10 +333,10 @@ class SemanticPass {
     exit_scope() {
         this.scope = this.scope.next;
     }
-    function_name(ast) {
-        return ast.callee.type !== 'MemberExpression'
-            ? ast.callee.name
-            : ast.callee.object.name + '.' + ast.callee.property.value;
+    function_name(node) {
+        return node.callee.type !== 'MemberExpression'
+            ? node.callee.name
+            : node.callee.object.name + '.' + node.callee.property.value;
     }
     check_arg_count(name, type, actual_count, expected_count, location) {
         var min_count, max_count;
@@ -379,10 +379,10 @@ class SemanticPass {
             }
         }
     }
-    sa_function_call(ast, funcInfo, opts) {
-        var k, args = ast.arguments;
-        ast.fname = {type: 'function_uname', uname: funcInfo.name};
-        this.check_arg_count(this.function_name(ast), 'function', args.length, funcInfo.arg_count, ast.location);
+    sa_function_call(node, funcInfo, opts) {
+        var k, args = node.arguments;
+        node.fname = {type: 'function_uname', uname: funcInfo.name};
+        this.check_arg_count(this.function_name(node), 'function', args.length, funcInfo.arg_count, node.location);
         var d = true;
         if (args) {
             for (k = 0; k < args.length; ++k) {
@@ -392,37 +392,37 @@ class SemanticPass {
         }
 
         if (opts.context !== 'stream' && opts.context !== 'reduce') {
-            ast.d = d;
+            node.d = d;
         } else {
             // because we don't know if the function contains a call to
             // Math.random() (PROD-4556)
-            ast.d = false;
+            node.d = false;
         }
-        return ast;
+        return node;
     }
     can_export() {
         return (this.context() === 'module' || this.context() === 'main');
     }
-    check_export(ast) {
-        if (ast.export  && !this.can_export()) {
+    check_export(node) {
+        if (node.export  && !this.can_export()) {
             throw errors.compileError('NON-TOPLEVEL-EXPORT', {
                 context: this.context(),
-                location: ast.location
+                location: node.location
             });
         }
     }
-    check_reducer_toplevel(ast, thing) {
+    check_reducer_toplevel(node, thing) {
         if (this.context() === 'reducer') {
             throw errors.compileError('REDUCER-TOPLEVEL-STATEMENT', {
                 thing: thing,
-                location: ast.location
+                location: node.location
             });
         }
     }
 
     // statements that can appear inside subs or at the top level
-    sa_statement(ast) {
-        switch (ast.type) {
+    sa_statement(node) {
+        switch (node.type) {
 
             case 'SubDef':
             case 'FunctionDef':
@@ -435,22 +435,22 @@ class SemanticPass {
             case 'SequentialGraph':
             case 'ImportStatement':
             case 'ParallelGraph':
-                return this['sa_' + ast.type](ast);
+                return this['sa_' + node.type](node);
 
             default:
-                throw new Error('unrecognized statement type ' + ast.type);
+                throw new Error('unrecognized statement type ' + node.type);
         }
     }
-    sa_ModuleDef(ast) {
+    sa_ModuleDef(node) {
         // turn module name into valid js identifier since
         // it will be used in the runtime module name
         //XXX/sm I don't understand this... this doesn't seem fully robust
         // and can create collisions...
-        var name_ident = ast.name.replace(/[^a-zA-Z0-9$_]/g, '_');
+        var name_ident = node.name.replace(/[^a-zA-Z0-9$_]/g, '_');
         var modName = this.scope.alloc_var(name_ident);
-        var k, elems = ast.elements;
+        var k, elems = node.elements;
 
-        ast.uname = modName;
+        node.uname = modName;
 
         var saved_scope = this.scope;
         this.scope = new Scope(null, 'module');
@@ -460,48 +460,48 @@ class SemanticPass {
             elems[k] = this.sa_statement(elems[k]);
         }
 
-        this.modules[ast.name] = {
+        this.modules[node.name] = {
             uname: modName,
             exports: this.scope.exports()
         };
         this.scope = saved_scope;
-        return ast;
+        return node;
     }
-    sa_SubDef(ast) {
+    sa_SubDef(node) {
         var uname, elems, k, has_graph;
 
-        this.check_export(ast);
+        this.check_export(node);
 
-        uname = this.scope.define_sub(ast.name, ast.args, ast.export);
-        ast.uname = uname;
-        this.enter_scope(ast.name === 'main' ? 'main' : 'sub');
+        uname = this.scope.define_sub(node.name, node.args, node.export);
+        node.uname = uname;
+        this.enter_scope(node.name === 'main' ? 'main' : 'sub');
 
-        elems = ast.elements;
-        ast.args = this.sa_args(ast.args);
+        elems = node.elements;
+        node.args = this.sa_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             elems[k] = this.sa_statement(elems[k]);
         }
         this.exit_scope();
 
         if (this.context() === 'top') {
-            has_graph = _.any(ast.elements, function(element) {
+            has_graph = _.any(node.elements, function(element) {
                 return element.type === 'SequentialGraph' || element.type === 'ParallelGraph';
             });
 
             if (!has_graph) {
                 throw errors.compileError('PROGRAM-WITHOUT-FLOWGRAPH', {
-                    location: ast.location
+                    location: node.location
                 });
             }
         }
 
-        return ast;
+        return node;
     }
 
     // statements that can appear inside functions or reducers
-    sa_function_statement(ast, opts) {
+    sa_function_statement(node, opts) {
         opts = opts || {};
-        switch (ast.type) {
+        switch (node.type) {
             case 'StatementBlock':
             case 'FunctionDef':
             case 'ConstStatement':
@@ -511,10 +511,10 @@ class SemanticPass {
             case 'IfStatement':
             case 'ReturnStatement':
             case 'ErrorStatement':
-                return this['sa_' + ast.type](ast, opts);
+                return this['sa_' + node.type](node, opts);
 
             default:
-                throw new Error('unrecognized function statement type ' + ast.type);
+                throw new Error('unrecognized function statement type ' + node.type);
         }
     }
     sa_args(args) {
@@ -542,46 +542,46 @@ class SemanticPass {
 
         return [requiredArgs.length, args.length];
     }
-    sa_FormalArg(ast) {
-        ast.uname = this.context().match(/fn/) || this.context() === 'reducer'
-            ? this.scope.define_var(ast.name, false)
-            : this.scope.define_const(ast.name, false, true);
+    sa_FormalArg(node) {
+        node.uname = this.context().match(/fn/) || this.context() === 'reducer'
+            ? this.scope.define_var(node.name, false)
+            : this.scope.define_const(node.name, false, true);
 
-        if (ast.default) {
-            ast.default = this.sa_expr(ast.default);
+        if (node.default) {
+            node.default = this.sa_expr(node.default);
         }
 
-        return ast;
+        return node;
     }
-    sa_FunctionDef(ast, opts) {
-        var elems, uname  = this.scope.define_func(ast.name, ast.export, this.compute_arg_count(ast.args));
-        ast.uname = uname;
-        this.check_export(ast);
+    sa_FunctionDef(node, opts) {
+        var elems, uname  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args));
+        node.uname = uname;
+        this.check_export(node);
 
         var context = this.context().match(/reducer/) ? 'fn-in-' + this.context() : 'fn';
-        this.enter_scope(context + ':' + ast.name);
+        this.enter_scope(context + ':' + node.name);
 
-        ast.args = this.sa_args(ast.args);
-        elems = ast.elements;
+        node.args = this.sa_args(node.args);
+        elems = node.elements;
         for (var k = 0; k < elems.length; ++k) {
             elems[k] = this.sa_function_statement(elems[k], opts);
         }
 
         this.exit_scope();
 
-        return ast;
+        return node;
     }
 
-    sa_ReducerDef(ast) {
+    sa_ReducerDef(node) {
         var k, elems;
-        var uname = this.scope.define_reducer(ast.name, ast.export, this.compute_arg_count(ast.args));
-        ast.uname = uname;
+        var uname = this.scope.define_reducer(node.name, node.export, this.compute_arg_count(node.args));
+        node.uname = uname;
 
-        this.check_export(ast);
+        this.check_export(node);
 
         this.enter_scope('reducer');
-        elems = ast.elements;
-        ast.args = this.sa_args(ast.args);
+        elems = node.elements;
+        node.args = this.sa_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             var elem = elems[k];
             var opts = { context: 'build' };
@@ -602,36 +602,36 @@ class SemanticPass {
             elems[k] = this.sa_function_statement(elem, opts);
             if (elem.type === 'FunctionDef') {
                 if (elem.name === 'update') {
-                    ast.update_uname = elem.uname;
+                    node.update_uname = elem.uname;
                 }
                 else if (elem.name === 'expire') {
-                    ast.expire_uname = elem.uname;
+                    node.expire_uname = elem.uname;
                 }
                 else if (elem.name === 'reset') {
-                    ast.reset_uname = elem.uname;
+                    node.reset_uname = elem.uname;
                 }
                 else if (elem.name === 'result') {
-                    ast.result_uname = elem.uname;
+                    node.result_uname = elem.uname;
                 }
             }
         }
         this.exit_scope();
 
-        return ast;
+        return node;
     }
-    sa_StatementBlock(ast, opts) {
-        this.check_reducer_toplevel(ast, 'a block');
+    sa_StatementBlock(node, opts) {
+        this.check_reducer_toplevel(node, 'a block');
 
-        var elems = ast.elements;
+        var elems = node.elements;
         this.enter_scope('block-in-' + this.context());
         for (var k = 0; k < elems.length; ++k) {
             elems[k] = this.sa_function_statement(elems[k], opts);
         }
         this.exit_scope();
-        return ast;
+        return node;
     }
     // elements of a flowgraph
-    sa_proc_element(ast) {
+    sa_proc_element(node) {
         // XXX
         var methods = {
             ParallelGraph: this.sa_ParallelGraph,
@@ -649,18 +649,18 @@ class SemanticPass {
             SortProc: this.sa_SortProc,
             WriteProc: this.sa_WriteProc
         };
-        if (methods.hasOwnProperty(ast.type)) {
-            if (!ast.options) {
-                ast.options = [];
+        if (methods.hasOwnProperty(node.type)) {
+            if (!node.options) {
+                node.options = [];
             }
-            return methods[ast.type].call(this, ast);
+            return methods[node.type].call(this, node);
         }
 
-        throw new Error('unrecognized processor or sub: ' + ast.type);
+        throw new Error('unrecognized processor or sub: ' + node.type);
     }
 
-    sa_graph(ast) {
-        var k, elems = ast.elements;
+    sa_graph(node) {
+        var k, elems = node.elements;
 
         // ignore top-level flowgraphs for imported modules
         // we check for semantic errors in imported module even
@@ -668,105 +668,105 @@ class SemanticPass {
         if (this.context() === 'module') {
             // remember this context so code generator can ignore procs
             // that are in the outer scope of a module
-            ast.outer_module = true;
+            node.outer_module = true;
         }
         for (k = 0; k < elems.length; k++) {
             elems[k] = this.sa_proc_element(elems[k]);
         }
-        return ast;
+        return node;
     }
 
-    sa_SequentialGraph(ast) {
-        return this.sa_graph(ast);
+    sa_SequentialGraph(node) {
+        return this.sa_graph(node);
     }
-    sa_ParallelGraph(ast) {
-        return this.sa_graph(ast);
+    sa_ParallelGraph(node) {
+        return this.sa_graph(node);
     }
 
-    sa_EmptyStatement(ast, opts) {
-        return ast;
+    sa_EmptyStatement(node, opts) {
+        return node;
     }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    sa_AssignmentStatement(ast, opts) {
-        this.check_reducer_toplevel(ast, 'an assignment');
+    sa_AssignmentStatement(node, opts) {
+        this.check_reducer_toplevel(node, 'an assignment');
 
         opts = opts || {};
-        ast.left = this.sa_assignment_lhs(ast.left, opts);
+        node.left = this.sa_assignment_lhs(node.left, opts);
         //XXX need to handle op's other than "="
-        ast.expr = this.sa_expr(ast.expr, opts);
-        return ast;
+        node.expr = this.sa_expr(node.expr, opts);
+        return node;
     }
     // this type of assignment lives in places where there can be
     // points or reducers
-    sa_AssignmentExpression(ast, opts) {
-        ast.left = this.sa_assignment_lhs(ast.left, opts);
-        ast.right = this.sa_expr(ast.right, opts);
-        ast.d = ast.left.d && ast.right.d;
-        return ast;
+    sa_AssignmentExpression(node, opts) {
+        node.left = this.sa_assignment_lhs(node.left, opts);
+        node.right = this.sa_expr(node.right, opts);
+        node.d = node.left.d && node.right.d;
+        return node;
     }
-    sa_VarStatement(ast, opts) {
+    sa_VarStatement(node, opts) {
         opts = opts || {};
-        var k, decls = ast.declarations;
+        var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
             decls[k] = this.sa_var_decl(decls[k], opts);
         }
-        return ast;
+        return node;
     }
-    sa_InputStatement(ast, opts) {
+    sa_InputStatement(node, opts) {
         var self = this;
         opts = opts || {};
 
-        this.check_export(ast);
+        this.check_export(node);
 
-        ast.options = _.map(ast.options, function(opt) {
+        node.options = _.map(node.options, function(opt) {
             var ret = {type: 'InputOption', id: opt.id, expr: self.sa_expr(opt.expr)};
             if (! ret.expr.d) {
                 throw errors.compileError('BAD-INPUT-OPTION', {
-                    input: ast.name,
+                    input: node.name,
                     option: opt.id,
                     location: opt.location
                 });
             }
             return ret;
         });
-        ast.uname = this.scope.define_variable(ast.name, 'const', ast.export, false, true, ast.location);
+        node.uname = this.scope.define_variable(node.name, 'const', node.export, false, true, node.location);
 
         var detector = new StaticInputDetector();
-        ast.static = detector.isStatic(ast);
+        node.static = detector.isStatic(node);
 
-        return ast;
+        return node;
     }
-    sa_ConstStatement(ast, opts) {
+    sa_ConstStatement(node, opts) {
         opts = opts || {};
-        var k, decls = ast.declarations;
-        this.check_export(ast);
+        var k, decls = node.declarations;
+        this.check_export(node);
         for (k = 0; k < decls.length; ++k) {
             if (!decls[k].expr) {
                 throw errors.compileError('UNINITIALIZED-CONST', {
                     name: decls[k].name,
-                    location: ast.location
+                    location: node.location
                 });
             }
-            decls[k] = this.sa_const_decl(decls[k], ast.export, ast.arg, opts);
+            decls[k] = this.sa_const_decl(decls[k], node.export, node.arg, opts);
         }
-        return ast;
+        return node;
     }
-    sa_ImportStatement(ast, functions) {
+    sa_ImportStatement(node, functions) {
         var self = this;
-        var modulename = ast.modulename.value;
+        var modulename = node.modulename.value;
 
         if (this.context() !== 'module' && this.context() !== 'main') {
             throw errors.compileError('NON-TOPLEVEL-IMPORT', {
                 context: this.context(),
-                location: ast.location
+                location: node.location
             });
         }
         if (_.contains(this.import_path, modulename)) {
             this.import_path.push(modulename); // for the error message
             throw errors.compileError('CYCLIC-IMPORT', {
                 path: this.import_path.join(' -> '),
-                location: ast.location
+                location: node.location
             });
         }
 
@@ -784,7 +784,7 @@ class SemanticPass {
         }
         // localname is the juttle "as" name of the module
         var module = this.modules[modulename];
-        this.scope.put(ast.localname, {
+        this.scope.put(node.localname, {
             type: 'import',
             exported: false,
             exports: module.exports
@@ -793,83 +793,83 @@ class SemanticPass {
         this.import_path.pop();
         this.stats.imports++;
 
-        return ast;
+        return node;
     }
 
-    sa_IfStatement(ast, opts) {
-        this.check_reducer_toplevel(ast, 'an if statement');
+    sa_IfStatement(node, opts) {
+        this.check_reducer_toplevel(node, 'an if statement');
 
-        ast.condition = this.sa_expr(ast.condition, opts);
-        ast.ifStatement = this.sa_function_statement(ast.ifStatement, opts);
-        if (ast.elseStatement) {
-            ast.elseStatement = this.sa_function_statement(ast.elseStatement,
+        node.condition = this.sa_expr(node.condition, opts);
+        node.ifStatement = this.sa_function_statement(node.ifStatement, opts);
+        if (node.elseStatement) {
+            node.elseStatement = this.sa_function_statement(node.elseStatement,
                                                            opts);
         }
-        return ast;
+        return node;
     }
-    sa_ReturnStatement(ast, opts) {
-        this.check_reducer_toplevel(ast, 'a return statement');
+    sa_ReturnStatement(node, opts) {
+        this.check_reducer_toplevel(node, 'a return statement');
 
-        if (ast.value) {
-            ast.value = this.sa_expr(ast.value, opts);
+        if (node.value) {
+            node.value = this.sa_expr(node.value, opts);
         }
-        return ast;
+        return node;
     }
-    sa_ErrorStatement(ast, opts) {
-        ast.message = this.sa_expr(ast.message, opts);
-        return ast;
+    sa_ErrorStatement(node, opts) {
+        node.message = this.sa_expr(node.message, opts);
+        return node;
     }
 
-    sa_ExpressionFilterTerm(ast, opts) {
-        ast.expression = this.sa_expr(ast.expression, { context: 'filter', coerce_var: 'field' });
+    sa_ExpressionFilterTerm(node, opts) {
+        node.expression = this.sa_expr(node.expression, { context: 'filter', coerce_var: 'field' });
         // will be carried in AST form to a proc implementation
-        ast.expression.d = false;
-        ast.d = false;
-        return ast;
+        node.expression.d = false;
+        node.d = false;
+        return node;
     }
-    sa_SimpleFilterTerm(ast) {
-        ast.expression = this.sa_expr(ast.expression);
+    sa_SimpleFilterTerm(node) {
+        node.expression = this.sa_expr(node.expression);
         // will be carried in AST form to a proc implementation
-        ast.d = false;
-        return ast;
+        node.d = false;
+        return node;
     }
-    sa_FilterLiteral(ast) {
-        ast.ast = this.sa_expr(ast.ast);
+    sa_FilterLiteral(node) {
+        node.ast = this.sa_expr(node.ast);
         // will be carried in AST form to a proc implementation
-        ast.d = false;
-        return ast;
+        node.d = false;
+        return node;
     }
-    sa_filter_proc(ast, opts) {
-        if (ast.filter) {
-            ast.filter = this.sa_expr(ast.filter, opts);
+    sa_filter_proc(node, opts) {
+        if (node.filter) {
+            node.filter = this.sa_expr(node.filter, opts);
         }
-        return this.sa_proc(ast);
+        return this.sa_proc(node);
     }
-    sa_sequence_proc(ast) {
+    sa_sequence_proc(node) {
         var self = this;
-        if (ast.filters.length < 2) {
+        if (node.filters.length < 2) {
             throw errors.compileError('PROC-NEEDS-ARG', {
                 name: 'sequence',
-                location: ast.location
+                location: node.location
             });
         }
-        if (ast.groupby) {
-            ast.options.push({id: 'groupby', expr:ast.groupby});
-            delete ast.groupby;
+        if (node.groupby) {
+            node.options.push({id: 'groupby', expr:node.groupby});
+            delete node.groupby;
         }
-        ast.filters = _.map(ast.filters, function (ast) { return self.sa_expr(ast); });
-        return this.sa_proc(ast);
+        node.filters = _.map(node.filters, function (node) { return self.sa_expr(node); });
+        return this.sa_proc(node);
     }
-    sa_FilterProc(ast) {
-        return this.sa_filter_proc(ast, { allow_field_comparisons: true });
+    sa_FilterProc(node) {
+        return this.sa_filter_proc(node, { allow_field_comparisons: true });
     }
-    sa_SequenceProc(ast) {
-        return this.sa_sequence_proc(ast);
+    sa_SequenceProc(node) {
+        return this.sa_sequence_proc(node);
     }
-    sa_ReadProc(ast) {
-        return this.sa_filter_proc(ast, { allow_field_comparisons: false });
+    sa_ReadProc(node) {
+        return this.sa_filter_proc(node, { allow_field_comparisons: false });
     }
-    sa_option_proc(ast, options) {
+    sa_option_proc(node, options) {
         // Some procs have syntactical sugar for parameters (e.g. the limit in
         // `head 10` or the bylist in `reduce by a, b`). They show up as named
         // attributes in the AST. We convert those into options (which are
@@ -877,45 +877,45 @@ class SemanticPass {
         // compiler)
         options = options || [];
         _.each(options, function(option) {
-            if (ast[option]) {
-                ast.options.push({id: option, expr: ast[option]});
-                delete ast[option];
+            if (node[option]) {
+                node.options.push({id: option, expr: node[option]});
+                delete node[option];
             }
         });
-        return this.sa_proc(ast);
+        return this.sa_proc(node);
     }
-    sa_SortProc(ast) {
-        return this.sa_option_proc(ast, ['groupby', 'columns']);
+    sa_SortProc(node) {
+        return this.sa_option_proc(node, ['groupby', 'columns']);
     }
-    sa_View(ast) {
+    sa_View(node) {
         // The "coerce_var" option needs to be set explicitly so that sa_ByList
         // doesn't override.
         var opts = {
             coerce_var: 'none'
         };
 
-        return this.sa_proc(ast, opts);
+        return this.sa_proc(node, opts);
     }
-    sa_ObjectLiteral(ast, opts) {
+    sa_ObjectLiteral(node, opts) {
         var k, props;
         var d = true;
-        props = ast.properties;
+        props = node.properties;
         for (k = 0; k < props.length; ++k) {
             props[k] = this.sa_ObjectProperty(props[k], opts);
             d = d && props[k].d;
         }
-        ast.d = d;
-        return ast;
+        node.d = d;
+        return node;
     }
-    sa_ObjectProperty(ast, opts) {
-        ast.key = this.sa_expr(ast.key, opts);
-        ast.value = this.sa_expr(ast.value, opts);
-        ast.d = ast.key.d && ast.value.d;
-        return ast;
+    sa_ObjectProperty(node, opts) {
+        node.key = this.sa_expr(node.key, opts);
+        node.value = this.sa_expr(node.value, opts);
+        node.d = node.key.d && node.value.d;
+        return node;
     }
-    sa_RegExpLiteral(ast) {
-        ast.d = true;
-        return ast;
+    sa_RegExpLiteral(node) {
+        node.d = true;
+        return node;
     }
     sa_reducer_arg(arg, opts) {
         // coerce a naked name to a string (ie a field name) if it
@@ -972,13 +972,13 @@ class SemanticPass {
         }
         return out;
     }
-    sa_reifier_proc(ast, opts) {
+    sa_reifier_proc(node, opts) {
         var k, reducers = [];
         opts.reducers = reducers;
 
-        for (k = 0; k < ast.exprs.length; ++k) {
+        for (k = 0; k < node.exprs.length; ++k) {
             opts.index = k;
-            ast.exprs[k] = this.sa_expr(ast.exprs[k], opts);
+            node.exprs[k] = this.sa_expr(node.exprs[k], opts);
         }
         //
         // decorate the AST with the list of reducers that are used
@@ -987,140 +987,140 @@ class SemanticPass {
         // reducer_index decoration in the expression AST node that calls
         // this particular reducer.
         //
-        ast.reducers = this.sa_reducers(reducers);
+        node.reducers = this.sa_reducers(reducers);
 
-        if (ast.groupby) {
-            ast.options.push({id: 'groupby', expr:ast.groupby});
-            delete ast.groupby;
+        if (node.groupby) {
+            node.options.push({id: 'groupby', expr:node.groupby});
+            delete node.groupby;
         }
-        return this.sa_proc(ast);
+        return this.sa_proc(node);
     }
-    sa_ReduceProc(ast) {
-        var reified = this.sa_reifier_proc(ast, {context: 'reduce'});
+    sa_ReduceProc(node) {
+        var reified = this.sa_reifier_proc(node, {context: 'reduce'});
         reified.reducers.forEach(function(reducer) {
             if (reducer.name === 'delta') {
                 throw errors.compileError('REDUCE-DELTA-ERROR', {
-                    location: ast.location
+                    location: node.location
                 });
             }
         });
         return reified;
     }
-    sa_PutProc(ast) {
-        return this.sa_reifier_proc(ast, {context: 'stream',
+    sa_PutProc(node) {
+        return this.sa_reifier_proc(node, {context: 'stream',
                                          coerce_var: 'field'});
     }
 
-    sa_builtin_proc(ast) {
-        ast.type = 'BuiltinProc';
+    sa_builtin_proc(node) {
+        node.type = 'BuiltinProc';
 
-        _.each(BUILTIN_PROCS[ast.name].maybe, function(attrname) {
-            if (ast[attrname]) {
-                ast.options.push({id: attrname, expr: ast[attrname]});
-                delete ast[attrname];
+        _.each(BUILTIN_PROCS[node.name].maybe, function(attrname) {
+            if (node[attrname]) {
+                node.options.push({id: attrname, expr: node[attrname]});
+                delete node[attrname];
             }
         });
 
-        _.each(BUILTIN_PROCS[ast.name].always, function(attrname) {
-            if (!ast[attrname]) {
+        _.each(BUILTIN_PROCS[node.name].always, function(attrname) {
+            if (!node[attrname]) {
                 throw errors.compileError('PROC-NEEDS-ARG', {
-                    name: ast.name,
-                    location: ast.location
+                    name: node.name,
+                    location: node.location
                 });
             }
-            ast.options.push({id: attrname, expr: ast[attrname]});
-            delete ast[attrname];
+            node.options.push({id: attrname, expr: node[attrname]});
+            delete node[attrname];
         });
-        return this.sa_proc(ast);
+        return this.sa_proc(node);
     }
-    sa_OptionOnlyProc(ast) {
-        return this.sa_builtin_proc(ast);
+    sa_OptionOnlyProc(node) {
+        return this.sa_builtin_proc(node);
     }
-    sa_WriteProc(ast) {
-        return this.sa_proc(ast);
+    sa_WriteProc(node) {
+        return this.sa_proc(node);
     }
-    sa_SingleArgProc(ast) {
-        return this.sa_builtin_proc(ast);
+    sa_SingleArgProc(node) {
+        return this.sa_builtin_proc(node);
     }
-    sa_FieldListArgProc(ast) {
-        return this.sa_builtin_proc(ast);
+    sa_FieldListArgProc(node) {
+        return this.sa_builtin_proc(node);
     }
-    sa_FunctionProc(ast) {
+    sa_FunctionProc(node) {
         var sub;
 
-        if (ast.op.type === 'MemberExpression') {
-            sub = this.scope.lookup_module_sub(ast.op.object.name, ast.op.property.value);
+        if (node.op.type === 'MemberExpression') {
+            sub = this.scope.lookup_module_sub(node.op.object.name, node.op.property.value);
             if (sub === undefined) {
                 throw errors.compileError('NOT-EXPORTED', {
                     thing: 'sub',
-                    name: ast.op.property.value,
-                    module: ast.op.object.name,
-                    location: ast.location
+                    name: node.op.property.value,
+                    module: node.op.object.name,
+                    location: node.location
                 });
             }
-            ast.op.object.symbol = this.scope.get(ast.op.object.name);
+            node.op.object.symbol = this.scope.get(node.op.object.name);
         } else {
-            sub = this.scope.get(ast.op.name);
+            sub = this.scope.get(node.op.name);
             if (!sub) {
                 throw errors.compileError('NO-SUCH-SUB', {
-                    name: ast.op.name,
-                    location: ast.location
+                    name: node.op.name,
+                    location: node.location
                 });
             }
             if (sub.type !== 'sub') {
                 throw errors.compileError('NOT-A-SUB', {
-                    name: ast.op.name,
-                    location: ast.location
+                    name: node.op.name,
+                    location: node.location
                 });
             }
-            ast.op.symbol = sub;
+            node.op.symbol = sub;
         }
 
         this.stats.subs++;
-        return this.sa_sub_call(ast, sub);
+        return this.sa_sub_call(node, sub);
     }
 
-    sa_assignment_lhs(ast, opts) {
-        switch (ast.type) {
+    sa_assignment_lhs(node, opts) {
+        switch (node.type) {
             case 'UnaryExpression':
-                ast = this.sa_UnaryExpression(ast, opts);
-                return ast;
+                node = this.sa_UnaryExpression(node, opts);
+                return node;
 
             case 'Variable':
-                if (!this.scope.lookup_variable(ast.name)) {
+                if (!this.scope.lookup_variable(node.name)) {
                     throw errors.compileError('UNDEFINED-VARIABLE', {
-                        name: ast.name,
-                        location: ast.location
+                        name: node.name,
+                        location: node.location
                     });
                 }
-                if (!this.scope.is_mutable(ast.name, opts, this.context())) {
+                if (!this.scope.is_mutable(node.name, opts, this.context())) {
                     throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
-                        name: ast.name,
-                        location: ast.location
+                        name: node.name,
+                        location: node.location
                     });
                 }
-                return this.sa_Variable(ast, opts);
+                return this.sa_Variable(node, opts);
 
             case 'Field':
-                return this.sa_Field(ast, opts);
+                return this.sa_Field(node, opts);
 
             case 'MemberExpression':
-                if (!this.scope.is_mutable(ast.object.name, opts, this.context())) {
+                if (!this.scope.is_mutable(node.object.name, opts, this.context())) {
                     throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
-                        name: ast.object.name,
-                        location: ast.location
+                        name: node.object.name,
+                        location: node.location
                     });
                 }
-                return this.sa_MemberExpression(ast, opts);
+                return this.sa_MemberExpression(node, opts);
 
             default:
-                throw new Error('unrecognized expression lhs ' + ast.type);
+                throw new Error('unrecognized expression lhs ' + node.type);
         }
     }
 
-    sa_expr(ast, opts) {
+    sa_expr(node, opts) {
         opts = opts || {};
-        switch (ast.type) {
+        switch (node.type) {
             case 'NullLiteral':
             case 'BooleanLiteral':
             case 'NumberLiteral':
@@ -1129,8 +1129,8 @@ class SemanticPass {
             case 'StringLiteral':
             case 'MomentLiteral':
             case 'DurationLiteral':
-                ast.d = true;
-                return ast;
+                node.d = true;
+                return node;
 
             case 'AssignmentExpression':
             case 'CallExpression':
@@ -1151,193 +1151,193 @@ class SemanticPass {
             case 'ExpressionFilterTerm':
             case 'SimpleFilterTerm':
             case 'FilterLiteral':
-                return this['sa_' + ast.type](ast, opts);
+                return this['sa_' + node.type](node, opts);
 
             default:
-                throw new Error('unrecognized expression type ' + ast.type);
+                throw new Error('unrecognized expression type ' + node.type);
         }
     }
 
-    sa_PostfixExpression(ast, opts) {
+    sa_PostfixExpression(node, opts) {
         var name;
-        switch (ast.expression.type) {
+        switch (node.expression.type) {
             case 'Variable':
             case 'MemberExpression':
-                name = ast.expression.type === 'Variable' ?
-                   ast.expression.name : ast.expression.object.name;
-                ast.expression = this.sa_expr(ast.expression, opts);
+                name = node.expression.type === 'Variable' ?
+                   node.expression.name : node.expression.object.name;
+                node.expression = this.sa_expr(node.expression, opts);
                 if (!this.scope.is_mutable(name, opts, this.context())) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
-                        operator: ast.operator,
+                        operator: node.operator,
                         variable: name,
-                        location: ast.location
+                        location: node.location
                     });
                 }
-                ast.d = ast.expression.d;
-                return ast;
+                node.d = node.expression.d;
+                return node;
             default:
                 throw errors.compileError('INVALID-POSTFIX-LHS', {
-                    location: ast.location
+                    location: node.location
                 });
         }
     }
-    sa_CallExpression(ast, opts) {
+    sa_CallExpression(node, opts) {
         var fname, args, funcInfo, i;
-        if (ast.callee.type === 'MemberExpression') {
-            args = ast.arguments;
+        if (node.callee.type === 'MemberExpression') {
+            args = node.arguments;
 
-            funcInfo = this.scope.lookup_module_reducer(ast.callee.object.name, ast.callee.property.value);
+            funcInfo = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
             if (funcInfo) {
                 // XXX opts.reducers implies reducer context
                 if (!opts.reducers) {
                     throw errors.compileError('INVALID-REDUCER-CALL', {
-                        name: ast.callee.object.name + '.' + ast.callee.property.value,
-                        location: ast.location
+                        name: node.callee.object.name + '.' + node.callee.property.value,
+                        location: node.location
                     });
                 }
                 opts.reducers.push({
-                    module: ast.callee.object.name,
-                    name:ast.callee.property.value,
+                    module: node.callee.object.name,
+                    name:node.callee.property.value,
                     args:args,
                     index: opts.index
                 });
-                ast.reducer_call_index = opts.reducers.length - 1;
-                ast.callee.symbol = funcInfo;
-                ast.callee.object.symbol = this.scope.get(ast.callee.object.name);
-                this.check_arg_count(this.function_name(ast), 'reducer', args.length, funcInfo.arg_count, ast.location);
-                ast.context = opts.context; // needed because reducer calls are different in put vs reduce
+                node.reducer_call_index = opts.reducers.length - 1;
+                node.callee.symbol = funcInfo;
+                node.callee.object.symbol = this.scope.get(node.callee.object.name);
+                this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
+                node.context = opts.context; // needed because reducer calls are different in put vs reduce
                 for (i = 0; i < args.length; ++i) {
                     args[i] = this.sa_reducer_arg(args[i]);
                 }
-                return ast;
+                return node;
             } else {
-                funcInfo = this.scope.lookup_module_func(ast.callee.object.name, ast.callee.property.value);
+                funcInfo = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
                 if (funcInfo === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
                         thing: 'function',
-                        name: ast.callee.property.value,
-                        module: ast.callee.object.name,
-                        location: ast.location
+                        name: node.callee.property.value,
+                        module: node.callee.object.name,
+                        location: node.location
                     });
                 }
-                ast.callee.symbol = funcInfo;
-                ast.callee.object.symbol = this.scope.get(ast.callee.object.name);
-                return (this.sa_function_call(ast, funcInfo, opts));
+                node.callee.symbol = funcInfo;
+                node.callee.object.symbol = this.scope.get(node.callee.object.name);
+                return (this.sa_function_call(node, funcInfo, opts));
             }
         } else {
             //XXX fragile b/c parser allows for expressions as function
-            fname = ast.callee.name;
+            fname = node.callee.name;
         }
 
-        args = ast.arguments;
+        args = node.arguments;
         if (is_builtin_reducer(fname) || (this.scope.get(fname) && this.scope.get(fname).type === 'reducer')) {
             if (!opts.reducers) {
                 throw errors.compileError('INVALID-REDUCER-CALL', {
                     name: fname,
-                    location: ast.location
+                    location: node.location
                 });
             }
             opts.reducers.push({name:fname, args:args, index: opts.index});
-            ast.reducer_call_index = opts.reducers.length - 1;
+            node.reducer_call_index = opts.reducers.length - 1;
             // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
             funcInfo = is_builtin_reducer(fname)
                 ? this.scope.fake_builtin_reducer_symbol(fname)
                 : this.scope.get(fname);
-            this.check_arg_count(this.function_name(ast), 'reducer', args.length, funcInfo.arg_count, ast.location);
-            ast.callee.symbol = funcInfo;
-            ast.context = opts.context; // needed because reducer calls are different in put vs reduce
+            this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
+            node.callee.symbol = funcInfo;
+            node.context = opts.context; // needed because reducer calls are different in put vs reduce
             for (i = 0; i < args.length; ++i) {
                 args[i] = this.sa_reducer_arg(args[i]);
             }
-            return ast;
+            return node;
         } else {
             funcInfo = this.scope.get(fname);
             if (!funcInfo) {
                 throw errors.compileError('NO-SUCH-FUNCTION', {
                     name: fname,
-                    location: ast.location
+                    location: node.location
                 });
             }
             if (funcInfo.type !== 'function') {
                 throw errors.compileError('NOT-A-FUNCTION', {
                     name: fname,
-                    location: ast.location
+                    location: node.location
                 });
             }
-            ast.callee.symbol = funcInfo;
-            return this.sa_function_call(ast, funcInfo, opts);
+            node.callee.symbol = funcInfo;
+            return this.sa_function_call(node, funcInfo, opts);
         }
     }
-    sa_UnaryExpression(ast, opts) {
-        var op = ast.operator;
+    sa_UnaryExpression(node, opts) {
+        var op = node.operator;
         var name;
 
-        ast.argument = this.sa_expr(ast.argument, opts);
+        node.argument = this.sa_expr(node.argument, opts);
         if (op === '*') {
             if (opts.context !== 'stream' && opts.context !== 'reduce' && opts.context !== 'filter') {
                 throw errors.compileError('INVALID-FIELD-REFERENCE', {
-                    location: ast.location
+                    location: node.location
                 });
             }
-            ast.d = false;
-            return ast;
+            node.d = false;
+            return node;
         }
-        ast.d = ast.argument.d;
+        node.d = node.argument.d;
         //XXX limit allowable operators?  why only look for these two?
         if (op === '++' || op === '--') {
-            name = ast.argument.type === 'Variable' ?
-                ast.argument.name : ast.argument.object.name;
+            name = node.argument.type === 'Variable' ?
+                node.argument.name : node.argument.object.name;
             if (!this.scope.is_mutable(name, opts, this.context())) {
                 throw errors.compileError('INVALID-PREFIX-USE', {
                     operator: op,
                     variable: name,
-                    location: ast.location
+                    location: node.location
                 });
             }
         }
-        return ast;
+        return node;
     }
-    sa_BinaryExpression(ast, opts) {
-        ast.left = this.sa_expr(ast.left, opts);
-        ast.right = this.sa_expr(ast.right, opts);
-        ast.d = ast.left.d && ast.right.d;
-        return ast;
+    sa_BinaryExpression(node, opts) {
+        node.left = this.sa_expr(node.left, opts);
+        node.right = this.sa_expr(node.right, opts);
+        node.d = node.left.d && node.right.d;
+        return node;
     }
-    sa_ConditionalExpression(ast, opts) {
-        ast.test = this.sa_expr(ast.test, opts);
-        ast.alternate = this.sa_expr(ast.alternate, opts);
-        ast.consequent = this.sa_expr(ast.consequent, opts);
+    sa_ConditionalExpression(node, opts) {
+        node.test = this.sa_expr(node.test, opts);
+        node.alternate = this.sa_expr(node.alternate, opts);
+        node.consequent = this.sa_expr(node.consequent, opts);
         //XXX can be smarter than this
-        ast.d = ast.test.d && ast.alternate.d && ast.consequent.d;
-        return ast;
+        node.d = node.test.d && node.alternate.d && node.consequent.d;
+        return node;
     }
-    sa_MultipartStringLiteral(ast, opts) {
+    sa_MultipartStringLiteral(node, opts) {
         var k;
         var d = true;
-        for (k = 0; k < ast.parts.length; k++) {
-            ast.parts[k] = this.sa_expr(ast.parts[k], opts);
-            d = d && ast.parts[k].d;
+        for (k = 0; k < node.parts.length; k++) {
+            node.parts[k] = this.sa_expr(node.parts[k], opts);
+            d = d && node.parts[k].d;
         }
-        ast.d = d;
-        return ast;
+        node.d = d;
+        return node;
     }
-    sa_ArrayLiteral(ast, opts) {
+    sa_ArrayLiteral(node, opts) {
         var k;
         var d = true;
-        for (k = 0; k < ast.elements.length; k++) {
-            ast.elements[k] = this.sa_expr(ast.elements[k], opts);
-            d = d && ast.elements[k].d;
+        for (k = 0; k < node.elements.length; k++) {
+            node.elements[k] = this.sa_expr(node.elements[k], opts);
+            d = d && node.elements[k].d;
         }
-        ast.d = d;
-        return ast;
+        node.d = d;
+        return node;
     }
-    sa_ByList(ast, opts) {
-        var k, elem = ast.elements;
+    sa_ByList(node, opts) {
+        var k, elem = node.elements;
         var d = true;
         if (!opts.coerce_var) {
             opts.coerce_var = 'string';
         }
-        // ast.elements is an array of the comma separated expressions
+        // node.elements is an array of the comma separated expressions
         // each element can be an identifier (which may be a variable
         // or may be coerced to a string), an expression that evaluates
         // to an array (which may be a single variable) or to an string.
@@ -1348,95 +1348,95 @@ class SemanticPass {
             elem[k] = this.sa_expr(elem[k], opts);
             d = d && elem[k].d;
         }
-        ast.d = d;
-        return ast;
+        node.d = d;
+        return node;
     }
-    sa_SortByList(ast) {
-        var k, elem = ast.elements;
+    sa_SortByList(node) {
+        var k, elem = node.elements;
         var d = true;
         var opts = {coerce_var:'string'};
         for (k = 0; k < elem.length; k++) {
             elem[k].expr = this.sa_expr(elem[k].expr, opts);
             d = d && elem[k].d;
         }
-        ast.d = d;
-        return ast;
+        node.d = d;
+        return node;
     }
-    sa_Variable(ast, opts) {
-        var varInfo = this.scope.get(ast.name);
+    sa_Variable(node, opts) {
+        var varInfo = this.scope.get(node.name);
 
         if (varInfo) {
-            ast.uname = this.scope.lookup_variable(ast.name);
-            ast.symbol = varInfo;
-            ast.d = varInfo.d;
+            node.uname = this.scope.lookup_variable(node.name);
+            node.symbol = varInfo;
+            node.d = varInfo.d;
 
-            return ast;
+            return node;
         } else {
             switch (opts.coerce_var) {
                 case 'string':
                     return {
                         type: 'StringLiteral',
-                        value: ast.name,
+                        value: node.name,
                         d:true,
-                        location: ast.location
+                        location: node.location
                     };
 
                 case 'field':
                     return {
                         type: 'Field',
-                        name: ast.name,
+                        name: node.name,
                         d:false,
-                        location: ast.location
+                        location: node.location
                     };
 
                 default:
                     throw errors.compileError('UNDEFINED', {
-                        name: ast.name,
-                        location: ast.location
+                        name: node.name,
+                        location: node.location
                     });
             }
         }
     }
-    sa_Field(ast, opts) {
+    sa_Field(node, opts) {
         if (opts.context !== 'stream' && opts.context !== 'reduce' && opts.context !== 'filter') {
             throw errors.compileError('INVALID-FIELD-REFERENCE', {
-                location: ast.location
+                location: node.location
             });
         }
-        ast.d = false;
-        return ast;
+        node.d = false;
+        return node;
     }
-    sa_ToString(ast, opts) {
-        ast.expression = this.sa_expr(ast.expression, opts);
-        ast.d = ast.expression.d;
-        return ast;
+    sa_ToString(node, opts) {
+        node.expression = this.sa_expr(node.expression, opts);
+        node.d = node.expression.d;
+        return node;
     }
-    sa_MemberExpression(ast, opts) {
+    sa_MemberExpression(node, opts) {
         var varInfo;
-        if (!ast.computed) {
-            varInfo = this.scope.lookup_module_variable(ast.object.name, ast.property.value);
+        if (!node.computed) {
+            varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
             if (varInfo === undefined) {
                 throw errors.compileError('NOT-EXPORTED', {
                     thing: 'variable',
-                    name: ast.property.value,
-                    module: ast.object.name,
-                    location: ast.location
+                    name: node.property.value,
+                    module: node.object.name,
+                    location: node.location
                 });
             }
 
-            ast.object = this.sa_expr(ast.object, opts);
+            node.object = this.sa_expr(node.object, opts);
 
-            ast.uname = varInfo.name;
-            ast.symbol = this.scope.get(ast.object.name).exports[ast.property.value];
-            ast.d = true;
+            node.uname = varInfo.name;
+            node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+            node.d = true;
         }
         else {
-            ast.object = this.sa_expr(ast.object, opts);
-            ast.property = this.sa_expr(ast.property, opts);
-            ast.d = ast.object.d && ast.property.d;
+            node.object = this.sa_expr(node.object, opts);
+            node.property = this.sa_expr(node.property, opts);
+            node.d = node.object.d && node.property.d;
             //XXX/TBD need to track d flag in arrays...
         }
-        return ast;
+        return node;
     }
 }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -583,35 +583,35 @@ class SemanticPass {
         elems = ast.elements;
         ast.args = this.sa_args(ast.args);
         for (k = 0; k < elems.length; ++k) {
-            var node = elems[k];
+            var elem = elems[k];
             var opts = { context: 'build' };
-            if (node.type === 'FunctionDef') {
-                if ((node.name === 'update' || node.name === 'result' || node.name === 'expire' || node.name === 'reset')) {
-                    if (node.args.length > 0) {
+            if (elem.type === 'FunctionDef') {
+                if ((elem.name === 'update' || elem.name === 'result' || elem.name === 'expire' || elem.name === 'reset')) {
+                    if (elem.args.length > 0) {
                         throw errors.compileError('REDUCER-METHOD-ARGS', {
-                            name: node.name,
-                            location: node.location
+                            name: elem.name,
+                            location: elem.location
                         });
                     }
-                    if (node.name === 'update' || node.name === 'expire') {
+                    if (elem.name === 'update' || elem.name === 'expire') {
                         opts.context = 'stream';
-                        node.stream = true;
+                        elem.stream = true;
                     }
                 }
             }
-            elems[k] = this.sa_function_statement(node, opts);
-            if (node.type === 'FunctionDef') {
-                if (node.name === 'update') {
-                    ast.update_uname = node.uname;
+            elems[k] = this.sa_function_statement(elem, opts);
+            if (elem.type === 'FunctionDef') {
+                if (elem.name === 'update') {
+                    ast.update_uname = elem.uname;
                 }
-                else if (node.name === 'expire') {
-                    ast.expire_uname = node.uname;
+                else if (elem.name === 'expire') {
+                    ast.expire_uname = elem.uname;
                 }
-                else if (node.name === 'reset') {
-                    ast.reset_uname = node.uname;
+                else if (elem.name === 'reset') {
+                    ast.reset_uname = elem.uname;
                 }
-                else if (node.name === 'result') {
-                    ast.result_uname = node.uname;
+                else if (elem.name === 'result') {
+                    ast.result_uname = elem.uname;
                 }
             }
         }


### PR DESCRIPTION
The new name is more logical and it is in line with most other code which processes AST nodes.

This is a small step toward #394, #395, and #396.