### PR TITLE
SemanticPass: Kill unames (almost)

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -293,14 +293,14 @@ class Build extends CodeGenerator {
     gen_FunctionDef(node) {
         var k, elems = node.elements;
         var args = _.map(node.args, arg => arg.symbol.uname);
-        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
+        this.emit('var ' + node.symbol.uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args, false);
         for (k = 0; k < elems.length; ++k) {
             this.gen_function_statement(elems[k]);
         }
         this.emit('return null;\n');
         this.emit('};\n');
-        this.emit(node.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
+        this.emit(node.symbol.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
 
         node = this.build_reify(node);
 

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -98,7 +98,7 @@ class Build extends CodeGenerator {
         return code;
     }
     gen_const_decl(decl) {
-        var uname = decl.uname;
+        var uname = decl.symbol.uname;
         var code = this.gen_var(uname);
         code += uname;
         code += ' = ';

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -79,7 +79,7 @@ class Build extends CodeGenerator {
         code = '(function(builder, juttle) {\n';
         code += body;
         code += 'builder.record_stats(' + JSON.stringify(ast.stats) + ');';
-        code += ast.uname + '();\n';
+        code += ast.symbol.uname + '();\n';
         code += '});\n';
         return code;
     }
@@ -220,7 +220,7 @@ class Build extends CodeGenerator {
         opts.path_info = opts.path_info || {};
         var flowgraph, returnVal;
         var args = _.map(node.args, arg => arg.symbol.uname);
-        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
+        this.emit('var ' + node.symbol.uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args, true);
 
         var self = this;

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -90,8 +90,8 @@ class Build extends CodeGenerator {
         return 'var ' + uname + ';\n';
     }
     gen_var_decl(decl) {
-        var code = this.gen_var(decl.uname);
-        code += decl.uname;
+        var code = this.gen_var(decl.symbol.uname);
+        code += decl.symbol.uname;
         code += ' = ';
         code += decl.expr ? this.gen_expr(decl.expr) : 'null';
         code += ';\n';

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -569,7 +569,7 @@ class Build extends CodeGenerator {
             case 'MemberExpression':
                 return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return node.uname;
+                return node.symbol.uname;
             case 'Field':
                 return this.gen_Field(node);
             default:
@@ -780,7 +780,7 @@ class Build extends CodeGenerator {
     gen_Variable(node) {
         switch (node.symbol.type) {
             case 'const':
-                return 'builder.get_const("' + node.uname + '")';
+                return 'builder.get_const("' + node.symbol.uname + '")';
             case 'import':
             case 'function':
             case 'reducer':
@@ -790,7 +790,7 @@ class Build extends CodeGenerator {
                     location: node.location
                 });
             default:
-                return node.uname;
+                return node.symbol.uname;
         }
     }
     gen_Field(node) {

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -547,7 +547,7 @@ class Build extends CodeGenerator {
             return option.id + ': ' + self.gen_expr(option.expr);
         }).join(', ') + '}';
 
-        var uname = node.uname;
+        var uname = node.symbol.uname;
         var code = this.gen_var(uname);
 
         code += uname;

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -219,7 +219,7 @@ class Build extends CodeGenerator {
         opts = opts || {};
         opts.path_info = opts.path_info || {};
         var flowgraph, returnVal;
-        var args = _.pluck(node.args, 'uname');
+        var args = _.map(node.args, arg => arg.symbol.uname);
         this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args, true);
 
@@ -266,13 +266,13 @@ class Build extends CodeGenerator {
     gen_fill_args(args, define_consts) {
         for (var k = 0; k < args.length; k++) {
             if (args[k].default) {
-                this.emit('if (' + args[k].uname + ' === undefined) {\n');
-                this.emit(args[k].uname + ' = ' + this.gen_expr(args[k].default) + ';\n');
+                this.emit('if (' + args[k].symbol.uname + ' === undefined) {\n');
+                this.emit(args[k].symbol.uname + ' = ' + this.gen_expr(args[k].default) + ';\n');
                 this.emit('}\n');
             }
 
             if (define_consts) {
-                this.emit('builder.set_const("' + args[k].uname + '",' + args[k].uname + ');\n');
+                this.emit('builder.set_const("' + args[k].symbol.uname + '",' + args[k].symbol.uname + ');\n');
             }
         }
     }
@@ -292,7 +292,7 @@ class Build extends CodeGenerator {
     }
     gen_FunctionDef(node) {
         var k, elems = node.elements;
-        var args = _.pluck(node.args, 'uname');
+        var args = _.map(node.args, arg => arg.symbol.uname);
         this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args, false);
         for (k = 0; k < elems.length; ++k) {

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -798,7 +798,7 @@ class Build extends CodeGenerator {
     }
     gen_MemberExpression(node, opts) {
         if (!node.computed) {
-            return node.uname;
+            return node.symbol.uname;
         } else {
             if (opts.lhs) {
                 return this.gen_expr(node.object)

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -187,9 +187,9 @@ class GraphBuilder {
         this.functions.push(ast);
     }
     add_reducer(ast) {
-        var bname = ast.uname + '_' + this.uid++;
-        this.bnames[ast.uname] = bname;
-        ast.uname = bname;
+        var bname = ast.symbol.uname + '_' + this.uid++;
+        this.bnames[ast.symbol.uname] = bname;
+        ast.symbol.uname = bname;
         this.reducers.push(ast);
     }
     set_const(uname, val) {

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -180,10 +180,10 @@ class GraphBuilder {
         return input.value;
     }
     add_function(ast) {
-        var bname = ast.uname + '_' + this.uid++;
-        this.bnames[ast.uname] = bname;
-        ast.sname = ast.uname;
-        ast.uname = bname;
+        var bname = ast.symbol.uname + '_' + this.uid++;
+        this.bnames[ast.symbol.uname] = bname;
+        ast.sname = ast.symbol.uname;
+        ast.symbol.uname = bname;
         this.functions.push(ast);
     }
     add_reducer(ast) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -736,7 +736,7 @@ class GraphCompiler extends CodeGenerator {
     }
     gen_MemberExpression(node, opts) {
         if (!node.computed) {
-            return node.uname;
+            return node.symbol.uname;
         } else {
             if (opts.lhs) {
                 return this.gen_expr(node.object)

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -297,15 +297,15 @@ class GraphCompiler extends CodeGenerator {
     gen_fill_args(args) {
         for (var k = 0; k < args.length; k++) {
             if (args[k].default) {
-                this.emit('if (' + args[k].uname + ' === undefined) {\n');
-                this.emit(args[k].uname + ' = ' + this.gen_expr(args[k].default) + ';\n');
+                this.emit('if (' + args[k].symbol.uname + ' === undefined) {\n');
+                this.emit(args[k].symbol.uname + ' = ' + this.gen_expr(args[k].default) + ';\n');
                 this.emit('}\n');
             }
         }
     }
     gen_FunctionDef(node) {
         var k, elems = node.elements;
-        var args = _.pluck(node.args, 'uname');
+        var args = _.map(node.args, arg => arg.symbol.uname);
         if (node.stream) {
             args.unshift('pt');
         }
@@ -323,7 +323,7 @@ class GraphCompiler extends CodeGenerator {
     gen_ReducerDef(node) {
         var k, code;
         var uname = node.uname;
-        var args = _.pluck(node.args, 'uname');
+        var args = _.map(node.args, arg => arg.symbol.uname);
         this.emit('var ' + uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args);
         for (k = 0; k < node.elements.length; ++k) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -166,7 +166,7 @@ class GraphCompiler extends CodeGenerator {
         return code;
     }
     gen_const_decl(decl) {
-        var uname = decl.uname;
+        var uname = decl.symbol.uname;
         var code = this.gen_var(uname);
         code += uname;
         code += ' = ';

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -573,7 +573,7 @@ class GraphCompiler extends CodeGenerator {
             case 'MemberExpression':
                 return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return node.uname;
+                return node.symbol.uname;
             case 'Field':
                 return this.gen_Field(node, { lhs: true });
             default:
@@ -723,7 +723,7 @@ class GraphCompiler extends CodeGenerator {
                     location: node.location
                 });
             default:
-                return node.uname;
+                return node.symbol.uname;
         }
     }
     gen_Field(node, opts) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -158,8 +158,8 @@ class GraphCompiler extends CodeGenerator {
         return 'var ' + uname + ';\n';
     }
     gen_var_decl(decl) {
-        var code = this.gen_var(decl.uname);
-        code += decl.uname;
+        var code = this.gen_var(decl.symbol.uname);
+        code += decl.symbol.uname;
         code += ' = ';
         code += decl.expr ? this.gen_expr(decl.expr) : 'null';
         code += ';\n';

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -322,7 +322,7 @@ class GraphCompiler extends CodeGenerator {
 
     gen_ReducerDef(node) {
         var k, code;
-        var uname = node.uname;
+        var uname = node.symbol.uname;
         var args = _.map(node.args, arg => arg.symbol.uname);
         this.emit('var ' + uname + '= function(' + args.join(', ') + ') {\n');
         this.gen_fill_args(node.args);

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -309,15 +309,15 @@ class GraphCompiler extends CodeGenerator {
         if (node.stream) {
             args.unshift('pt');
         }
-        this.emit('var ' + node.uname + '= function(' + args.join(', ') + ') {\n');
-        this.emit('var ' + node.sname + ' = ' + node.uname + ';\n');
+        this.emit('var ' + node.symbol.uname + '= function(' + args.join(', ') + ') {\n');
+        this.emit('var ' + node.sname + ' = ' + node.symbol.uname + ';\n');
         this.gen_fill_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             this.gen_function_statement(elems[k]);
         }
         this.emit('return null;\n');
         this.emit('};\n');
-        this.emit(node.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
+        this.emit(node.symbol.uname + '.location = ' + JSON.stringify(node.location) + ';\n');
     }
 
     gen_ReducerDef(node) {

--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -97,28 +97,33 @@ class Scope {
     }
     define_var(name, exported) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'var', exported: exported, uname: runtimeVar });
-        return runtimeVar;
+        var symbol = { type: 'var', exported: exported, uname: runtimeVar };
+        this.put(name, symbol);
+        return symbol;
     }
     define_const(name, exported, d) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'const', exported: exported, uname: runtimeVar, d: d });
-        return runtimeVar;
+        var symbol = { type: 'const', exported: exported, uname: runtimeVar, d: d };
+        this.put(name, symbol);
+        return symbol;
     }
     define_sub(name, args, exported) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'sub', exported: exported, uname: runtimeVar, args: args });
-        return runtimeVar;
+        var symbol = { type: 'sub', exported: exported, uname: runtimeVar, args: args };
+        this.put(name, symbol);
+        return symbol;
     }
     define_func(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'function', exported: exported, arg_count: arg_count, uname: runtimeVar });
-        return runtimeVar;
+        var symbol = { type: 'function', exported: exported, arg_count: arg_count, uname: runtimeVar };
+        this.put(name, symbol);
+        return symbol;
     }
     define_reducer(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'reducer', exported: exported, arg_count: arg_count, uname: runtimeVar });
-        return runtimeVar;
+        var symbol = { type: 'reducer', exported: exported, arg_count: arg_count, uname: runtimeVar };
+        this.put(name, symbol);
+        return symbol;
     }
     define_variable(name, type, exported, can_redefine, d, location) {
         if (!can_redefine && this.symbols.hasOwnProperty(name)) {

--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -41,7 +41,7 @@ class Scope {
             switch (symbol.type) {
                 case 'const':
                 case 'var':
-                    return symbol.name;
+                    return symbol.uname;
             }
         }
 
@@ -97,27 +97,27 @@ class Scope {
     }
     define_var(name, exported) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'var', exported: exported, name: runtimeVar });
+        this.put(name, { type: 'var', exported: exported, uname: runtimeVar });
         return runtimeVar;
     }
     define_const(name, exported, d) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'const', exported: exported, name: runtimeVar, d: d });
+        this.put(name, { type: 'const', exported: exported, uname: runtimeVar, d: d });
         return runtimeVar;
     }
     define_sub(name, args, exported) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'sub', exported: exported, name: runtimeVar, args: args });
+        this.put(name, { type: 'sub', exported: exported, uname: runtimeVar, args: args });
         return runtimeVar;
     }
     define_func(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'function', exported: exported, arg_count: arg_count, name: runtimeVar });
+        this.put(name, { type: 'function', exported: exported, arg_count: arg_count, uname: runtimeVar });
         return runtimeVar;
     }
     define_reducer(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
-        this.put(name, { type: 'reducer', exported: exported, arg_count: arg_count, name: runtimeVar });
+        this.put(name, { type: 'reducer', exported: exported, arg_count: arg_count, uname: runtimeVar });
         return runtimeVar;
     }
     define_variable(name, type, exported, can_redefine, d, location) {
@@ -142,7 +142,7 @@ class Scope {
             type: 'reducer',
             exported: false,
             arg_count: builtin_reducers[name].arg_count,
-            name: 'juttle.reducers.' + name + '.fn'
+            uname: 'juttle.reducers.' + name + '.fn'
         };
     }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -283,12 +283,12 @@ class SemanticPass {
         if (decl.expr) {
             this.sa_expr(decl.expr, opts);
         }
-        decl.uname = this.scope.define_variable(varname, 'var', false, false, false, decl.location);
+        decl.uname = this.scope.define_variable(varname, 'var', false, false, false, decl.location).uname;
     }
     sa_const_decl(decl, exported, can_redefine, opts) {
         var varname = decl.name;
         this.sa_expr(decl.expr, opts);
-        decl.uname = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location);
+        decl.uname = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location).uname;
     }
     // a flowgraph node
     sa_proc(node, opts) {
@@ -459,7 +459,7 @@ class SemanticPass {
 
         this.check_export(node);
 
-        uname = this.scope.define_sub(node.name, node.args, node.export);
+        uname = this.scope.define_sub(node.name, node.args, node.export).uname;
         node.uname = uname;
         this.enter_scope(node.name === 'main' ? 'main' : 'sub');
 
@@ -529,15 +529,15 @@ class SemanticPass {
     }
     sa_FormalArg(node) {
         node.uname = this.context().match(/fn/) || this.context() === 'reducer'
-            ? this.scope.define_var(node.name, false)
-            : this.scope.define_const(node.name, false, true);
+            ? this.scope.define_var(node.name, false).uname
+            : this.scope.define_const(node.name, false, true).uname;
 
         if (node.default) {
             this.sa_expr(node.default);
         }
     }
     sa_FunctionDef(node, opts) {
-        var elems, uname  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args));
+        var elems, uname  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args)).uname;
         node.uname = uname;
         this.check_export(node);
 
