### PR TITLE
validate options before init read or write proc

### DIFF
--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -19,6 +19,7 @@ class Read extends source {
         }
 
         this.handleTimeOptions(options);
+        this.validate_options(adapter.read.allowedOptions(), adapter.read.requiredOptions());
 
         params.now = this.program.now;
         params.logger_name = this.logger_name;
@@ -32,8 +33,6 @@ class Read extends source {
             }
             throw err;
         }
-
-        this.validate_options(adapter.read.allowedOptions(), adapter.read.requiredOptions());
 
         var defaultTimeOptions = this.adapter.defaultTimeOptions();
         this.from = this.options.from || defaultTimeOptions.from;

--- a/lib/runtime/procs/write.js
+++ b/lib/runtime/procs/write.js
@@ -15,6 +15,8 @@ class Write extends sink {
             });
         }
 
+        this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
+
         this.adapter = new adapter.write(options, params);
 
         this.adapter.on('error', (err) => {
@@ -24,8 +26,6 @@ class Write extends sink {
         this.adapter.on('warning', (err) => {
             this.trigger('warning', err);
         });
-
-        this.validate_options(adapter.write.allowedOptions(), adapter.write.requiredOptions());
     }
 
     procName() {


### PR DESCRIPTION
Lets validate options before initializing the the `read` or `write` proc.

Why? Because sometimes the `read` or `write` proc constructors need to use validated options.