### PR TITLE
Add ASTTransformer and StaticFilterCompiler to adapter API

### DIFF
--- a/lib/adapters/api.js
+++ b/lib/adapters/api.js
@@ -15,7 +15,9 @@ let AdapterAPI = {
     AdapterWrite: require('./adapter-write'),
     compiler: {
         ASTVisitor: require('../compiler/ast-visitor'),
-        FilterJSCompiler: require('../compiler/filters/filter-js-compiler')
+        ASTTransformer: require('../compiler/ast-transformer'),
+        StaticFilterCompiler: require('../compiler/filters/static-filter-compiler'),
+        FilterJSCompiler: require('../compiler/filters/filter-js-compiler'),
     },
     errors: require('../errors'),
     getLogger: require('../logger').getLogger,


### PR DESCRIPTION
`ASTTransformer` can be used by adapters which transform filter AST before processing, e.g. the InfluxDB adapter.

`StaticFilterCompiler` is the new base class for filter compilers.

Related to #320.