@@ -555,7 +555,7 @@ class SemanticPass {
 
     sa_ReducerDef(node) {
         var k, elems;
-        var uname = this.scope.define_reducer(node.name, node.export, this.compute_arg_count(node.args));
+        var uname = this.scope.define_reducer(node.name, node.export, this.compute_arg_count(node.args)).uname;
         node.uname = uname;
 
         this.check_export(node);
@@ -704,7 +704,7 @@ class SemanticPass {
             }
             return ret;
         });
-        node.uname = this.scope.define_variable(node.name, 'const', node.export, false, true, node.location);
+        node.uname = this.scope.define_variable(node.name, 'const', node.export, false, true, node.location).uname;
 
         var detector = new StaticInputDetector();
         node.static = detector.isStatic(node);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -537,8 +537,8 @@ class SemanticPass {
         }
     }
     sa_FunctionDef(node, opts) {
-        var elems, uname  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args)).uname;
-        node.uname = uname;
+        var elems, symbol  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args));
+        node.symbol = symbol;
         this.check_export(node);
 
         var context = this.context().match(/reducer/) ? 'fn-in-' + this.context() : 'fn';
@@ -583,16 +583,16 @@ class SemanticPass {
             this.sa_function_statement(elem, opts);
             if (elem.type === 'FunctionDef') {
                 if (elem.name === 'update') {
-                    node.update_uname = elem.uname;
+                    node.update_uname = elem.symbol.uname;
                 }
                 else if (elem.name === 'expire') {
-                    node.expire_uname = elem.uname;
+                    node.expire_uname = elem.symbol.uname;
                 }
                 else if (elem.name === 'reset') {
-                    node.reset_uname = elem.uname;
+                    node.reset_uname = elem.symbol.uname;
                 }
                 else if (elem.name === 'result') {
-                    node.result_uname = elem.uname;
+                    node.result_uname = elem.symbol.uname;
                 }
             }
         }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -555,8 +555,8 @@ class SemanticPass {
 
     sa_ReducerDef(node) {
         var k, elems;
-        var uname = this.scope.define_reducer(node.name, node.export, this.compute_arg_count(node.args)).uname;
-        node.uname = uname;
+        var symbol = this.scope.define_reducer(node.name, node.export, this.compute_arg_count(node.args));
+        node.symbol = symbol;
 
         this.check_export(node);
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -528,9 +528,9 @@ class SemanticPass {
         return [requiredArgs.length, args.length];
     }
     sa_FormalArg(node) {
-        node.uname = this.context().match(/fn/) || this.context() === 'reducer'
-            ? this.scope.define_var(node.name, false).uname
-            : this.scope.define_const(node.name, false, true).uname;
+        node.symbol = this.context().match(/fn/) || this.context() === 'reducer'
+            ? this.scope.define_var(node.name, false)
+            : this.scope.define_const(node.name, false, true);
 
         if (node.default) {
             this.sa_expr(node.default);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -283,7 +283,7 @@ class SemanticPass {
         if (decl.expr) {
             this.sa_expr(decl.expr, opts);
         }
-        decl.uname = this.scope.define_variable(varname, 'var', false, false, false, decl.location).uname;
+        decl.symbol = this.scope.define_variable(varname, 'var', false, false, false, decl.location);
     }
     sa_const_decl(decl, exported, can_redefine, opts) {
         var varname = decl.name;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -455,12 +455,12 @@ class SemanticPass {
         this.scope = saved_scope;
     }
     sa_SubDef(node) {
-        var uname, elems, k, has_graph;
+        var symbol, elems, k, has_graph;
 
         this.check_export(node);
 
-        uname = this.scope.define_sub(node.name, node.args, node.export).uname;
-        node.uname = uname;
+        symbol = this.scope.define_sub(node.name, node.args, node.export);
+        node.symbol = symbol;
         this.enter_scope(node.name === 'main' ? 'main' : 'sub');
 
         elems = node.elements;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1320,7 +1320,6 @@ class SemanticPass {
         var varInfo = this.scope.get(node.name);
 
         if (varInfo) {
-            node.uname = this.scope.lookup_variable(node.name);
             node.symbol = varInfo;
             node.d = varInfo.d;
         } else {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -439,15 +439,7 @@ class SemanticPass {
         }
     }
     sa_ModuleDef(node) {
-        // turn module name into valid js identifier since
-        // it will be used in the runtime module name
-        //XXX/sm I don't understand this... this doesn't seem fully robust
-        // and can create collisions...
-        var name_ident = node.name.replace(/[^a-zA-Z0-9$_]/g, '_');
-        var modName = this.scope.alloc_var(name_ident);
         var k, elems = node.elements;
-
-        node.uname = modName;
 
         var saved_scope = this.scope;
         this.scope = new Scope(null, 'module');
@@ -458,7 +450,6 @@ class SemanticPass {
         }
 
         this.modules[node.name] = {
-            uname: modName,
             exports: this.scope.exports()
         };
         this.scope = saved_scope;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -84,34 +84,34 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Constants */
-                E:      { type: 'const', exported: true, name: 'Math.E'                                   },
-                LN10:   { type: 'const', exported: true, name: 'Math.LN10'                                },
-                LN2:    { type: 'const', exported: true, name: 'Math.LN2'                                 },
-                LOG2E:  { type: 'const', exported: true, name: 'Math.LOG2E'                               },
-                LOG10E: { type: 'const', exported: true, name: 'Math.LOG10E'                              },
-                PI:     { type: 'const', exported: true, name: 'Math.PI'                                  },
-                SQRT1_2:{ type: 'const', exported: true, name: 'Math.SQRT1_2'                             },
-                SQRT2:  { type: 'const', exported: true, name: 'Math.SQRT2'                               },
+                E:      { type: 'const', exported: true, uname: 'Math.E'                                   },
+                LN10:   { type: 'const', exported: true, uname: 'Math.LN10'                                },
+                LN2:    { type: 'const', exported: true, uname: 'Math.LN2'                                 },
+                LOG2E:  { type: 'const', exported: true, uname: 'Math.LOG2E'                               },
+                LOG10E: { type: 'const', exported: true, uname: 'Math.LOG10E'                              },
+                PI:     { type: 'const', exported: true, uname: 'Math.PI'                                  },
+                SQRT1_2:{ type: 'const', exported: true, uname: 'Math.SQRT1_2'                             },
+                SQRT2:  { type: 'const', exported: true, uname: 'Math.SQRT2'                               },
                 /* Functions */
-                abs:    { type: 'function', exported: true, name: 'juttle.modules.math.abs',    arg_count: 1             },
-                acos:   { type: 'function', exported: true, name: 'juttle.modules.math.acos',   arg_count: 1             },
-                asin:   { type: 'function', exported: true, name: 'juttle.modules.math.asin',   arg_count: 1             },
-                atan:   { type: 'function', exported: true, name: 'juttle.modules.math.atan',   arg_count: 1             },
-                atan2:  { type: 'function', exported: true, name: 'juttle.modules.math.atan2',  arg_count: 2             },
-                ceil:   { type: 'function', exported: true, name: 'juttle.modules.math.ceil',   arg_count: 1             },
-                cos:    { type: 'function', exported: true, name: 'juttle.modules.math.cos',    arg_count: 1             },
-                exp:    { type: 'function', exported: true, name: 'juttle.modules.math.exp',    arg_count: 1             },
-                floor:  { type: 'function', exported: true, name: 'juttle.modules.math.floor',  arg_count: 1             },
-                log:    { type: 'function', exported: true, name: 'juttle.modules.math.log',    arg_count: 1             },
-                max:    { type: 'function', exported: true, name: 'juttle.modules.math.max',    arg_count: [0, Infinity] },
-                min:    { type: 'function', exported: true, name: 'juttle.modules.math.min',    arg_count: [0, Infinity] },
-                pow:    { type: 'function', exported: true, name: 'juttle.modules.math.pow',    arg_count: 2             },
-                random: { type: 'function', exported: true, name: 'juttle.modules.math.random', arg_count: 0             },
-                round:  { type: 'function', exported: true, name: 'juttle.modules.math.round',  arg_count: 1             },
-                sin:    { type: 'function', exported: true, name: 'juttle.modules.math.sin',    arg_count: 1             },
-                seed:   { type: 'function', exported: true, name: 'juttle.modules.math.seed',   arg_count: 1             },
-                sqrt:   { type: 'function', exported: true, name: 'juttle.modules.math.sqrt',   arg_count: 1             },
-                tan:    { type: 'function', exported: true, name: 'juttle.modules.math.tan',    arg_count: 1             },
+                abs:    { type: 'function', exported: true, uname: 'juttle.modules.math.abs',    arg_count: 1             },
+                acos:   { type: 'function', exported: true, uname: 'juttle.modules.math.acos',   arg_count: 1             },
+                asin:   { type: 'function', exported: true, uname: 'juttle.modules.math.asin',   arg_count: 1             },
+                atan:   { type: 'function', exported: true, uname: 'juttle.modules.math.atan',   arg_count: 1             },
+                atan2:  { type: 'function', exported: true, uname: 'juttle.modules.math.atan2',  arg_count: 2             },
+                ceil:   { type: 'function', exported: true, uname: 'juttle.modules.math.ceil',   arg_count: 1             },
+                cos:    { type: 'function', exported: true, uname: 'juttle.modules.math.cos',    arg_count: 1             },
+                exp:    { type: 'function', exported: true, uname: 'juttle.modules.math.exp',    arg_count: 1             },
+                floor:  { type: 'function', exported: true, uname: 'juttle.modules.math.floor',  arg_count: 1             },
+                log:    { type: 'function', exported: true, uname: 'juttle.modules.math.log',    arg_count: 1             },
+                max:    { type: 'function', exported: true, uname: 'juttle.modules.math.max',    arg_count: [0, Infinity] },
+                min:    { type: 'function', exported: true, uname: 'juttle.modules.math.min',    arg_count: [0, Infinity] },
+                pow:    { type: 'function', exported: true, uname: 'juttle.modules.math.pow',    arg_count: 2             },
+                random: { type: 'function', exported: true, uname: 'juttle.modules.math.random', arg_count: 0             },
+                round:  { type: 'function', exported: true, uname: 'juttle.modules.math.round',  arg_count: 1             },
+                sin:    { type: 'function', exported: true, uname: 'juttle.modules.math.sin',    arg_count: 1             },
+                seed:   { type: 'function', exported: true, uname: 'juttle.modules.math.seed',   arg_count: 1             },
+                sqrt:   { type: 'function', exported: true, uname: 'juttle.modules.math.sqrt',   arg_count: 1             },
+                tan:    { type: 'function', exported: true, uname: 'juttle.modules.math.tan',    arg_count: 1             },
             }
         });
     }
@@ -121,7 +121,7 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                toString: { type: 'function', exported: true, name: 'juttle.modules.null.toString', arg_count: 1 },
+                toString: { type: 'function', exported: true, uname: 'juttle.modules.null.toString', arg_count: 1 },
             }
         });
     }
