### PR TITLE
test-adapter-timeseries.js - support emitting more points during one tick

### DIFF
--- a/test/runtime/test-adapter-timeseries/index.js
+++ b/test/runtime/test-adapter-timeseries/index.js
@@ -25,6 +25,7 @@ class TestTimeseriesRead extends AdapterRead {
         }
 
         this.every = options.every || this.defaultTimeOptions().every;
+        this.density = options.density || 1; // points per batch
         this.count = 0;
     }
 
@@ -39,6 +40,8 @@ class TestTimeseriesRead extends AdapterRead {
         });
     }
 
+    static allowedOptions() { return super.commonOptions().concat(['density']); }
+
     read(from, to, limit, state) {
         // Use the state to store the next timestamp to send.
         if (! state) {
@@ -46,6 +49,7 @@ class TestTimeseriesRead extends AdapterRead {
         }
 
         var points = [];
+
         while (points.length < limit) {
             if (state.gte(to)) {
                 break;
@@ -56,7 +60,7 @@ class TestTimeseriesRead extends AdapterRead {
                 count: this.count++
             });
 
-            state = state.add(this.every);
+            state = state.add(this.every.divide(this.density));
         }
 
         return Promise.resolve({


### PR DESCRIPTION
For testing two parallel timeseries reads where each reads different # of points.