### PR TITLE
Fanin readability

### DIFF
--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -122,13 +122,15 @@ class Input {
         // null. In case of ties, prefer marks so they always go out
         // ahead of points in their batch. An item with no timestamps
         // will be considered earliest of all.
+        var pendingInputs = _.filter(this.ins, (input) => { return !input.empty(); });
+
+        if (_.isEmpty(pendingInputs)) { return null; }
+
         var earliest = null;
         var earliest_time = null;
-        for (var i = 0 ; i < this.ins.length ; i++) {
-            var input = this.ins[i];
-            if (input.empty()) {
-                continue;
-            } else if (!earliest) {
+        for (var i = 0 ; i < pendingInputs.length ; i++) {
+            var input = pendingInputs[i];
+            if (!earliest) {
                 earliest = input;
                 earliest_time = input.first().time;
             } else if (!earliest_time) {

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -117,11 +117,11 @@ class Input {
         input.push(tpoint);
         this.produce();
     }
+    // Return the input having the earliest itemstamped item or an input
+    // containing a point with no timestamp. In case of ties, prefer marks so
+    // they always go out ahead of points in their batch. If all inputs are empty,
+    // return null.
     earliest() {
-        // return the input having the earliest itemstamped item, or
-        // null. In case of ties, prefer marks so they always go out
-        // ahead of points in their batch. An item with no timestamps
-        // will be considered earliest of all.
         var pendingInputs = _.filter(this.ins, (input) => { return !input.empty(); });
 
         if (_.isEmpty(pendingInputs)) { return null; }

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -147,18 +147,18 @@ class Input {
         return earliest;
     }
     produce() {
-        // Whenever we have a timestamp present on each input, or a
-        // timestamp equal to the most recently emitted timestamp on
-        // an input, dequeue the earliest item. Emit it, unless it is
-        // a duplicate of the most recent mark or it is a tick (they
-        // are no longer realtime once queued). Hold back emitting an
-        // eof until all inputs are at eof.
         var earliest = this.earliest();
-        while (earliest &&
-               (!earliest.first().time
-                || earliest.first().time.eq(this.last_emitted)
-                || this.ins.every(function backlogged(input) {
-                    return !input.empty(); }))) {
+        while (earliest) {
+            var produceMore =
+                // All inputs have something to say
+                this.ins.every((input) => { return !input.empty(); })
+                // Or some are empty and the earliest is a timeless point
+                || !earliest.first().time
+                // or has a timestamp equal to most recently emitted point/mark/tick
+                || earliest.first().time.eq(this.last_emitted);
+
+            if (!produceMore) { break; }
+
             var output = earliest.shift();
             if (output.eof) {
                 // backlogged is true, so this only happens when every input is eof

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -126,6 +126,10 @@ class Input {
 
         if (_.isEmpty(pendingInputs)) { return null; }
 
+        var timelessInput = _.find(pendingInputs, (input) => { return !input.first().time; });
+
+        if (timelessInput) { return timelessInput; }
+
         var earliest = null;
         var earliest_time = null;
         for (var i = 0 ; i < pendingInputs.length ; i++) {
@@ -133,8 +137,6 @@ class Input {
             if (!earliest) {
                 earliest = input;
                 earliest_time = input.first().time;
-            } else if (!earliest_time) {
-                break;
             } else {
                 var p = input.first();
                 if (!p.time

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -50,7 +50,6 @@ class Input {
         this.last_mark = JuttleMoment.epsMoment(-Infinity) ;
         this.last_tick = JuttleMoment.epsMoment(-Infinity) ;
         this.last_emitted = JuttleMoment.epsMoment(-Infinity) ;
-        this.emitted_eof = false;
     }
     build_input(proc) {
         return new Input({proc: proc}) ;
@@ -160,14 +159,17 @@ class Input {
             if (!produceMore) { break; }
 
             var output = earliest.shift();
+
+            // If we got here, all inputs were nonempty (produceMore was true).
+            // As EOFs are added to the queue with a timestamp +Infinity and
+            // the earliest point is an EOF, this implies all inputs are EOFs.
+            // Shifting an EOF from of one of the inputs and getting out of the
+            // loop will ensure EOF is emitted only once.
             if (output.eof) {
-                // backlogged is true, so this only happens when every input is eof
-                if (!this.emitted_eof) {
-                    this.eof();
-                    this.emitted_eof = true;
-                }
+                this.eof();
                 break;
             }
+
             if (output.mark && output.time.gt(this.last_mark)) {
                 // de-dup marks
                 this.mark(output.time);

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -130,24 +130,16 @@ class Input {
 
         if (timelessInput) { return timelessInput; }
 
-        var earliest = null;
-        var earliest_time = null;
-        for (var i = 0 ; i < pendingInputs.length ; i++) {
-            var input = pendingInputs[i];
-            if (!earliest) {
-                earliest = input;
-                earliest_time = input.first().time;
+        return _.reduce(pendingInputs, (earliest, input) => {
+            var inPt = input.first();
+            var earliestPt = earliest.first();
+
+            if (inPt.time.lt(earliestPt.time) || (inPt.mark && inPt.time.eq(earliestPt.time))) {
+                return input;
             } else {
-                var p = input.first();
-                if (!p.time
-                    || p.time.lt(earliest_time)
-                    || p.time.eq(earliest_time) && p.mark) {
-                    earliest = input;
-                    earliest_time = p.time;
-                }
+                return earliest;
             }
-        }
-        return earliest;
+        }, pendingInputs.shift());
     }
     produce() {
         var earliest = this.earliest();


### PR DESCRIPTION
Improve readability of fanin's 'input with earliest point' selection.

Commit refactoring the `earliest` loop will be squashed - they were kept separate for easier review.