@@ -131,8 +131,8 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                indexOf: { type: 'function', exported: true, name: 'juttle.modules.array.indexOf',  arg_count: 2 },
-                length:  { type: 'function', exported: true, name: 'juttle.modules.array.length',   arg_count: 1 }
+                indexOf: { type: 'function', exported: true, uname: 'juttle.modules.array.indexOf',  arg_count: 2 },
+                length:  { type: 'function', exported: true, uname: 'juttle.modules.array.length',   arg_count: 1 }
             }
         });
     }
@@ -142,7 +142,7 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                toString: { type: 'function', exported: true, name: 'juttle.modules.boolean.toString', arg_count: 1 },
+                toString: { type: 'function', exported: true, uname: 'juttle.modules.boolean.toString', arg_count: 1 },
             }
         });
     }
@@ -152,15 +152,15 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Constants (sorted alphabetically) */
-                MAX_VALUE:         { type: 'const', exported: true, name: 'Number.MAX_VALUE'         },
-                MIN_VALUE:         { type: 'const', exported: true, name: 'Number.MIN_VALUE'         },
-                NaN:               { type: 'const', exported: true, name: 'Number.NaN'               },
-                NEGATIVE_INFINITY: { type: 'const', exported: true, name: 'Number.NEGATIVE_INFINITY' },
-                POSITIVE_INFINITY: { type: 'const', exported: true, name: 'Number.POSITIVE_INFINITY' },
+                MAX_VALUE:         { type: 'const', exported: true, uname: 'Number.MAX_VALUE'         },
+                MIN_VALUE:         { type: 'const', exported: true, uname: 'Number.MIN_VALUE'         },
+                NaN:               { type: 'const', exported: true, uname: 'Number.NaN'               },
+                NEGATIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.NEGATIVE_INFINITY' },
+                POSITIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.POSITIVE_INFINITY' },
 
                 /* Functions (sorted alphabetically) */
