### PR TITLE
oops-fanin.js: Fix args passing to warn_oops

### DIFF
--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -50,7 +50,7 @@ class oops_fanin extends fanin {
     emit_mark(time, output_name) {
         if (this.watch_oops) {
             if (time.lt(this.last_output_time)) {
-                this.warn_oops();
+                this.warn_oops(time, this.last_output_time);
                 return;
             } else {
                 this.last_output_time = time;


### PR DESCRIPTION
warn_oops was called without arguments from emit_mark, which caused an
error masking the actuall out-of-order problem