### PR TITLE
add followLinkHeader to read adapter

### DIFF
--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -21,6 +21,10 @@ read http -url url
           -rootPath rootPath
           -includeHeaders true/false
           -format csv/json/jsonl
+          -followLinkHeader true/false
+          -pageParam parameter
+          -pageStart start
+          -pageUnit unit
 ```
 
 Parameter         |             Description          | Required?
@@ -34,6 +38,10 @@ Parameter         |             Description          | Required?
 `-includeHeaders` | When set to true the headers from the response are appended to each of the points in the response | No; default: `false`
 `-timeField`      | Name of the field in the data which contains a valid timestamp  | No; defaults to `time`
 `-format`         | HTTP data format, supports: `csv`, `json` and `jsonl` | No; defaults to HTTP response header `Content-Type`
+`-followLinkHeader` |  When set to true the [Web Linking](https://tools.ietf.org/html/rfc5988) feature is enabled which allows for automatic handling of paging as specified by the [RFC5988](https://tools.ietf.org/html/rfc5988). | No; default `false`
+`-pageParam`      | The name of the query parameter used to enable paging with multiple HTTP requests sent to the URL provided until response contains 0 records | No; defaults to paging behavior disabled
+`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request | No; default: `0`
+`-pageUnit <request|record>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. | No; default: `request`
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -5,15 +5,20 @@ var contentType = require('content-type');
 var AdapterRead = require('../adapter-read');
 var parsers = require('../parsers');
 var errors = require('../../errors');
+var parseLinkHeader = require('parse-link-header');
+var querystring = require('querystring');
 var Promise = require('bluebird');
 var request = require('request');
 var JuttleMoment = require('../../runtime/types/juttle-moment');
+var urlParse = require('url').parse;
+var urlFormat = require('url').format;
 
 class Iterator {
     constructor(adapter, res, from, to) {
         this.points = [];
         this.done = false;
         this.adapter = adapter;
+        this.total = 0;
 
         var format;
         try {
@@ -26,9 +31,18 @@ class Iterator {
             rootPath: this.adapter.rootPath,
             optimization: this.adapter.optimization_info
         });
-        this.adapter.logger.debug('starting parse');
+
+        if (res.headers['link']) {
+            var parsed = parseLinkHeader(res.headers['link']);
+            if (parsed.next) {
+                this.adapter.logger.debug('following link header', parsed.next.url);
+                this.linkHeader = parsed.next.url;
+            }
+        }
+
         this.parser.parseStream(res, (points) => {
             points = this.process(res, points, from, to);
+            this.total += points.length;
 
             // The current parser API doesn't offer any kind of backpressure,
             // so all we can do is manage our own buffer of points and return
@@ -41,7 +55,7 @@ class Iterator {
             this.adapter.trigger('error', err);
         })
         .then(() => {
-            this.adapter.logger.debug('done');
+            this.adapter.logger.debug('parse done, got', this.points.length, 'points');
             this.done = true;
             this.notify();
         });
@@ -78,12 +92,11 @@ class Iterator {
             this.waiter = null;
             var points = this.points;
             this.points = [];
-            var ret = {
-                state: this,
+            return {
                 points: points,
+                state: this,
                 readEnd: this.done ? new JuttleMoment(Infinity) : null
             };
-            return ret;
         });
     }
 
@@ -100,6 +113,30 @@ class ReadHTTP extends AdapterRead {
     constructor(options, params) {
         super(options, params);
 
+        if (params.filter_ast) {
+            throw new errors.compileError('ADAPTER-UNSUPPORTED-FILTER', {
+                proc: 'read http',
+                filter: 'filtering'
+            });
+        }
+
+        _.each(['pageParam', 'pageUnit', 'pageStart'], (option) => {
+            if (options.followLinkHeader && options[option] !== undefined) {
+                throw new errors.compileError('INCOMPATIBLE-OPTION', {
+                    option: 'followLinkHeader',
+                    other: option
+                });
+            }
+        });
+
+        if (options.pageUnit &&
+            !_.contains(['request', 'record'], options.pageUnit)) {
+            throw new errors.compileError('INVALID-OPTION-VALUE', {
+                option: 'pageUnit',
+                supported: 'request, record'
+            });
+        }
+
         this.url = options.url;
         this.method = options.method ? options.method : 'GET';
         this.headers = options.headers ? options.headers : {};
@@ -113,20 +150,20 @@ class ReadHTTP extends AdapterRead {
         this.includeHeaders = options.includeHeaders;
         this.rootPath = options.rootPath;
         this.format = options.format;
-
-        if (params.filter_ast) {
-            throw new errors.compileError('ADAPTER-UNSUPPORTED-FILTER', {
-                proc: 'read http',
-                filter: 'filtering'
-            });
-        }
-
+        this.followLinkHeader = options.followLinkHeader;
+        this.pageParam = options.pageParam;
+        this.pageStart = options.pageStart || 0;
+        this.pageCount = this.pageStart;
+        this.pageUnit = options.pageUnit || 'request';
         this.optimization_info = params && params.optimization_info || {};
     }
 
     static allowedOptions() {
         var httpOptions = ['url', 'method', 'headers', 'body', 'timeField',
-            'includeHeaders', 'rootPath', 'format'];
+                           'includeHeaders', 'rootPath', 'format',
+                           'followLinkHeader', 'pageParam', 'pageStart',
+                           'pageUnit'];
+
         return AdapterRead.commonOptions().concat(httpOptions);
     }
 
@@ -144,26 +181,75 @@ class ReadHTTP extends AdapterRead {
     }
 
     read(from, to, limit, iterator) {
-        // The first read call should kick off the actual fetch request.
-        //
-        // adapter returns a promise that either rejects with an error or resolves
-        // with an iterator object  that handles paging through the results in
-        // chunks that we return as the read state.
-        if (! iterator) {
-            return this.fetch(from, to)
-            .then((iterator) => {
-                return iterator.next(to);
-            });
-        } else {
-            return iterator.next(to);
-        }
+        // The first read call should kick off the actual fetch request. This
+        // returns a promise that either rejects with an error or resolves with
+        // an iterator object that handles paging through the results in chunks
+        // that we return as the read state.
+        var getIterator = iterator
+            ? Promise.resolve(iterator)
+            : this.fetch(this.url, from, to);
+
+        return getIterator
+        .then((iterator) => {
+            return iterator.next();
+        })
+        .then((result) => {
+            // To support paging, check if the current iterator (which is
+            // returned in result.state) got any points for the current page. If
+            // so, then advance the page and keep going. Otherwise just stop.
+            if (this.pageParam && result.readEnd) {
+                if (result.state.total === 0) {
+                    this.logger.debug('no results for page', this.pageCount, ' -- paging completed');
+                } else {
+                    this.logger.debug('got', result.state.total, 'results for page', this.nextPage);
+
+                    switch(this.pageUnit) {
+                        case 'request':
+                            this.pageCount++;
+                            break;
+
+                        case 'record':
+                            this.pageCount += result.state.total;
+                    }
+
+                    result.readEnd = undefined;
+                    result.state = undefined;
+                }
+            }
+
+            // if followLinkHeader is set and there is an actual linkHeader
+            // returned from the last fetch then lets follow that link
+            if (this.followLinkHeader && result.state.linkHeader) {
+                this.url = result.state.linkHeader;
+                result.readEnd = undefined;
+                result.state = undefined;
+            }
+
+            return result;
+        });
     }
 
-    fetch(from, to) {
+    fetch(url, from, to) {
         return new Promise((resolve, reject) => {
-            this.logger.debug('starting request', this.method, this.url);
+            if (this.pageParam) {
+                // when pageParam is set we manage the URL construction and use
+                // the options pageParam, pageStart and pageUnit
+                var parsedURL = urlParse(this.url);
+                var parsedQueryString = querystring.parse(parsedURL.query);
+                parsedQueryString[this.pageParam] = this.pageCount;
+
+                url = urlFormat({
+                    protocol: parsedURL.protocol,
+                    hostname: parsedURL.hostname,
+                    port: parsedURL.port,
+                    pathname: parsedURL.pathname,
+                    search: '?' + querystring.stringify(parsedQueryString)
+                });
+            }
+
+            this.logger.debug('starting request', this.method, url);
             request({
-                uri: this.url,
+                uri: url,
                 method: this.method,
                 headers: this.headers,
                 body: JSON.stringify(this.body)
@@ -189,9 +275,7 @@ class ReadHTTP extends AdapterRead {
                             error: message
                         }));
                     });
-                }
-                // Otherwise create a new iterator to handle the stream
-                else {
+                } else {
                     try {
                         resolve(new Iterator(this, res, from, to));
                     } catch(err) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "moment-parser": "^0.3.0",
     "moment-timezone": "^0.4.0",
     "oboe": "^2.1.2",
+    "parse-link-header": "^0.4.1",
     "pegjs": "^0.9.0",
     "request": "^2.67.0",
     "seedrandom": "^2.3.6",

--- a/test/adapters/http/test-server.js
+++ b/test/adapters/http/test-server.js
@@ -343,6 +343,73 @@ class TestHTTPServer {
                 }
             });
 
+            this.app.get('/pageByRequest', (req, res) => {
+                // returns 5 pages with 1 point at a time
+                var page;
+                if (req.query['page']) {
+                    page = parseInt(req.query.page);
+                }
+
+                res.set('Content-Type', 'application/json');
+                res.status(200);
+                if (page <= 5 ) {
+                    var data = [{ page: page, index: 0 }];
+                    res.end(JSON.stringify(data));
+                } else {
+                    res.end('[]');
+                }
+            });
+
+            this.app.get('/pageByRecord', (req, res) => {
+                // returns 5 records based on the record count and limit parameter
+                var offset = parseInt(req.query['offset']);
+                var limit = parseInt(req.query['limit']);
+                
+                var left = 5 - offset;
+                res.set('Content-Type', 'application/json');
+                res.status(200);
+
+                if (left < 0) { 
+                    res.end('[]');
+                } else { 
+                    var data = [];
+                
+                    if (left < limit) { 
+                        limit = left;
+                    }
+                   
+                    for (var index = 0; index < limit; index++) {
+                        data.push({ index: offset + index});
+                    }
+
+                    res.end(JSON.stringify(data));
+                }
+            });
+
+            this.app.get('/linked', (req, res) => {
+                // returns 5 pages with 1 point at a time and provides the
+                // `Link` header needed to get the subsequent elements
+                var page = 0;
+                var next = 1;
+                if (req.query['page']) {
+                    page = parseInt(req.query.page);
+                    next = page + 1;
+                }
+
+                if (next < 5) {
+                    res.set('Link', '<' + this.url + '/linked?page=' + next + '>; rel="next"');
+                }
+
+                res.set('Content-Type', 'application/json');
+                if (page < 5 ) {
+                    var data = [{ page: next, index: 0 }];
+                    res.status(200);
+                    res.end(JSON.stringify(data));
+                } else {
+                    res.status(400);
+                }
+            });
+
             this.server = this.app.listen(port);
             this.url = 'http://localhost:' + port;
         });


### PR DESCRIPTION
partially fixes #195

added the option `-followLinkHeader` to http read adapter that allows
for automatic following of the HTTP Link header as described in
https://tools.ietf.org/html/rfc5988