-                fromString: { type: 'function', exported: true, name: 'juttle.modules.number.fromString', arg_count: 1 },
-                toString: { type: 'function', exported: true, name: 'juttle.modules.number.toString', arg_count: 1 },
+                fromString: { type: 'function', exported: true, uname: 'juttle.modules.number.fromString', arg_count: 1 },
+                toString: { type: 'function', exported: true, uname: 'juttle.modules.number.toString', arg_count: 1 },
             }
         });
     }
@@ -170,19 +170,19 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                length: { type: 'function', exported: true, name: 'juttle.modules.string.length', arg_count: 1             },
-                concat: { type: 'function', exported: true, name: 'juttle.modules.string.concat', arg_count: [0, Infinity] },
-                indexOf: { type: 'function', exported: true, name: 'juttle.modules.string.indexOf', arg_count: 2           },
-                lastIndexOf: { type: 'function', exported: true, name: 'juttle.modules.string.lastIndexOf', arg_count: 2   },
-                replace: { type: 'function', exported: true, name: 'juttle.modules.string.replace', arg_count: 3           },
-                search: { type: 'function', exported: true, name: 'juttle.modules.string.search', arg_count: 2             },
-                slice:  { type: 'function', exported: true, name: 'juttle.modules.string.slice',  arg_count: [2, 3]        },
-                split:  { type: 'function', exported: true, name: 'juttle.modules.string.split',  arg_count: 2             },
+                length: { type: 'function', exported: true, uname: 'juttle.modules.string.length', arg_count: 1             },
+                concat: { type: 'function', exported: true, uname: 'juttle.modules.string.concat', arg_count: [0, Infinity] },
+                indexOf: { type: 'function', exported: true, uname: 'juttle.modules.string.indexOf', arg_count: 2           },
+                lastIndexOf: { type: 'function', exported: true, uname: 'juttle.modules.string.lastIndexOf', arg_count: 2   },
+                replace: { type: 'function', exported: true, uname: 'juttle.modules.string.replace', arg_count: 3           },
+                search: { type: 'function', exported: true, uname: 'juttle.modules.string.search', arg_count: 2             },
+                slice:  { type: 'function', exported: true, uname: 'juttle.modules.string.slice',  arg_count: [2, 3]        },
+                split:  { type: 'function', exported: true, uname: 'juttle.modules.string.split',  arg_count: 2             },
                 // substr is undocumented, but used in tests
