### PR TITLE
Do not coerce identifiers in multi-value options to strings

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1726,20 +1726,15 @@ ProcStatement
 ProcOptions = ProcOption*
 
 ProcOption
-    = ___ id:ProcOptionName ACOptionValueStart ___ ACOptionValueEnd by:ByList {
-          // If the list has only 1 element, pass the element itself.
-          if (by.elements.length === 1) {
-              by = by.elements[0];
-          }
-
+    = ___ id:ProcOptionName ACOptionValueStart ___ ACOptionValueEnd value:OptionValue {
           // Populate value of the last option for autocomplete.
           if (options.autocompleteCallback) {
-              currentProcOptions[currentProcOptions.length - 1].value = by;
+              currentProcOptions[currentProcOptions.length - 1].value = value;
           };
 
           return createNode('ProcOption', location(), {
               id: id,
-              expr: by
+              expr: value
           });
      }
 
@@ -1748,6 +1743,16 @@ ProcOptionName 'option'
     // The following line ensures that a lone "-" gets marked up as an
     // autocomplete region even when it is syntactically not an option.
     / ACOptionNameStart '-' ACOptionNameEnd Fail
+
+OptionValue
+    = head:ConditionalExpressionToplevel
+      tail:(__ ',' __ ConditionalExpressionToplevel)* {
+          return tail.length === 0
+              ? head
+              : createNode('ArrayLiteral', location(), {
+                  elements: buildList(head, tail, 3)
+              });
+      }
 
 ByClause = elements:( __ ByToken __ ByList) {
     return extractOptional(elements, 3);
@@ -1822,12 +1827,7 @@ View
       }
 
 ViewOption
-    = ___ name:ViewOptionName ACOptionValueStart ___ ACOptionValueEnd value:ByList {
-        if (value.elements.length === 1) {
-            // If the list has only 1 element, pass the element itself.
-            value = value.elements[0];
-        }
-
+    = ___ name:ViewOptionName ACOptionValueStart ___ ACOptionValueEnd value:OptionValue {
         // Populate value of the last option for autocomplete.
         if (options.autocompleteCallback) {
           currentProcOptions[currentProcOptions.length - 1].value = value;
@@ -1853,11 +1853,7 @@ ViewOptionName 'option'
     / ACOptionNameStart '-' ACOptionNameEnd Fail
 
 InputOption
-    = ___ '-' name:InputOptionName ___ value:ByList {
-        if (value.elements.length === 1) {
-            // If the list has only 1 element, pass the element itself.
-            value = value.elements[0];
-        }
+    = ___ '-' name:InputOptionName ___ value:OptionValue {
         return createNode('InputOption', location(), {
             id: name,
             expr: value

--- a/test/runtime/sinks.spec.js
+++ b/test/runtime/sinks.spec.js
@@ -118,7 +118,7 @@ describe('Juttle sinks validation', function() {
             program: 'const opts = '+ JSON.stringify(opts) +'; emit -limit 1 | view result -foo opts, "bar"'
         })
             .then(function(res) {
-                expect(sink_options(res.prog, 0).foo).to.deep.equal(opts.concat(['bar']));
+                expect(sink_options(res.prog, 0).foo).to.deep.equal([['something'], 'bar']);
             });
     });
 

--- a/test/runtime/specs/juttle-spec/inputs/options.spec.md
+++ b/test/runtime/specs/juttle-spec/inputs/options.spec.md
@@ -1,0 +1,16 @@
+Input options
+=============
+
+Identifiers in multi-value options are not coerced to strings
+-------------------------------------------------------------
+
+Regression test for #444.
+
+### Juttle
+
+    input i: text -default a, b, c;
+
+### Errors
+
+  * CompileError: a is not defined
+

--- a/test/runtime/specs/juttle-spec/procs/options.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/options.spec.md
@@ -1,0 +1,15 @@
+Proc options
+============
+
+Identifiers in multi-value options are not coerced to strings
+-------------------------------------------------------------
+
+Regression test for #444.
+
+### Juttle
+
+    emit -limit a, b, c
+
+### Errors
+
+  * CompileError: a is not defined

--- a/test/runtime/specs/juttle-spec/views/options.spec.md
+++ b/test/runtime/specs/juttle-spec/views/options.spec.md
@@ -1,0 +1,15 @@
+View options
+============
+
+Identifiers in multi-value options are not coerced to strings
+-------------------------------------------------------------
+
+Regression test for #444.
+
+### Juttle
+
+    view text -format a, b, c
+
+### Errors
+
+  * CompileError: a is not defined


### PR DESCRIPTION
Before this commit, option values were parsed using the `ByList` rule. This was an easy way to parse multi-value options, but it meant the parser returned multiple values as `ByList` nodes, which triggered
coercion rules for `by` clauses in the semantic pass. This was undesirable.

This commit changes the grammar to parse options using a new `OptionValue` rule which returns multiple option values as `ArrayLiteral` nodes. These don’t trigger coercion in the semantic pass.

Note the change also means options no longer auto-flatten their values (this was another side effect of using `ByList`). I think this is OK — the behavior was surprising and it probably needs some tweaking even in case of `by` clauses.

Fixes #444.