### PR TITLE
SemanticPass: Do not return nodes

### DIFF
--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -204,7 +204,12 @@ class GraphBuilder {
     value_ast(result) {
         // The _semantic_ast call is needed to correctly process filter
         // literals.
-        return this._semantic_ast(values.toAST(result));
+        var semantic = new SemanticPass({ now: this.now });
+        var ast = values.toAST(result);
+
+        semantic.sa_expr(ast);
+
+        return ast;
     }
     build_sub_args(sub_sig, callopts, subname, location) {
         var opts = {};
@@ -252,10 +257,6 @@ class GraphBuilder {
         }
 
         return null;
-    }
-    _semantic_ast(ast) {
-        var semantic = new SemanticPass({ now: this.now });
-        return semantic.sa_expr(ast);
     }
 }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -267,12 +267,12 @@ class SemanticPass {
     analyze(ast) {
         this.module_asts = ast.modules;
 
-        var analyzed_ast = this.sa_SubDef(ast);
+        this.sa_SubDef(ast);
 
-        analyzed_ast.modules = this.ordered_module_asts;
-        analyzed_ast.stats = this.stats;
+        ast.modules = this.ordered_module_asts;
+        ast.stats = this.stats;
 
-        return analyzed_ast;
+        return ast;
     }
     context() {
         return this.scope.type;
@@ -281,16 +281,14 @@ class SemanticPass {
     sa_var_decl(decl, opts) {
         var varname = decl.name;
         if (decl.expr) {
-            decl.expr = this.sa_expr(decl.expr, opts);
+            this.sa_expr(decl.expr, opts);
         }
         decl.uname = this.scope.define_variable(varname, 'var', false, false, false, decl.location);
-        return decl;
     }
     sa_const_decl(decl, exported, can_redefine, opts) {
         var varname = decl.name;
-        decl.expr = this.sa_expr(decl.expr, opts);
+        this.sa_expr(decl.expr, opts);
         decl.uname = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location);
-        return decl;
     }
     // a flowgraph node
     sa_proc(node, opts) {
@@ -298,19 +296,18 @@ class SemanticPass {
         //XXX check options and parameters for unknowns and illegals
         node.uname = uname;
         this.sa_options(node.options, opts);
-        return node;
     }
     sa_sub_call(node, sub) {
         var that = this;
         node.uname = this.scope.alloc_var();
         node.uname_sub = sub.name;
         node.options = _.map(node.options, function(opt) {
-            return {id: opt.id, expr:that.sa_expr(opt.expr), location: opt.location};
+            that.sa_expr(opt.expr);
+            return {id: opt.id, expr: opt.expr, location: opt.location};
         });
         node.sub_sig = _.map(sub.args, function(arg) {
             return { name: arg.name, required: !arg.default };
         });
-        return node;
     }
     //XXX this one operates in place on the option expressions
     //  does not check params
@@ -324,7 +321,7 @@ class SemanticPass {
             //   -> just need to pass down opts context right?!
             //   -> and right now, undefined implies build context so we are ok
 
-            options[index].expr = that.sa_expr(option.expr, opts);
+            that.sa_expr(option.expr, opts);
         });
     }
     enter_scope(context) {
@@ -386,7 +383,7 @@ class SemanticPass {
         var d = true;
         if (args) {
             for (k = 0; k < args.length; ++k) {
-                args[k] = this.sa_expr(args[k], opts);
+                this.sa_expr(args[k], opts);
                 d = d && args[k].d;
             }
         }
@@ -398,7 +395,6 @@ class SemanticPass {
             // Math.random() (PROD-4556)
             node.d = false;
         }
-        return node;
     }
     can_export() {
         return (this.context() === 'module' || this.context() === 'main');
@@ -435,7 +431,8 @@ class SemanticPass {
             case 'SequentialGraph':
             case 'ImportStatement':
             case 'ParallelGraph':
-                return this['sa_' + node.type](node);
+                this['sa_' + node.type](node);
+                break;
 
             default:
                 throw new Error('unrecognized statement type ' + node.type);
@@ -457,7 +454,7 @@ class SemanticPass {
         this.import_standard_modules();
 
         for (k = 0; k < elems.length; ++k) {
-            elems[k] = this.sa_statement(elems[k]);
+            this.sa_statement(elems[k]);
         }
 
         this.modules[node.name] = {
@@ -465,7 +462,6 @@ class SemanticPass {
             exports: this.scope.exports()
         };
         this.scope = saved_scope;
-        return node;
     }
     sa_SubDef(node) {
         var uname, elems, k, has_graph;
@@ -477,9 +473,9 @@ class SemanticPass {
         this.enter_scope(node.name === 'main' ? 'main' : 'sub');
 
         elems = node.elements;
-        node.args = this.sa_args(node.args);
+        this.sa_args(node.args);
         for (k = 0; k < elems.length; ++k) {
-            elems[k] = this.sa_statement(elems[k]);
+            this.sa_statement(elems[k]);
         }
         this.exit_scope();
 
@@ -494,8 +490,6 @@ class SemanticPass {
                 });
             }
         }
-
-        return node;
     }
 
     // statements that can appear inside functions or reducers
@@ -511,7 +505,8 @@ class SemanticPass {
             case 'IfStatement':
             case 'ReturnStatement':
             case 'ErrorStatement':
-                return this['sa_' + node.type](node, opts);
+                this['sa_' + node.type](node, opts);
+                break;
 
             default:
                 throw new Error('unrecognized function statement type ' + node.type);
@@ -529,11 +524,10 @@ class SemanticPass {
                 });
             }
 
-            args[k] = this.sa_FormalArg(args[k]);
+            this.sa_FormalArg(args[k]);
 
             seen_optional = is_optional;
         }
-        return args;
     }
     compute_arg_count(args) {
         var requiredArgs = _.filter(args, function(arg) {
@@ -548,10 +542,8 @@ class SemanticPass {
             : this.scope.define_const(node.name, false, true);
 
         if (node.default) {
-            node.default = this.sa_expr(node.default);
+            this.sa_expr(node.default);
         }
-
-        return node;
     }
     sa_FunctionDef(node, opts) {
         var elems, uname  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args));
@@ -561,15 +553,13 @@ class SemanticPass {
         var context = this.context().match(/reducer/) ? 'fn-in-' + this.context() : 'fn';
         this.enter_scope(context + ':' + node.name);
 
-        node.args = this.sa_args(node.args);
+        this.sa_args(node.args);
         elems = node.elements;
         for (var k = 0; k < elems.length; ++k) {
-            elems[k] = this.sa_function_statement(elems[k], opts);
+            this.sa_function_statement(elems[k], opts);
         }
 
         this.exit_scope();
-
-        return node;
     }
 
     sa_ReducerDef(node) {
@@ -581,7 +571,7 @@ class SemanticPass {
 
         this.enter_scope('reducer');
         elems = node.elements;
-        node.args = this.sa_args(node.args);
+        this.sa_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             var elem = elems[k];
             var opts = { context: 'build' };
@@ -599,7 +589,7 @@ class SemanticPass {
                     }
                 }
             }
-            elems[k] = this.sa_function_statement(elem, opts);
+            this.sa_function_statement(elem, opts);
             if (elem.type === 'FunctionDef') {
                 if (elem.name === 'update') {
                     node.update_uname = elem.uname;
@@ -616,8 +606,6 @@ class SemanticPass {
             }
         }
         this.exit_scope();
-
-        return node;
     }
     sa_StatementBlock(node, opts) {
         this.check_reducer_toplevel(node, 'a block');
@@ -625,10 +613,9 @@ class SemanticPass {
         var elems = node.elements;
         this.enter_scope('block-in-' + this.context());
         for (var k = 0; k < elems.length; ++k) {
-            elems[k] = this.sa_function_statement(elems[k], opts);
+            this.sa_function_statement(elems[k], opts);
         }
         this.exit_scope();
-        return node;
     }
     // elements of a flowgraph
     sa_proc_element(node) {
@@ -653,10 +640,10 @@ class SemanticPass {
             if (!node.options) {
                 node.options = [];
             }
-            return methods[node.type].call(this, node);
+            methods[node.type].call(this, node);
+        } else {
+            throw new Error('unrecognized processor or sub: ' + node.type);
         }
-
-        throw new Error('unrecognized processor or sub: ' + node.type);
     }
 
     sa_graph(node) {
@@ -671,20 +658,18 @@ class SemanticPass {
             node.outer_module = true;
         }
         for (k = 0; k < elems.length; k++) {
-            elems[k] = this.sa_proc_element(elems[k]);
+            this.sa_proc_element(elems[k]);
         }
-        return node;
     }
 
     sa_SequentialGraph(node) {
-        return this.sa_graph(node);
+        this.sa_graph(node);
     }
     sa_ParallelGraph(node) {
-        return this.sa_graph(node);
+        this.sa_graph(node);
     }
 
     sa_EmptyStatement(node, opts) {
-        return node;
     }
     // this type of assignment lives only in places where there are
     // no points or reducers
@@ -692,26 +677,23 @@ class SemanticPass {
         this.check_reducer_toplevel(node, 'an assignment');
 
         opts = opts || {};
-        node.left = this.sa_assignment_lhs(node.left, opts);
+        this.sa_assignment_lhs(node.left, opts);
         //XXX need to handle op's other than "="
-        node.expr = this.sa_expr(node.expr, opts);
-        return node;
+        this.sa_expr(node.expr, opts);
     }
     // this type of assignment lives in places where there can be
     // points or reducers
     sa_AssignmentExpression(node, opts) {
-        node.left = this.sa_assignment_lhs(node.left, opts);
-        node.right = this.sa_expr(node.right, opts);
+        this.sa_assignment_lhs(node.left, opts);
+        this.sa_expr(node.right, opts);
         node.d = node.left.d && node.right.d;
-        return node;
     }
     sa_VarStatement(node, opts) {
         opts = opts || {};
         var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
-            decls[k] = this.sa_var_decl(decls[k], opts);
+            this.sa_var_decl(decls[k], opts);
         }
-        return node;
     }
     sa_InputStatement(node, opts) {
         var self = this;
@@ -720,7 +702,8 @@ class SemanticPass {
         this.check_export(node);
 
         node.options = _.map(node.options, function(opt) {
-            var ret = {type: 'InputOption', id: opt.id, expr: self.sa_expr(opt.expr)};
+            self.sa_expr(opt.expr);
+            var ret = {type: 'InputOption', id: opt.id, expr: opt.expr};
             if (! ret.expr.d) {
                 throw errors.compileError('BAD-INPUT-OPTION', {
                     input: node.name,
@@ -734,8 +717,6 @@ class SemanticPass {
 
         var detector = new StaticInputDetector();
         node.static = detector.isStatic(node);
-
-        return node;
     }
     sa_ConstStatement(node, opts) {
         opts = opts || {};
@@ -748,9 +729,8 @@ class SemanticPass {
                     location: node.location
                 });
             }
-            decls[k] = this.sa_const_decl(decls[k], node.export, node.arg, opts);
+            this.sa_const_decl(decls[k], node.export, node.arg, opts);
         }
-        return node;
     }
     sa_ImportStatement(node, functions) {
         var self = this;
@@ -792,58 +772,50 @@ class SemanticPass {
 
         this.import_path.pop();
         this.stats.imports++;
-
-        return node;
     }
 
     sa_IfStatement(node, opts) {
         this.check_reducer_toplevel(node, 'an if statement');
 
-        node.condition = this.sa_expr(node.condition, opts);
-        node.ifStatement = this.sa_function_statement(node.ifStatement, opts);
+        this.sa_expr(node.condition, opts);
+        this.sa_function_statement(node.ifStatement, opts);
         if (node.elseStatement) {
-            node.elseStatement = this.sa_function_statement(node.elseStatement,
-                                                           opts);
+            this.sa_function_statement(node.elseStatement,
+                                      opts);
         }
-        return node;
     }
     sa_ReturnStatement(node, opts) {
         this.check_reducer_toplevel(node, 'a return statement');
 
         if (node.value) {
-            node.value = this.sa_expr(node.value, opts);
+            this.sa_expr(node.value, opts);
         }
-        return node;
     }
     sa_ErrorStatement(node, opts) {
-        node.message = this.sa_expr(node.message, opts);
-        return node;
+        this.sa_expr(node.message, opts);
     }
 
     sa_ExpressionFilterTerm(node, opts) {
-        node.expression = this.sa_expr(node.expression, { context: 'filter', coerce_var: 'field' });
+        this.sa_expr(node.expression, { context: 'filter', coerce_var: 'field' });
         // will be carried in AST form to a proc implementation
         node.expression.d = false;
         node.d = false;
-        return node;
     }
     sa_SimpleFilterTerm(node) {
-        node.expression = this.sa_expr(node.expression);
+        this.sa_expr(node.expression);
         // will be carried in AST form to a proc implementation
         node.d = false;
-        return node;
     }
     sa_FilterLiteral(node) {
-        node.ast = this.sa_expr(node.ast);
+        this.sa_expr(node.ast);
         // will be carried in AST form to a proc implementation
         node.d = false;
-        return node;
     }
     sa_filter_proc(node, opts) {
         if (node.filter) {
-            node.filter = this.sa_expr(node.filter, opts);
+            this.sa_expr(node.filter, opts);
         }
-        return this.sa_proc(node);
+        this.sa_proc(node);
     }
     sa_sequence_proc(node) {
         var self = this;
@@ -857,17 +829,17 @@ class SemanticPass {
             node.options.push({id: 'groupby', expr:node.groupby});
             delete node.groupby;
         }
-        node.filters = _.map(node.filters, function (node) { return self.sa_expr(node); });
-        return this.sa_proc(node);
+        _.each(node.filters, function (node) { self.sa_expr(node); });
+        this.sa_proc(node);
     }
     sa_FilterProc(node) {
-        return this.sa_filter_proc(node, { allow_field_comparisons: true });
+        this.sa_filter_proc(node, { allow_field_comparisons: true });
     }
     sa_SequenceProc(node) {
-        return this.sa_sequence_proc(node);
+        this.sa_sequence_proc(node);
     }
     sa_ReadProc(node) {
-        return this.sa_filter_proc(node, { allow_field_comparisons: false });
+        this.sa_filter_proc(node, { allow_field_comparisons: false });
     }
     sa_option_proc(node, options) {
         // Some procs have syntactical sugar for parameters (e.g. the limit in
@@ -882,10 +854,10 @@ class SemanticPass {
                 delete node[option];
             }
         });
-        return this.sa_proc(node);
+        this.sa_proc(node);
     }
     sa_SortProc(node) {
-        return this.sa_option_proc(node, ['groupby', 'columns']);
+        this.sa_option_proc(node, ['groupby', 'columns']);
     }
     sa_View(node) {
         // The "coerce_var" option needs to be set explicitly so that sa_ByList
@@ -894,28 +866,25 @@ class SemanticPass {
             coerce_var: 'none'
         };
 
-        return this.sa_proc(node, opts);
+        this.sa_proc(node, opts);
     }
     sa_ObjectLiteral(node, opts) {
         var k, props;
         var d = true;
         props = node.properties;
         for (k = 0; k < props.length; ++k) {
-            props[k] = this.sa_ObjectProperty(props[k], opts);
+            this.sa_ObjectProperty(props[k], opts);
             d = d && props[k].d;
         }
         node.d = d;
-        return node;
     }
     sa_ObjectProperty(node, opts) {
-        node.key = this.sa_expr(node.key, opts);
-        node.value = this.sa_expr(node.value, opts);
+        this.sa_expr(node.key, opts);
+        this.sa_expr(node.value, opts);
         node.d = node.key.d && node.value.d;
-        return node;
     }
     sa_RegExpLiteral(node) {
         node.d = true;
-        return node;
     }
     sa_reducer_arg(arg, opts) {
         // coerce a naked name to a string (ie a field name) if it
@@ -928,14 +897,12 @@ class SemanticPass {
             // single variable arguments to be coerced...? and other
             // reducer undefined variables to be flagged as such...
             // not sure
-            return {
-                type:'StringLiteral',
-                value:arg.name,
-                location:arg.location
-            };
+            arg.type ='StringLiteral';
+            arg.value = arg.name;
+            delete arg.name;
         } else {
             // reducer *arguments* are evaluated at build time
-            return this.sa_expr(arg, {context:'build'});
+            this.sa_expr(arg, {context:'build'});
         }
     }
     //
@@ -978,7 +945,7 @@ class SemanticPass {
 
         for (k = 0; k < node.exprs.length; ++k) {
             opts.index = k;
-            node.exprs[k] = this.sa_expr(node.exprs[k], opts);
+            this.sa_expr(node.exprs[k], opts);
         }
         //
         // decorate the AST with the list of reducers that are used
@@ -993,22 +960,21 @@ class SemanticPass {
             node.options.push({id: 'groupby', expr:node.groupby});
             delete node.groupby;
         }
-        return this.sa_proc(node);
+        this.sa_proc(node);
     }
     sa_ReduceProc(node) {
-        var reified = this.sa_reifier_proc(node, {context: 'reduce'});
-        reified.reducers.forEach(function(reducer) {
+        this.sa_reifier_proc(node, {context: 'reduce'});
+        node.reducers.forEach(function(reducer) {
             if (reducer.name === 'delta') {
                 throw errors.compileError('REDUCE-DELTA-ERROR', {
                     location: node.location
                 });
             }
         });
-        return reified;
     }
     sa_PutProc(node) {
-        return this.sa_reifier_proc(node, {context: 'stream',
-                                         coerce_var: 'field'});
+        this.sa_reifier_proc(node, {context: 'stream',
+                                  coerce_var: 'field'});
     }
 
     sa_builtin_proc(node) {
@@ -1031,19 +997,19 @@ class SemanticPass {
             node.options.push({id: attrname, expr: node[attrname]});
             delete node[attrname];
         });
-        return this.sa_proc(node);
+        this.sa_proc(node);
     }
     sa_OptionOnlyProc(node) {
-        return this.sa_builtin_proc(node);
+        this.sa_builtin_proc(node);
     }
     sa_WriteProc(node) {
-        return this.sa_proc(node);
+        this.sa_proc(node);
     }
     sa_SingleArgProc(node) {
-        return this.sa_builtin_proc(node);
+        this.sa_builtin_proc(node);
     }
     sa_FieldListArgProc(node) {
-        return this.sa_builtin_proc(node);
+        this.sa_builtin_proc(node);
     }
     sa_FunctionProc(node) {
         var sub;
@@ -1077,14 +1043,14 @@ class SemanticPass {
         }
 
         this.stats.subs++;
-        return this.sa_sub_call(node, sub);
+        this.sa_sub_call(node, sub);
     }
 
     sa_assignment_lhs(node, opts) {
         switch (node.type) {
             case 'UnaryExpression':
-                node = this.sa_UnaryExpression(node, opts);
-                return node;
+                this.sa_UnaryExpression(node, opts);
+                break;
 
             case 'Variable':
                 if (!this.scope.lookup_variable(node.name)) {
@@ -1099,10 +1065,12 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                return this.sa_Variable(node, opts);
+                this.sa_Variable(node, opts);
+                break;
 
             case 'Field':
-                return this.sa_Field(node, opts);
+                this.sa_Field(node, opts);
+                break;
 
             case 'MemberExpression':
                 if (!this.scope.is_mutable(node.object.name, opts, this.context())) {
@@ -1111,7 +1079,8 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                return this.sa_MemberExpression(node, opts);
+                this.sa_MemberExpression(node, opts);
+                break;
 
             default:
                 throw new Error('unrecognized expression lhs ' + node.type);
@@ -1130,7 +1099,7 @@ class SemanticPass {
             case 'MomentLiteral':
             case 'DurationLiteral':
                 node.d = true;
-                return node;
+                break;
 
             case 'AssignmentExpression':
             case 'CallExpression':
@@ -1151,7 +1120,8 @@ class SemanticPass {
             case 'ExpressionFilterTerm':
             case 'SimpleFilterTerm':
             case 'FilterLiteral':
-                return this['sa_' + node.type](node, opts);
+                this['sa_' + node.type](node, opts);
+                break;
 
             default:
                 throw new Error('unrecognized expression type ' + node.type);
@@ -1165,7 +1135,7 @@ class SemanticPass {
             case 'MemberExpression':
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
-                node.expression = this.sa_expr(node.expression, opts);
+                this.sa_expr(node.expression, opts);
                 if (!this.scope.is_mutable(name, opts, this.context())) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
                         operator: node.operator,
@@ -1174,7 +1144,7 @@ class SemanticPass {
                     });
                 }
                 node.d = node.expression.d;
-                return node;
+                break;
             default:
                 throw errors.compileError('INVALID-POSTFIX-LHS', {
                     location: node.location
@@ -1207,9 +1177,9 @@ class SemanticPass {
                 this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
                 node.context = opts.context; // needed because reducer calls are different in put vs reduce
                 for (i = 0; i < args.length; ++i) {
-                    args[i] = this.sa_reducer_arg(args[i]);
+                    this.sa_reducer_arg(args[i]);
                 }
-                return node;
+                return;
             } else {
                 funcInfo = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
                 if (funcInfo === undefined) {
@@ -1222,7 +1192,8 @@ class SemanticPass {
                 }
                 node.callee.symbol = funcInfo;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                return (this.sa_function_call(node, funcInfo, opts));
+                this.sa_function_call(node, funcInfo, opts);
+                return;
             }
         } else {
             //XXX fragile b/c parser allows for expressions as function
@@ -1247,9 +1218,8 @@ class SemanticPass {
             node.callee.symbol = funcInfo;
             node.context = opts.context; // needed because reducer calls are different in put vs reduce
             for (i = 0; i < args.length; ++i) {
-                args[i] = this.sa_reducer_arg(args[i]);
+                this.sa_reducer_arg(args[i]);
             }
-            return node;
         } else {
             funcInfo = this.scope.get(fname);
             if (!funcInfo) {
@@ -1265,14 +1235,14 @@ class SemanticPass {
                 });
             }
             node.callee.symbol = funcInfo;
-            return this.sa_function_call(node, funcInfo, opts);
+            this.sa_function_call(node, funcInfo, opts);
         }
     }
     sa_UnaryExpression(node, opts) {
         var op = node.operator;
         var name;
 
-        node.argument = this.sa_expr(node.argument, opts);
+        this.sa_expr(node.argument, opts);
         if (op === '*') {
             if (opts.context !== 'stream' && opts.context !== 'reduce' && opts.context !== 'filter') {
                 throw errors.compileError('INVALID-FIELD-REFERENCE', {
@@ -1280,7 +1250,7 @@ class SemanticPass {
                 });
             }
             node.d = false;
-            return node;
+            return;
         }
         node.d = node.argument.d;
         //XXX limit allowable operators?  why only look for these two?
@@ -1295,41 +1265,36 @@ class SemanticPass {
                 });
             }
         }
-        return node;
     }
     sa_BinaryExpression(node, opts) {
-        node.left = this.sa_expr(node.left, opts);
-        node.right = this.sa_expr(node.right, opts);
+        this.sa_expr(node.left, opts);
+        this.sa_expr(node.right, opts);
         node.d = node.left.d && node.right.d;
-        return node;
     }
     sa_ConditionalExpression(node, opts) {
-        node.test = this.sa_expr(node.test, opts);
-        node.alternate = this.sa_expr(node.alternate, opts);
-        node.consequent = this.sa_expr(node.consequent, opts);
+        this.sa_expr(node.test, opts);
+        this.sa_expr(node.alternate, opts);
+        this.sa_expr(node.consequent, opts);
         //XXX can be smarter than this
         node.d = node.test.d && node.alternate.d && node.consequent.d;
-        return node;
     }
     sa_MultipartStringLiteral(node, opts) {
         var k;
         var d = true;
         for (k = 0; k < node.parts.length; k++) {
-            node.parts[k] = this.sa_expr(node.parts[k], opts);
+            this.sa_expr(node.parts[k], opts);
             d = d && node.parts[k].d;
         }
         node.d = d;
-        return node;
     }
     sa_ArrayLiteral(node, opts) {
         var k;
         var d = true;
         for (k = 0; k < node.elements.length; k++) {
-            node.elements[k] = this.sa_expr(node.elements[k], opts);
+            this.sa_expr(node.elements[k], opts);
             d = d && node.elements[k].d;
         }
         node.d = d;
-        return node;
     }
     sa_ByList(node, opts) {
         var k, elem = node.elements;
@@ -1345,22 +1310,20 @@ class SemanticPass {
         // results into a top level array that is the list of strings
         // representing the field names
         for (k = 0; k < elem.length; k++) {
-            elem[k] = this.sa_expr(elem[k], opts);
+            this.sa_expr(elem[k], opts);
             d = d && elem[k].d;
         }
         node.d = d;
-        return node;
     }
     sa_SortByList(node) {
         var k, elem = node.elements;
         var d = true;
         var opts = {coerce_var:'string'};
         for (k = 0; k < elem.length; k++) {
-            elem[k].expr = this.sa_expr(elem[k].expr, opts);
+            this.sa_expr(elem[k].expr, opts);
             d = d && elem[k].d;
         }
         node.d = d;
-        return node;
     }
     sa_Variable(node, opts) {
         var varInfo = this.scope.get(node.name);
@@ -1369,25 +1332,19 @@ class SemanticPass {
             node.uname = this.scope.lookup_variable(node.name);
             node.symbol = varInfo;
             node.d = varInfo.d;
-
-            return node;
         } else {
             switch (opts.coerce_var) {
                 case 'string':
-                    return {
-                        type: 'StringLiteral',
-                        value: node.name,
-                        d:true,
-                        location: node.location
-                    };
+                    node.type = 'StringLiteral';
+                    node.value = node.name;
+                    node.d = true;
+                    delete node.name;
+                    break;
 
                 case 'field':
-                    return {
-                        type: 'Field',
-                        name: node.name,
-                        d:false,
-                        location: node.location
-                    };
+                    node.type = 'Field';
+                    node.d = false;
+                    break;
 
                 default:
                     throw errors.compileError('UNDEFINED', {
@@ -1404,12 +1361,10 @@ class SemanticPass {
             });
         }
         node.d = false;
-        return node;
     }
     sa_ToString(node, opts) {
-        node.expression = this.sa_expr(node.expression, opts);
+        this.sa_expr(node.expression, opts);
         node.d = node.expression.d;
-        return node;
     }
     sa_MemberExpression(node, opts) {
         var varInfo;
@@ -1424,19 +1379,18 @@ class SemanticPass {
                 });
             }
 
-            node.object = this.sa_expr(node.object, opts);
+            this.sa_expr(node.object, opts);
 
             node.uname = varInfo.name;
             node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             node.d = true;
         }
         else {
-            node.object = this.sa_expr(node.object, opts);
-            node.property = this.sa_expr(node.property, opts);
+            this.sa_expr(node.object, opts);
+            this.sa_expr(node.property, opts);
             node.d = node.object.d && node.property.d;
             //XXX/TBD need to track d flag in arrays...
         }
-        return node;
     }
 }
 

--- a/test/compiler/filters/process-filter.js
+++ b/test/compiler/filters/process-filter.js
@@ -12,7 +12,7 @@ function processFilter(filter) {
     // We need to run the semantic pass to convert Variable nodes to field
     // references.
     var semantic = new SemanticPass();
-    ast = semantic.sa_expr(ast);
+    semantic.sa_expr(ast);
 
     var simplifier = new FilterSimplifier();
     ast = simplifier.simplify(ast);


### PR DESCRIPTION
The semantics pass was somewhat schizophrenic: its methods modified AST nodes in-place, but they also returned them, which would normally suggest a functional interface without in-place modifications.

This commit bends semantic pass internals firmly toward the in-place modification side, getting rid of node returns and fixing all places where returned nodes were used. The other alternative was to keep the returns and modify the code to work in functional style, always returning new nodes. This would complicate the code, cause performance problems, and provide little overall benefit, so I decided not to go this way, despite its apparent elegance.

One disadvantage of this approach is that `sa_Variable` and `sa_reducer_arg`, which created new nodes, now have to modify the existing ones, including changing their type. I suppose this will get solved once the semantic pass is split into multiple passes (which is a long-term goal) and pass containing these becomes an instance of `ASTTransformer`.

Note the schizophrenia was kept at the interface level (the `analyze` method). I may provide a functional interface at that level in the future by cloning the whole tree before processing, but I didn’t want to go into that now.

Also note this change reduces quite some code which was previously part of assignments to pure traversal (see e.g. `sa_BinaryExpression`). This means it will be possible to replace it by `super.*` calls when `SemanticPass` becomes an instance of `ASTVisitor`.

This is a prep work for #419.