-                substr: { type: 'function', exported: true, name: 'juttle.modules.string.substr', arg_count: [2, 3]        },
-                toLowerCase: { type: 'function', exported: true, name: 'juttle.modules.string.toLowerCase', arg_count: 1   },
-                toString: { type: 'function', exported: true, name: 'juttle.modules.string.toString', arg_count: 1   },
-                toUpperCase: { type: 'function', exported: true, name: 'juttle.modules.string.toUpperCase', arg_count: 1   },
+                substr: { type: 'function', exported: true, uname: 'juttle.modules.string.substr', arg_count: [2, 3]        },
+                toLowerCase: { type: 'function', exported: true, uname: 'juttle.modules.string.toLowerCase', arg_count: 1   },
+                toString: { type: 'function', exported: true, uname: 'juttle.modules.string.toString', arg_count: 1   },
+                toUpperCase: { type: 'function', exported: true, uname: 'juttle.modules.string.toUpperCase', arg_count: 1   },
             }
         });
     }
@@ -192,7 +192,7 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                keys: { type: 'function', exported: true, name: 'juttle.modules.object.keys', arg_count: 1 }
+                keys: { type: 'function', exported: true, uname: 'juttle.modules.object.keys', arg_count: 1 }
             }
         });
     }
@@ -202,7 +202,7 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                toString: { type: 'function', exported: true, name: 'juttle.modules.regexp.toString', arg_count: 1 },
+                toString: { type: 'function', exported: true, uname: 'juttle.modules.regexp.toString', arg_count: 1 },
             }
         });
     }
