### PR TITLE
Semantic: Kill “opts”

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -57,7 +57,7 @@ class Scope {
             return undefined;
         }
     }
-    is_mutable(name, opts, context) {
+    is_mutable(name, context) {
         var symbol;
 
         if (this.symbols.hasOwnProperty(name)) {
@@ -71,7 +71,7 @@ class Scope {
             }
         }
         if (this.next) {
-            return this.next.is_mutable(name, opts, context);
+            return this.next.is_mutable(name, context);
         }
         return undefined;
     }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -317,24 +317,24 @@ class SemanticPass {
         }
     }
 
-    sa_var_decl(decl, opts) {
+    sa_var_decl(decl) {
         var varname = decl.name;
         if (decl.expr) {
-            this.sa_expr(decl.expr, opts);
+            this.sa_expr(decl.expr);
         }
         decl.symbol = this.scope.define_variable(varname, 'var', false, false, false, decl.location);
     }
-    sa_const_decl(decl, exported, can_redefine, opts) {
+    sa_const_decl(decl, exported, can_redefine) {
         var varname = decl.name;
-        this.sa_expr(decl.expr, opts);
+        this.sa_expr(decl.expr);
         decl.symbol = this.scope.define_variable(varname, 'const', exported, can_redefine, decl.expr.d || false, decl.location);
     }
     // a flowgraph node
-    sa_proc(node, opts) {
+    sa_proc(node) {
         var uname = this.scope.alloc_var();
         //XXX check options and parameters for unknowns and illegals
         node.uname = uname;
-        this.sa_options(node.options, opts);
+        this.sa_options(node.options);
     }
     sa_sub_call(node, sub) {
         var that = this;
@@ -352,7 +352,7 @@ class SemanticPass {
     //  does not check params
     // XXX should extend this to check for illegal options
     // XXX maybe even try to do some amount of type checking?
-    sa_options(options, opts) {
+    sa_options(options) {
         var that = this;
         _.each(options, function(option, index) {
             //XXX need sa_juttle_static_expr() that doesn't operate on stream
@@ -360,7 +360,7 @@ class SemanticPass {
             //   -> just need to pass down opts context right?!
             //   -> and right now, undefined implies build context so we are ok
 
-            that.sa_expr(option.expr, opts);
+            that.sa_expr(option.expr);
         });
     }
     enter_scope(type) {
@@ -415,14 +415,14 @@ class SemanticPass {
             }
         }
     }
-    sa_function_call(node, funcInfo, opts) {
+    sa_function_call(node, funcInfo) {
         var k, args = node.arguments;
         node.fname = {type: 'function_uname', uname: funcInfo.uname};
         this.check_arg_count(this.function_name(node), 'function', args.length, funcInfo.arg_count, node.location);
         var d = true;
         if (args) {
             for (k = 0; k < args.length; ++k) {
-                this.sa_expr(args[k], opts);
+                this.sa_expr(args[k]);
                 d = d && args[k].d;
             }
         }
@@ -523,8 +523,7 @@ class SemanticPass {
     }
 
     // statements that can appear inside functions or reducers
-    sa_function_statement(node, opts) {
-        opts = opts || {};
+    sa_function_statement(node) {
         switch (node.type) {
             case 'StatementBlock':
             case 'FunctionDef':
@@ -535,7 +534,7 @@ class SemanticPass {
             case 'IfStatement':
             case 'ReturnStatement':
             case 'ErrorStatement':
-                this['sa_' + node.type](node, opts);
+                this['sa_' + node.type](node);
                 break;
 
             default:
@@ -575,7 +574,7 @@ class SemanticPass {
             this.sa_expr(node.default);
         }
     }
-    sa_FunctionDef(node, opts) {
+    sa_FunctionDef(node) {
         var elems, symbol  = this.scope.define_func(node.name, node.export, this.compute_arg_count(node.args));
         node.symbol = symbol;
         this.check_export(node);
@@ -586,7 +585,7 @@ class SemanticPass {
         this.sa_args(node.args);
         elems = node.elements;
         for (var k = 0; k < elems.length; ++k) {
-            this.sa_function_statement(elems[k], opts);
+            this.sa_function_statement(elems[k]);
         }
 
         this.exit_scope();
@@ -639,13 +638,13 @@ class SemanticPass {
         }
         this.exit_scope();
     }
-    sa_StatementBlock(node, opts) {
+    sa_StatementBlock(node) {
         this.check_reducer_toplevel(node, 'a block');
 
         var elems = node.elements;
         this.enter_scope('block-in-' + this.scope.type);
         for (var k = 0; k < elems.length; ++k) {
-            this.sa_function_statement(elems[k], opts);
+            this.sa_function_statement(elems[k]);
         }
         this.exit_scope();
     }
@@ -701,35 +700,32 @@ class SemanticPass {
         this.sa_graph(node);
     }
 
-    sa_EmptyStatement(node, opts) {
+    sa_EmptyStatement(node) {
     }
     // this type of assignment lives only in places where there are
     // no points or reducers
-    sa_AssignmentStatement(node, opts) {
+    sa_AssignmentStatement(node) {
         this.check_reducer_toplevel(node, 'an assignment');
 
-        opts = opts || {};
-        this.sa_assignment_lhs(node.left, opts);
+        this.sa_assignment_lhs(node.left);
         //XXX need to handle op's other than "="
-        this.sa_expr(node.expr, opts);
+        this.sa_expr(node.expr);
     }
     // this type of assignment lives in places where there can be
     // points or reducers
-    sa_AssignmentExpression(node, opts) {
-        this.sa_assignment_lhs(node.left, opts);
-        this.sa_expr(node.right, opts);
+    sa_AssignmentExpression(node) {
+        this.sa_assignment_lhs(node.left);
+        this.sa_expr(node.right);
         node.d = node.left.d && node.right.d;
     }
-    sa_VarStatement(node, opts) {
-        opts = opts || {};
+    sa_VarStatement(node) {
         var k, decls = node.declarations;
         for (k = 0; k < decls.length; ++k) {
-            this.sa_var_decl(decls[k], opts);
+            this.sa_var_decl(decls[k]);
         }
     }
-    sa_InputStatement(node, opts) {
+    sa_InputStatement(node) {
         var self = this;
-        opts = opts || {};
 
         this.check_export(node);
 
@@ -750,8 +746,7 @@ class SemanticPass {
         var detector = new StaticInputDetector();
         node.static = detector.isStatic(node);
     }
-    sa_ConstStatement(node, opts) {
-        opts = opts || {};
+    sa_ConstStatement(node) {
         var k, decls = node.declarations;
         this.check_export(node);
         for (k = 0; k < decls.length; ++k) {
@@ -761,7 +756,7 @@ class SemanticPass {
                     location: node.location
                 });
             }
-            this.sa_const_decl(decls[k], node.export, node.arg, opts);
+            this.sa_const_decl(decls[k], node.export, node.arg);
         }
     }
     sa_ImportStatement(node, functions) {
@@ -806,28 +801,27 @@ class SemanticPass {
         this.stats.imports++;
     }
 
-    sa_IfStatement(node, opts) {
+    sa_IfStatement(node) {
         this.check_reducer_toplevel(node, 'an if statement');
 
-        this.sa_expr(node.condition, opts);
-        this.sa_function_statement(node.ifStatement, opts);
+        this.sa_expr(node.condition);
+        this.sa_function_statement(node.ifStatement);
         if (node.elseStatement) {
-            this.sa_function_statement(node.elseStatement,
-                                      opts);
+            this.sa_function_statement(node.elseStatement);
         }
     }
-    sa_ReturnStatement(node, opts) {
+    sa_ReturnStatement(node) {
         this.check_reducer_toplevel(node, 'a return statement');
 
         if (node.value) {
-            this.sa_expr(node.value, opts);
+            this.sa_expr(node.value);
         }
     }
-    sa_ErrorStatement(node, opts) {
-        this.sa_expr(node.message, opts);
+    sa_ErrorStatement(node) {
+        this.sa_expr(node.message);
     }
 
-    sa_ExpressionFilterTerm(node, opts) {
+    sa_ExpressionFilterTerm(node) {
         this.with_context('filter', () => {
             this.with_coercion_mode('field', () => {
                 this.sa_expr(node.expression);
@@ -847,9 +841,9 @@ class SemanticPass {
         // will be carried in AST form to a proc implementation
         node.d = false;
     }
-    sa_filter_proc(node, opts) {
+    sa_filter_proc(node) {
         if (node.filter) {
-            this.sa_expr(node.filter, opts);
+            this.sa_expr(node.filter);
         }
         this.sa_proc(node);
     }
@@ -898,25 +892,25 @@ class SemanticPass {
     sa_View(node) {
         this.sa_proc(node);
     }
-    sa_ObjectLiteral(node, opts) {
+    sa_ObjectLiteral(node) {
         var k, props;
         var d = true;
         props = node.properties;
         for (k = 0; k < props.length; ++k) {
-            this.sa_ObjectProperty(props[k], opts);
+            this.sa_ObjectProperty(props[k]);
             d = d && props[k].d;
         }
         node.d = d;
     }
-    sa_ObjectProperty(node, opts) {
-        this.sa_expr(node.key, opts);
-        this.sa_expr(node.value, opts);
+    sa_ObjectProperty(node) {
+        this.sa_expr(node.key);
+        this.sa_expr(node.value);
         node.d = node.key.d && node.value.d;
     }
     sa_RegExpLiteral(node) {
         node.d = true;
     }
-    sa_reducer_arg(arg, opts) {
+    sa_reducer_arg(arg) {
         // coerce a naked name to a string (ie a field name) if it
         // isn't visible as a variable.
         if (arg.type === 'Variable'
@@ -971,13 +965,13 @@ class SemanticPass {
         }
         return out;
     }
-    sa_reifier_proc(node, opts) {
+    sa_reifier_proc(node) {
         var k, reducers = [];
         this.reducers = reducers;
 
         for (k = 0; k < node.exprs.length; ++k) {
             this.index = k;
-            this.sa_expr(node.exprs[k], opts);
+            this.sa_expr(node.exprs[k]);
         }
         //
         // decorate the AST with the list of reducers that are used
@@ -996,7 +990,7 @@ class SemanticPass {
     }
     sa_ReduceProc(node) {
         this.with_context('reduce', () => {
-            this.sa_reifier_proc(node, {});
+            this.sa_reifier_proc(node);
         });
         node.reducers.forEach(function(reducer) {
             if (reducer.name === 'delta') {
@@ -1009,7 +1003,7 @@ class SemanticPass {
     sa_PutProc(node) {
         this.with_context('put', () => {
             this.with_coercion_mode('field', () => {
-                this.sa_reifier_proc(node, {});
+                this.sa_reifier_proc(node);
             });
         });
     }
@@ -1083,10 +1077,10 @@ class SemanticPass {
         this.sa_sub_call(node, sub);
     }
 
-    sa_assignment_lhs(node, opts) {
+    sa_assignment_lhs(node) {
         switch (node.type) {
             case 'UnaryExpression':
-                this.sa_UnaryExpression(node, opts);
+                this.sa_UnaryExpression(node);
                 break;
 
             case 'Variable':
@@ -1102,11 +1096,11 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                this.sa_Variable(node, opts);
+                this.sa_Variable(node);
                 break;
 
             case 'Field':
-                this.sa_Field(node, opts);
+                this.sa_Field(node);
                 break;
 
             case 'MemberExpression':
@@ -1116,7 +1110,7 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                this.sa_MemberExpression(node, opts);
+                this.sa_MemberExpression(node);
                 break;
 
             default:
@@ -1124,8 +1118,7 @@ class SemanticPass {
         }
     }
 
-    sa_expr(node, opts) {
-        opts = opts || {};
+    sa_expr(node) {
         switch (node.type) {
             case 'NullLiteral':
             case 'BooleanLiteral':
@@ -1157,7 +1150,7 @@ class SemanticPass {
             case 'ExpressionFilterTerm':
             case 'SimpleFilterTerm':
             case 'FilterLiteral':
-                this['sa_' + node.type](node, opts);
+                this['sa_' + node.type](node);
                 break;
 
             default:
@@ -1165,14 +1158,14 @@ class SemanticPass {
         }
     }
 
-    sa_PostfixExpression(node, opts) {
+    sa_PostfixExpression(node) {
         var name;
         switch (node.expression.type) {
             case 'Variable':
             case 'MemberExpression':
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
-                this.sa_expr(node.expression, opts);
+                this.sa_expr(node.expression);
                 if (!this.scope.is_mutable(name, this.scope.type)) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
                         operator: node.operator,
@@ -1188,7 +1181,7 @@ class SemanticPass {
                 });
         }
     }
-    sa_CallExpression(node, opts) {
+    sa_CallExpression(node) {
         var fname, args, funcInfo, i;
         if (node.callee.type === 'MemberExpression') {
             args = node.arguments;
@@ -1228,7 +1221,7 @@ class SemanticPass {
                 }
                 node.callee.symbol = funcInfo;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.sa_function_call(node, funcInfo, opts);
+                this.sa_function_call(node, funcInfo);
                 return;
             }
         } else {
@@ -1271,14 +1264,14 @@ class SemanticPass {
                 });
             }
             node.callee.symbol = funcInfo;
-            this.sa_function_call(node, funcInfo, opts);
+            this.sa_function_call(node, funcInfo);
         }
     }
-    sa_UnaryExpression(node, opts) {
+    sa_UnaryExpression(node) {
         var op = node.operator;
         var name;
 
-        this.sa_expr(node.argument, opts);
+        this.sa_expr(node.argument);
         if (op === '*') {
             if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
                 throw errors.compileError('INVALID-FIELD-REFERENCE', {
@@ -1302,37 +1295,37 @@ class SemanticPass {
             }
         }
     }
-    sa_BinaryExpression(node, opts) {
-        this.sa_expr(node.left, opts);
-        this.sa_expr(node.right, opts);
+    sa_BinaryExpression(node) {
+        this.sa_expr(node.left);
+        this.sa_expr(node.right);
         node.d = node.left.d && node.right.d;
     }
-    sa_ConditionalExpression(node, opts) {
-        this.sa_expr(node.test, opts);
-        this.sa_expr(node.alternate, opts);
-        this.sa_expr(node.consequent, opts);
+    sa_ConditionalExpression(node) {
+        this.sa_expr(node.test);
+        this.sa_expr(node.alternate);
+        this.sa_expr(node.consequent);
         //XXX can be smarter than this
         node.d = node.test.d && node.alternate.d && node.consequent.d;
     }
-    sa_MultipartStringLiteral(node, opts) {
+    sa_MultipartStringLiteral(node) {
         var k;
         var d = true;
         for (k = 0; k < node.parts.length; k++) {
-            this.sa_expr(node.parts[k], opts);
+            this.sa_expr(node.parts[k]);
             d = d && node.parts[k].d;
         }
         node.d = d;
     }
-    sa_ArrayLiteral(node, opts) {
+    sa_ArrayLiteral(node) {
         var k;
         var d = true;
         for (k = 0; k < node.elements.length; k++) {
-            this.sa_expr(node.elements[k], opts);
+            this.sa_expr(node.elements[k]);
             d = d && node.elements[k].d;
         }
         node.d = d;
     }
-    sa_ByList(node, opts) {
+    sa_ByList(node) {
         var k, elem = node.elements;
         var d = true;
         // node.elements is an array of the comma separated expressions
@@ -1344,7 +1337,7 @@ class SemanticPass {
         // representing the field names
         for (k = 0; k < elem.length; k++) {
             this.with_coercion_mode('string', () => {
-                this.sa_expr(elem[k], opts);
+                this.sa_expr(elem[k]);
             });
             d = d && elem[k].d;
         }
@@ -1361,7 +1354,7 @@ class SemanticPass {
         }
         node.d = d;
     }
-    sa_Variable(node, opts) {
+    sa_Variable(node) {
         var varInfo = this.scope.get(node.name);
 
         if (varInfo) {
@@ -1389,7 +1382,7 @@ class SemanticPass {
             }
         }
     }
-    sa_Field(node, opts) {
+    sa_Field(node) {
         if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
             throw errors.compileError('INVALID-FIELD-REFERENCE', {
                 location: node.location
@@ -1397,11 +1390,11 @@ class SemanticPass {
         }
         node.d = false;
     }
-    sa_ToString(node, opts) {
-        this.sa_expr(node.expression, opts);
+    sa_ToString(node) {
+        this.sa_expr(node.expression);
         node.d = node.expression.d;
     }
-    sa_MemberExpression(node, opts) {
+    sa_MemberExpression(node) {
         var varInfo;
         if (!node.computed) {
             varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
@@ -1414,14 +1407,14 @@ class SemanticPass {
                 });
             }
 
-            this.sa_expr(node.object, opts);
+            this.sa_expr(node.object);
 
             node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             node.d = true;
         }
         else {
-            this.sa_expr(node.object, opts);
-            this.sa_expr(node.property, opts);
+            this.sa_expr(node.object);
+            this.sa_expr(node.property);
             node.d = node.object.d && node.property.d;
             //XXX/TBD need to track d flag in arrays...
         }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1096,7 +1096,7 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                if (!this.scope.is_mutable(node.name, opts, this.scope.type)) {
+                if (!this.scope.is_mutable(node.name, this.scope.type)) {
                     throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
                         name: node.name,
                         location: node.location
@@ -1110,7 +1110,7 @@ class SemanticPass {
                 break;
 
             case 'MemberExpression':
-                if (!this.scope.is_mutable(node.object.name, opts, this.scope.type)) {
+                if (!this.scope.is_mutable(node.object.name, this.scope.type)) {
                     throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
                         name: node.object.name,
                         location: node.location
@@ -1173,7 +1173,7 @@ class SemanticPass {
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
                 this.sa_expr(node.expression, opts);
-                if (!this.scope.is_mutable(name, opts, this.scope.type)) {
+                if (!this.scope.is_mutable(name, this.scope.type)) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
                         operator: node.operator,
                         variable: name,
@@ -1293,7 +1293,7 @@ class SemanticPass {
         if (op === '++' || op === '--') {
             name = node.argument.type === 'Variable' ?
                 node.argument.name : node.argument.object.name;
-            if (!this.scope.is_mutable(name, opts, this.scope.type)) {
+            if (!this.scope.is_mutable(name, this.scope.type)) {
                 throw errors.compileError('INVALID-PREFIX-USE', {
                     operator: op,
                     variable: name,

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -48,6 +48,8 @@ class SemanticPass {
         this.modules = {};
         this.scope = new Scope(null, 'top');
 
+        this.coercion_mode = 'none';
+
         // As we encounter module imports, we will build up this list of
         // module ASTs, in the order we encounter them. We'll then replace the
         // original (unordered) list with this one, so that the build pass can
@@ -292,6 +294,15 @@ class SemanticPass {
         ast.stats = this.stats;
 
         return ast;
+    }
+    with_coercion_mode(coercion_mode, fn) {
+        var saved_coercion_mode = this.coercion_mode;
+        this.coercion_mode = coercion_mode;
+        try {
+            fn();
+        } finally {
+            this.coercion_mode = saved_coercion_mode;
+        }
     }
 
     sa_var_decl(decl, opts) {
@@ -803,7 +814,9 @@ class SemanticPass {
     }
 
     sa_ExpressionFilterTerm(node, opts) {
-        this.sa_expr(node.expression, { context: 'filter', coerce_var: 'field' });
+        this.with_coercion_mode('field', () => {
+            this.sa_expr(node.expression, { context: 'filter' });
+        });
         // will be carried in AST form to a proc implementation
         node.expression.d = false;
         node.d = false;
@@ -974,8 +987,9 @@ class SemanticPass {
         });
     }
     sa_PutProc(node) {
-        this.sa_reifier_proc(node, {context: 'put',
-                                  coerce_var: 'field'});
+        this.with_coercion_mode('field', () => {
+            this.sa_reifier_proc(node, {context: 'put'});
+        });
     }
 
     sa_builtin_proc(node) {
@@ -1299,7 +1313,6 @@ class SemanticPass {
     sa_ByList(node, opts) {
         var k, elem = node.elements;
         var d = true;
-        opts.coerce_var = 'string';
         // node.elements is an array of the comma separated expressions
         // each element can be an identifier (which may be a variable
         // or may be coerced to a string), an expression that evaluates
@@ -1308,7 +1321,9 @@ class SemanticPass {
         // results into a top level array that is the list of strings
         // representing the field names
         for (k = 0; k < elem.length; k++) {
-            this.sa_expr(elem[k], opts);
+            this.with_coercion_mode('string', () => {
+                this.sa_expr(elem[k], opts);
+            });
             d = d && elem[k].d;
         }
         node.d = d;
@@ -1316,9 +1331,10 @@ class SemanticPass {
     sa_SortByList(node) {
         var k, elem = node.elements;
         var d = true;
-        var opts = {coerce_var:'string'};
         for (k = 0; k < elem.length; k++) {
-            this.sa_expr(elem[k].expr, opts);
+            this.with_coercion_mode('string', () => {
+                this.sa_expr(elem[k].expr);
+            });
             d = d && elem[k].d;
         }
         node.d = d;
@@ -1330,7 +1346,7 @@ class SemanticPass {
             node.symbol = varInfo;
             node.d = varInfo.d;
         } else {
-            switch (opts.coerce_var) {
+            switch (this.coercion_mode) {
                 case 'string':
                     node.type = 'StringLiteral';
                     node.value = node.name;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -48,6 +48,7 @@ class SemanticPass {
         this.modules = {};
         this.scope = new Scope(null, 'top');
 
+        this.context = 'build';
         this.coercion_mode = 'none';
 
         // As we encounter module imports, we will build up this list of
@@ -295,6 +296,15 @@ class SemanticPass {
 
         return ast;
     }
+    with_context(context, fn) {
+        var saved_context = this.context;
+        this.context = context;
+        try {
+            fn();
+        } finally {
+            this.context = saved_context;
+        }
+    }
     with_coercion_mode(coercion_mode, fn) {
         var saved_coercion_mode = this.coercion_mode;
         this.coercion_mode = coercion_mode;
@@ -415,7 +425,7 @@ class SemanticPass {
             }
         }
 
-        if (opts.context !== 'put' && opts.context !== 'reduce') {
+        if (this.context !== 'put' && this.context !== 'reduce') {
             node.d = d;
         } else {
             // because we don't know if the function contains a call to
@@ -592,7 +602,7 @@ class SemanticPass {
         this.sa_args(node.args);
         for (k = 0; k < elems.length; ++k) {
             var elem = elems[k];
-            var opts = { context: 'build' };
+            var context = 'build';
             if (elem.type === 'FunctionDef') {
                 if ((elem.name === 'update' || elem.name === 'result' || elem.name === 'expire' || elem.name === 'reset')) {
                     if (elem.args.length > 0) {
@@ -602,12 +612,14 @@ class SemanticPass {
                         });
                     }
                     if (elem.name === 'update' || elem.name === 'expire') {
-                        opts.context = 'put';
+                        context = 'put';
                         elem.stream = true;
                     }
                 }
             }
-            this.sa_function_statement(elem, opts);
+            this.with_context(context, () => {
+                this.sa_function_statement(elem);
+            });
             if (elem.type === 'FunctionDef') {
                 if (elem.name === 'update') {
                     node.update_uname = elem.symbol.uname;
@@ -814,8 +826,10 @@ class SemanticPass {
     }
 
     sa_ExpressionFilterTerm(node, opts) {
-        this.with_coercion_mode('field', () => {
-            this.sa_expr(node.expression, { context: 'filter' });
+        this.with_context('filter', () => {
+            this.with_coercion_mode('field', () => {
+                this.sa_expr(node.expression);
+            });
         });
         // will be carried in AST form to a proc implementation
         node.expression.d = false;
@@ -916,7 +930,9 @@ class SemanticPass {
             delete arg.name;
         } else {
             // reducer *arguments* are evaluated at build time
-            this.sa_expr(arg, {context:'build'});
+            this.with_context('build', () => {
+                this.sa_expr(arg);
+            });
         }
     }
     //
@@ -977,7 +993,9 @@ class SemanticPass {
         this.sa_proc(node);
     }
     sa_ReduceProc(node) {
-        this.sa_reifier_proc(node, {context: 'reduce'});
+        this.with_context('reduce', () => {
+            this.sa_reifier_proc(node, {});
+        });
         node.reducers.forEach(function(reducer) {
             if (reducer.name === 'delta') {
                 throw errors.compileError('REDUCE-DELTA-ERROR', {
@@ -987,8 +1005,10 @@ class SemanticPass {
         });
     }
     sa_PutProc(node) {
-        this.with_coercion_mode('field', () => {
-            this.sa_reifier_proc(node, {context: 'put'});
+        this.with_context('put', () => {
+            this.with_coercion_mode('field', () => {
+                this.sa_reifier_proc(node, {});
+            });
         });
     }
 
@@ -1173,7 +1193,7 @@ class SemanticPass {
 
             funcInfo = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
             if (funcInfo) {
-                if (opts.context !== 'put' && opts.context !== 'reduce') {
+                if (this.context !== 'put' && this.context !== 'reduce') {
                     throw errors.compileError('INVALID-REDUCER-CALL', {
                         name: node.callee.object.name + '.' + node.callee.property.value,
                         location: node.location
@@ -1189,7 +1209,7 @@ class SemanticPass {
                 node.callee.symbol = funcInfo;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
                 this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
-                node.context = opts.context; // needed because reducer calls are different in put vs reduce
+                node.context = this.context; // needed because reducer calls are different in put vs reduce
                 for (i = 0; i < args.length; ++i) {
                     this.sa_reducer_arg(args[i]);
                 }
@@ -1216,7 +1236,7 @@ class SemanticPass {
 
         args = node.arguments;
         if (is_builtin_reducer(fname) || (this.scope.get(fname) && this.scope.get(fname).type === 'reducer')) {
-            if (opts.context !== 'put' && opts.context !== 'reduce') {
+            if (this.context !== 'put' && this.context !== 'reduce') {
                 throw errors.compileError('INVALID-REDUCER-CALL', {
                     name: fname,
                     location: node.location
@@ -1230,7 +1250,7 @@ class SemanticPass {
                 : this.scope.get(fname);
             this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
             node.callee.symbol = funcInfo;
-            node.context = opts.context; // needed because reducer calls are different in put vs reduce
+            node.context = this.context; // needed because reducer calls are different in put vs reduce
             for (i = 0; i < args.length; ++i) {
                 this.sa_reducer_arg(args[i]);
             }
@@ -1258,7 +1278,7 @@ class SemanticPass {
 
         this.sa_expr(node.argument, opts);
         if (op === '*') {
-            if (opts.context !== 'put' && opts.context !== 'reduce' && opts.context !== 'filter') {
+            if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
                 throw errors.compileError('INVALID-FIELD-REFERENCE', {
                     location: node.location
                 });
@@ -1368,7 +1388,7 @@ class SemanticPass {
         }
     }
     sa_Field(node, opts) {
-        if (opts.context !== 'put' && opts.context !== 'reduce' && opts.context !== 'filter') {
+        if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
             throw errors.compileError('INVALID-FIELD-REFERENCE', {
                 location: node.location
             });

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -50,6 +50,8 @@ class SemanticPass {
 
         this.context = 'build';
         this.coercion_mode = 'none';
+        this.reducers = null;
+        this.index = null;
 
         // As we encounter module imports, we will build up this list of
         // module ASTs, in the order we encounter them. We'll then replace the
@@ -971,10 +973,10 @@ class SemanticPass {
     }
     sa_reifier_proc(node, opts) {
         var k, reducers = [];
-        opts.reducers = reducers;
+        this.reducers = reducers;
 
         for (k = 0; k < node.exprs.length; ++k) {
-            opts.index = k;
+            this.index = k;
             this.sa_expr(node.exprs[k], opts);
         }
         //
@@ -1199,13 +1201,13 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                opts.reducers.push({
+                this.reducers.push({
                     module: node.callee.object.name,
                     name:node.callee.property.value,
                     args:args,
-                    index: opts.index
+                    index: this.index
                 });
-                node.reducer_call_index = opts.reducers.length - 1;
+                node.reducer_call_index = this.reducers.length - 1;
                 node.callee.symbol = funcInfo;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
                 this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
@@ -1242,8 +1244,8 @@ class SemanticPass {
                     location: node.location
                 });
             }
-            opts.reducers.push({name:fname, args:args, index: opts.index});
-            node.reducer_call_index = opts.reducers.length - 1;
+            this.reducers.push({name:fname, args:args, index: this.index});
+            node.reducer_call_index = this.reducers.length - 1;
             // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
             funcInfo = is_builtin_reducer(fname)
                 ? this.scope.fake_builtin_reducer_symbol(fname)


### PR DESCRIPTION
The high-level idea of this PR is to stop using the `opts` parameter to pass context around in the semantic pass and replace it by instance variables.

In general, passing context around using a parameter leads to unnecessarily verbose code and [can lead to performance problems](https://github.com/pegjs/pegjs/commit/cdeecf750f8a3f781459ed817815a537392993c1) when done properly (the context ends up being copied often so that child nodes don’t modify parents’ context).

In the particular case of semantic pass, the `opts` parameter was also used inconsistently, which made related code was brittle and bug-prone. Using an instance variable ensures the context is defined everywhere and is set in more controlled manner.

Note the instance variables and helper methods introduced in this PR probably aren’t the final form — there is a `Context` class hiding here :-) But we’ll see what we’ll need after the semantic pass gets converted to a visitor and split into multiple passes.

Prep work for #419.