### PR TITLE
error: add toJSON so that message is included when serializing

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -12,15 +12,18 @@ var messages = require('./messages');
 // instead.
 class JuttleError extends Error {
     constructor(message, code, info) {
-        super(message, code, info);
+        super(message);
         this.name = 'JuttleError';
-        this.message = message;
         this.code = code;
         this.info = info;
 
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, this.constructor);
         }
+    }
+
+    toJSON() {
+        return { message: this.message, code: this.code, info: this.info };
     }
 }
 

--- a/test/runtime/types/errors.spec.js
+++ b/test/runtime/types/errors.spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var errors = require('../../../lib/errors');
+var expect = require('chai').expect;
+
+describe('Juttle Error tests', function() {
+    var e = errors.compileError('INTERNAL-ERROR', { error: 'some error', test: 'info' });
+
+    it('implements proper class inheritance', function() {
+        expect(e).is.an.instanceOf(Error);
+        expect(e).is.an.instanceOf(errors.CompileError);
+        expect(e).is.not.an.instanceOf(errors.RuntimeError);
+    });
+
+    it('has the expected message', function() {
+        expect(e.message).equals('internal error some error');
+    });
+
+    it('stringifies properly', function() {
+        expect(e.toString()).equals('CompileError: internal error some error');
+    });
+
+    it('serializes to JSON properly', function() {
+        expect(JSON.stringify(e)).equals('{"message":"internal error some error","code":"INTERNAL-ERROR","info":{"error":"some error","test":"info"}}');
+    });
+});


### PR DESCRIPTION
As a side-effect of changing from extendable-base to ES6 classes, and
due to the fact that the `message` property is not enumerable when
passed to the Error constructor, the message wasn't actually included
in the JSON representation of an Error.

To fix this, add a toJSON implementation that explicitly enumerates
message, code, and info. This does not include the name of the error
class, which makes things compatible with how they were in juttle 0.4
and earlier.