@@ -212,19 +212,19 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                elapsed:     { type: 'function', exported: true, name: 'juttle.modules.date.elapsed',     arg_count: 1      },
-                endOf:       { type: 'function', exported: true, name: 'juttle.modules.date.endOf',       arg_count: 2      },
-                format:      { type: 'function', exported: true, name: 'juttle.modules.date.format',      arg_count: [1, 3] },
-                formatTz:    { type: 'function', exported: true, name: 'juttle.modules.date.formatTz',      arg_count: 2 },
-                parse:       { type: 'function', exported: true, name: 'juttle.modules.date.parse',       arg_count: [1, 2] },
-                get:         { type: 'function', exported: true, name: 'juttle.modules.date.get',         arg_count: 2      },
-                new:         { type: 'function', exported: true, name: 'juttle.modules.date.new',         arg_count: 1      },
-                quantize:    { type: 'function', exported: true, name: 'juttle.modules.date.quantize',    arg_count: 2      },
-                startOf:     { type: 'function', exported: true, name: 'juttle.modules.date.startOf',     arg_count: 2      },
-                time:        { type: 'function', exported: true, name: 'juttle.modules.date.time',        arg_count: 0      },
-                toString:    { type: 'function', exported: true, name: 'juttle.modules.date.toString',    arg_count: 1      },
-                unix:        { type: 'function', exported: true, name: 'juttle.modules.date.unix',        arg_count: 1      },
-                unixms:      { type: 'function', exported: true, name: 'juttle.modules.date.unixms',      arg_count: 1      },
+                elapsed:     { type: 'function', exported: true, uname: 'juttle.modules.date.elapsed',     arg_count: 1      },
+                endOf:       { type: 'function', exported: true, uname: 'juttle.modules.date.endOf',       arg_count: 2      },
+                format:      { type: 'function', exported: true, uname: 'juttle.modules.date.format',      arg_count: [1, 3] },
+                formatTz:    { type: 'function', exported: true, uname: 'juttle.modules.date.formatTz',      arg_count: 2 },
+                parse:       { type: 'function', exported: true, uname: 'juttle.modules.date.parse',       arg_count: [1, 2] },
+                get:         { type: 'function', exported: true, uname: 'juttle.modules.date.get',         arg_count: 2      },
+                new:         { type: 'function', exported: true, uname: 'juttle.modules.date.new',         arg_count: 1      },
+                quantize:    { type: 'function', exported: true, uname: 'juttle.modules.date.quantize',    arg_count: 2      },
+                startOf:     { type: 'function', exported: true, uname: 'juttle.modules.date.startOf',     arg_count: 2      },
+                time:        { type: 'function', exported: true, uname: 'juttle.modules.date.time',        arg_count: 0      },
+                toString:    { type: 'function', exported: true, uname: 'juttle.modules.date.toString',    arg_count: 1      },
+                unix:        { type: 'function', exported: true, uname: 'juttle.modules.date.unix',        arg_count: 1      },
+                unixms:      { type: 'function', exported: true, uname: 'juttle.modules.date.unixms',      arg_count: 1      },
             }
         });
     }
@@ -234,13 +234,13 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Functions (sorted alphabetically) */
-                as:           { type: 'function', exported: true, name: 'juttle.modules.duration.as',           arg_count: 2 },
-                format:       { type: 'function', exported: true, name: 'juttle.modules.duration.format',       arg_count: [1, 2] },
-                get:          { type: 'function', exported: true, name: 'juttle.modules.duration.get',          arg_count: 2 },
-                milliseconds: { type: 'function', exported: true, name: 'juttle.modules.duration.milliseconds', arg_count: 1 },
-                new:          { type: 'function', exported: true, name: 'juttle.modules.duration.new',          arg_count: 1 },
-                seconds:      { type: 'function', exported: true, name: 'juttle.modules.duration.seconds',      arg_count: 1 },
-                toString:     { type: 'function', exported: true, name: 'juttle.modules.duration.toString',     arg_count: 1 },
+                as:           { type: 'function', exported: true, uname: 'juttle.modules.duration.as',           arg_count: 2 },
+                format:       { type: 'function', exported: true, uname: 'juttle.modules.duration.format',       arg_count: [1, 2] },
+                get:          { type: 'function', exported: true, uname: 'juttle.modules.duration.get',          arg_count: 2 },
+                milliseconds: { type: 'function', exported: true, uname: 'juttle.modules.duration.milliseconds', arg_count: 1 },
+                new:          { type: 'function', exported: true, uname: 'juttle.modules.duration.new',          arg_count: 1 },
+                seconds:      { type: 'function', exported: true, uname: 'juttle.modules.duration.seconds',      arg_count: 1 },
+                toString:     { type: 'function', exported: true, uname: 'juttle.modules.duration.toString',     arg_count: 1 },
             }
         });
     }
@@ -249,8 +249,8 @@ class SemanticPass {
             type: 'import',
             exported: false,
             exports: {
-                parse:       { type: 'function', exported: true, name: 'juttle.modules.json.parse',       arg_count: 1 },
-                stringify:   { type: 'function', exported: true, name: 'juttle.modules.json.stringify',   arg_count: 1 },
+                parse:       { type: 'function', exported: true, uname: 'juttle.modules.json.parse',       arg_count: 1 },
+                stringify:   { type: 'function', exported: true, uname: 'juttle.modules.json.stringify',   arg_count: 1 },
             }
         });
     }
@@ -259,8 +259,8 @@ class SemanticPass {
             type: 'import',
             exported: false,
             exports: {
-                version: { type: 'const', exported: true, name: 'juttle.modules.juttle.version' },
-                adapters: { type: 'function', exported: true, name: 'juttle.modules.juttle.adapters' }
+                version: { type: 'const', exported: true, uname: 'juttle.modules.juttle.version' },
+                adapters: { type: 'function', exported: true, uname: 'juttle.modules.juttle.adapters' }
             }
         });
     }
@@ -300,7 +300,7 @@ class SemanticPass {
     sa_sub_call(node, sub) {
         var that = this;
         node.uname = this.scope.alloc_var();
-        node.uname_sub = sub.name;
+        node.uname_sub = sub.uname;
         node.options = _.map(node.options, function(opt) {
             that.sa_expr(opt.expr);
             return {id: opt.id, expr: opt.expr, location: opt.location};
@@ -378,7 +378,7 @@ class SemanticPass {
     }
     sa_function_call(node, funcInfo, opts) {
         var k, args = node.arguments;
-        node.fname = {type: 'function_uname', uname: funcInfo.name};
+        node.fname = {type: 'function_uname', uname: funcInfo.uname};
         this.check_arg_count(this.function_name(node), 'function', args.length, funcInfo.arg_count, node.location);
         var d = true;
         if (args) {
@@ -925,7 +925,7 @@ class SemanticPass {
             out.push({
                 index: index,
                 name: op,
-                uname: {type: 'function_uname', uname: reducerInfo.name},
+                uname: {type: 'function_uname', uname: reducerInfo.uname},
                 arguments: args });
         }
         return out;
@@ -1372,7 +1372,7 @@ class SemanticPass {
 
             this.sa_expr(node.object, opts);
 
-            node.uname = varInfo.name;
+            node.uname = varInfo.uname;
             node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             node.d = true;
         }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -704,7 +704,7 @@ class SemanticPass {
             }
             return ret;
         });
-        node.uname = this.scope.define_variable(node.name, 'const', node.export, false, true, node.location).uname;
+        node.symbol = this.scope.define_variable(node.name, 'const', node.export, false, true, node.location);
 
         var detector = new StaticInputDetector();
         node.static = detector.isStatic(node);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1371,7 +1371,6 @@ class SemanticPass {
 
             this.sa_expr(node.object, opts);
 
-            node.uname = varInfo.uname;
             node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             node.d = true;
         }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -288,7 +288,7 @@ class SemanticPass {
     sa_const_decl(decl, exported, can_redefine, opts) {
         var varname = decl.name;
         this.sa_expr(decl.expr, opts);
-        decl.uname = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location).uname;
+        decl.symbol = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location);
     }
     // a flowgraph node
     sa_proc(node, opts) {


### PR DESCRIPTION
The semantic pass added two properties to `Variable` and `MemberExpression` nodes:

  * `uname` — unique name of the variable or module export, to be used in compiled code
  * `symbol` — symbol table entry for the variable or module export

Since the symbol table entry already contained the unique name, setting the `uname` property on the nodes was redundant, and I decided to remove the `uname` assignment. Note this makes a lot of sense conceptually — the unique name is a property of the referenced object (variable, function, reducer,…), not of the reference to it, so it belongs to its symbol table entry, not to the node referencing it.

During the work it turned out that `uname` is also set for nodes which *define* symbols, such as `FunctionDef` or `ReducerDef`. I decided to make these consistent with `Variable` and `MemberExpression` and use the `symbol` property there too. I also did few other small cleanups.

I left the `uname` property assignment for nodes corresponding to procs as there are no symbols defined for them.

Prep work for #419.