### PR TITLE
JuttleSpec: Mark level 1 and 2 headings using # and ##

### DIFF
--- a/test/runtime/specs/juttle-spec/arrays.spec.md
+++ b/test/runtime/specs/juttle-spec/arrays.spec.md
@@ -1,9 +1,7 @@
-Arrays
-======
+# Arrays
 
 
-Assign to array (literal index)
--------------------------------
+## Assign to array (literal index)
 
 ### Juttle
 
@@ -22,8 +20,7 @@ Assign to array (literal index)
 
 
 
-Assign to array (expression index)
-----------------------------------
+## Assign to array (expression index)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/duration-forever.spec.md
+++ b/test/runtime/specs/juttle-spec/duration-forever.spec.md
@@ -1,9 +1,7 @@
-Juttle moments, new functionality
-===================================
+# Juttle moments, new functionality
 
 
-can assign :forever: to a point
--------------------------------
+## can assign :forever: to a point
 
 ### Juttle
     const long_time = :1000000y:;
@@ -17,8 +15,7 @@ can assign :forever: to a point
     {f: "Infinity", g: "-Infinity"}
 
 
-can assign forever const to a point
------------------------------------
+## can assign forever const to a point
 
 ### Juttle
     const long_time = :1000000y:;
@@ -33,8 +30,7 @@ can assign forever const to a point
     {f: "Infinity", g: "-Infinity"}
 
 
-can assign forever const to a point (runtime function)
-------------------------------------------------------
+## can assign forever const to a point (runtime function)
 
 ### Juttle
     // the use of Math.random() below is to ensure that f()
@@ -51,8 +47,7 @@ can assign forever const to a point (runtime function)
     {f: "Infinity", g: "-Infinity"}
 
 
-can add/subtract durations with :forever:
------------------------------------------
+## can add/subtract durations with :forever:
 
 ### Juttle
     const long_time = :1000000y:;
@@ -66,8 +61,7 @@ can add/subtract durations with :forever:
     {f: "Infinity", g: "Infinity", h: "Infinity", i: "Infinity"}
 
 
-can add :forever: to a finite date
-----------------------------------
+## can add :forever: to a finite date
 
 ### Juttle
     const f = :now: + :forever:;
@@ -81,8 +75,7 @@ can add :forever: to a finite date
     {f: "Infinity", g: "Infinity"}
 
 
-can subtract :forever: from a finite date
------------------------------------------
+## can subtract :forever: from a finite date
 
 ### Juttle
     const f = :now: - :forever:;
@@ -97,8 +90,7 @@ can subtract :forever: from a finite date
 
 
 
-can divide/multiply numbers with :forever:
------------------------------------------
+## can divide/multiply numbers with :forever:
 
 ### Juttle
 
@@ -111,8 +103,7 @@ can divide/multiply numbers with :forever:
     {f: "Infinity", g: "Infinity", h: "Infinity"}
 
 
-can compare durations with :forever:
-------------------------------------
+## can compare durations with :forever:
 
 ### Juttle
     emit -from :-1m: -limit 10
@@ -126,8 +117,7 @@ can compare durations with :forever:
     {count: 10}
 
 
-programmatic infinite duration
-------------------------------
+## programmatic infinite duration
 
 ### Juttle
     emit -from :-1m: -limit 1
@@ -139,8 +129,7 @@ programmatic infinite duration
     {foo: true}
 
 
-programmatic infinite duration (as const)
------------------------------------------
+## programmatic infinite duration (as const)
 
 ### Juttle
     const forever = Duration.new(1/0);
@@ -153,8 +142,7 @@ programmatic infinite duration (as const)
     {foo: true}
 
 
-can add/subtract durations with negative :forever:
---------------------------------------------------
+## can add/subtract durations with negative :forever:
 
 ### Juttle
     const long_time = :1000000y:;
@@ -168,8 +156,7 @@ can add/subtract durations with negative :forever:
     {f: "-Infinity", g: "-Infinity", h: "-Infinity", i: "-Infinity"}
 
 
-can divide/multiply numbers with negative :forever:
----------------------------------------------------
+## can divide/multiply numbers with negative :forever:
 
 ### Juttle
 
@@ -183,8 +170,7 @@ can divide/multiply numbers with negative :forever:
 
 
 
-can compare durations with negative :forever:
----------------------------------------------
+## can compare durations with negative :forever:
 
 ### Juttle
     emit -from :-1m: -limit 10
@@ -199,8 +185,7 @@ can compare durations with negative :forever:
 
 
 
-programmatic negative infinite duration
----------------------------------------
+## programmatic negative infinite duration
 
 ### Juttle
     emit -from :-1m: -limit 1

--- a/test/runtime/specs/juttle-spec/expressions/add-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/add-operator.spec.md
@@ -1,8 +1,6 @@
-The `+` operator
-================
+# The `+` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 11 }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: "abcdefgh" }
 
-Returns correct result when used on a `Date` and a `Duration`
--------------------------------------------------------------
+## Returns correct result when used on a `Date` and a `Duration`
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Returns correct result when used on a `Date` and a `Duration`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "2015-01-01T00:00:11.000Z" }
 
-Returns correct result when used on a `Duration` and a `Date`
--------------------------------------------------------------
+## Returns correct result when used on a `Duration` and a `Date`
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns correct result when used on a `Duration` and a `Date`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "2015-01-01T00:00:11.000Z" }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:11.000" }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/bitwise-and-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/bitwise-and-operator.spec.md
@@ -1,8 +1,6 @@
-The `&` operator
-================
+# The `&` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 4 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/bitwise-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/bitwise-not-operator.spec.md
@@ -1,8 +1,6 @@
-The `~` operator
-================
+# The `~` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: -6 }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/bitwise-or-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/bitwise-or-operator.spec.md
@@ -1,8 +1,6 @@
-The `|` operator
-================
+# The `|` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 7 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/bitwise-xor-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/bitwise-xor-operator.spec.md
@@ -1,8 +1,6 @@
-The `^` operator
-================
+# The `^` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 3 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/divide-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/divide-operator.spec.md
@@ -1,8 +1,6 @@
-The `/` operator
-================
+# The `/` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 6 }
 
-Returns correct result when used on a `Duration` and a `Number`
----------------------------------------------------------------
+## Returns correct result when used on a `Duration` and a `Number`
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on a `Duration` and a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:06.000" }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 6 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/does-not-match-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/does-not-match-operator.spec.md
@@ -1,8 +1,6 @@
-The `!~` operator
-=================
+# The `!~` operator
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", ma: false, nm: true }
 
-Returns correct result when used on a non-`String` and a `String`
------------------------------------------------------------------
+## Returns correct result when used on a non-`String` and a `String`
 
 ### Juttle
 
@@ -28,8 +25,7 @@ Returns correct result when used on a non-`String` and a `String`
 
     { "time": "1970-01-01T00:00:00.000Z", nm: true }
 
-Returns correct result when used on a `String` and a `RegExp`
--------------------------------------------------------------
+## Returns correct result when used on a `String` and a `RegExp`
 
 ### Juttle
 
@@ -42,8 +38,7 @@ Returns correct result when used on a `String` and a `RegExp`
 
     { "time": "1970-01-01T00:00:00.000Z", ma: false, nm: true }
 
-Returns correct result when used on a non-`String` and a `RegExp`
------------------------------------------------------------------
+## Returns correct result when used on a non-`String` and a `RegExp`
 
 ### Juttle
 
@@ -55,8 +50,7 @@ Returns correct result when used on a non-`String` and a `RegExp`
 
     { "time": "1970-01-01T00:00:00.000Z", nm: true }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/eager-logical-and-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/eager-logical-and-operator.spec.md
@@ -1,8 +1,6 @@
-The `AND` operator
-==================
+# The `AND` operator
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -17,8 +15,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", ff: false, ft: false, tf: false, tt: true }
 
-Doesn't short-circuit
----------------------
+## Doesn't short-circuit
 
 ### Juttle
 
@@ -35,8 +32,7 @@ Doesn't short-circuit
 
   * Invalid operand types for "<": null and null.
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/eager-logical-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/eager-logical-not-operator.spec.md
@@ -1,8 +1,6 @@
-The `NOT` operator
-==================
+# The `NOT` operator
 
-Returns correct result when used on a `Boolean`
------------------------------------------------
+## Returns correct result when used on a `Boolean`
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on a `Boolean`
 
     { "time": "1970-01-01T00:00:00.000Z", f: true, t: false }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/eager-logical-or-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/eager-logical-or-operator.spec.md
@@ -1,8 +1,6 @@
-The `OR` operator
-=================
+# The `OR` operator
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -17,8 +15,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", ff: false, ft: true, tf: true, tt: true }
 
-Doesn't short-circuit
----------------------
+## Doesn't short-circuit
 
 ### Juttle
 
@@ -34,8 +31,7 @@ Doesn't short-circuit
 
   * Invalid operand types for "<": null and null.
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/equal-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/equal-operator.spec.md
@@ -1,8 +1,6 @@
-The `==` operator
-=================
+# The `==` operator
 
-Returns correct result when used on two `Null`s
------------------------------------------------
+## Returns correct result when used on two `Null`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Null`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true }
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -26,8 +23,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -40,8 +36,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -54,8 +49,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `RegExp`s
--------------------------------------------------
+## Returns correct result when used on two `RegExp`s
 
 ### Juttle
 
@@ -68,8 +62,7 @@ Returns correct result when used on two `RegExp`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -82,8 +75,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -96,8 +88,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, ne: false }
 
-Returns correct result when used on two `Array`s
-------------------------------------------------
+## Returns correct result when used on two `Array`s
 
 ### Juttle
 
@@ -112,8 +103,7 @@ Returns correct result when used on two `Array`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq1: true, eq2: true, ne1: false, ne2: false }
 
-Returns correct result when used on two `Object`s
--------------------------------------------------
+## Returns correct result when used on two `Object`s
 
 ### Juttle
 
@@ -128,8 +118,7 @@ Returns correct result when used on two `Object`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq1: true, eq2: true, ne1: false, ne2: false }
 
-Returns `false` when used on two values of a different type
------------------------------------------------------------
+## Returns `false` when used on two values of a different type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
@@ -1,8 +1,6 @@
-A function call
-===============
+# A function call
 
-Works correctly inside a recursive function
--------------------------------------------
+## Works correctly inside a recursive function
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Works correctly inside a recursive function
 
     { time: "1970-01-01T00:00:00.000Z", result: 120 }
 
-Returns correct result when passed required parameters (with optional parameters)
----------------------------------------------------------------------------------
+## Returns correct result when passed required parameters (with optional parameters)
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Returns correct result when passed required parameters (with optional parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters (with optional parameters)
-----------------------------------------------------------------------------------------------
+## Returns correct result when passed required and optional parameters (with optional parameters)
 
 ### Juttle
 
@@ -46,8 +42,7 @@ Returns correct result when passed required and optional parameters (with option
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters (with optional parameters)
----------------------------------------------------------------------------
+## Produces an error when passed too few parameters (with optional parameters)
 
 ### Juttle
 
@@ -61,8 +56,7 @@ Produces an error when passed too few parameters (with optional parameters)
 
   * Error: function f expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters (with optional parameters)
-----------------------------------------------------------------------------
+## Produces an error when passed too many parameters (with optional parameters)
 
 ### Juttle
 
@@ -76,8 +70,7 @@ Produces an error when passed too many parameters (with optional parameters)
 
   * Error: function f expects 1 to 2 arguments but was called with 3
 
-Returns correct result when passed required parameters (module, with optional parameters)
------------------------------------------------------------------------------------------
+## Returns correct result when passed required parameters (module, with optional parameters)
 
 ### Module `m`
 
@@ -95,8 +88,7 @@ Returns correct result when passed required parameters (module, with optional pa
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters (module, with optional parameters)
-------------------------------------------------------------------------------------------------------
+## Returns correct result when passed required and optional parameters (module, with optional parameters)
 
 ### Module `m`
 
@@ -114,8 +106,7 @@ Returns correct result when passed required and optional parameters (module, wit
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters (module, with optional parameters)
------------------------------------------------------------------------------------
+## Produces an error when passed too few parameters (module, with optional parameters)
 
 ### Module `m`
 
@@ -133,8 +124,7 @@ Produces an error when passed too few parameters (module, with optional paramete
 
   * Error: function m.f expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters (module, with optional parameters)
-------------------------------------------------------------------------------------
+## Produces an error when passed too many parameters (module, with optional parameters)
 
 ### Module `m`
 
@@ -152,8 +142,7 @@ Produces an error when passed too many parameters (module, with optional paramet
 
   * Error: function m.f expects 1 to 2 arguments but was called with 3
 
-Returns correct result when passed required parameters (without optional parameters)
-------------------------------------------------------------------------------------
+## Returns correct result when passed required parameters (without optional parameters)
 
 ### Juttle
 
@@ -168,8 +157,7 @@ Returns correct result when passed required parameters (without optional paramet
     { time: "1970-01-01T00:00:00.000Z", result: 1 }
 
 
-Produces an error when passed too few parameters (without optional parameters)
-------------------------------------------------------------------------------
+## Produces an error when passed too few parameters (without optional parameters)
 
 ### Juttle
 
@@ -183,8 +171,7 @@ Produces an error when passed too few parameters (without optional parameters)
 
   * Error: function f expects 1 argument but was called with 0
 
-Produces an error when passed too many parameters (without optional parameters)
--------------------------------------------------------------------------------
+## Produces an error when passed too many parameters (without optional parameters)
 
 ### Juttle
 
@@ -198,8 +185,7 @@ Produces an error when passed too many parameters (without optional parameters)
 
   * Error: function f expects 1 argument but was called with 3
 
-Returns correct result when passed required parameters (module, without optional parameters)
---------------------------------------------------------------------------------------------
+## Returns correct result when passed required parameters (module, without optional parameters)
 
 ### Module `m`
 
@@ -217,8 +203,7 @@ Returns correct result when passed required parameters (module, without optional
 
     { time: "1970-01-01T00:00:00.000Z", result: 1 }
 
-Produces an error when passed too few parameters (module, without optional parameters)
---------------------------------------------------------------------------------------
+## Produces an error when passed too few parameters (module, without optional parameters)
 
 ### Module `m`
 
@@ -236,8 +221,7 @@ Produces an error when passed too few parameters (module, without optional param
 
   * Error: function m.f expects 1 argument but was called with 0
 
-Produces an error when passed too many parameters (module, without optional parameters)
----------------------------------------------------------------------------------------
+## Produces an error when passed too many parameters (module, without optional parameters)
 
 ### Module `m`
 

--- a/test/runtime/specs/juttle-spec/expressions/get-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator.spec.md
@@ -1,10 +1,8 @@
-The `[]` operator
-=================
+# The `[]` operator
 
 Partial specification. Will be finished as part of PROD-5468.
 
-Returns correct result when used on an array (existing element)
----------------------------------------------------------------
+## Returns correct result when used on an array (existing element)
 
 ### Juttle
 
@@ -14,8 +12,7 @@ Returns correct result when used on an array (existing element)
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns correct result when used on an array (missing element)
---------------------------------------------------------------
+## Returns correct result when used on an array (missing element)
 
 ### Juttle
 
@@ -25,8 +22,7 @@ Returns correct result when used on an array (missing element)
 
     { "time": "1970-01-01T00:00:00.000Z", result: null }
 
-Returns correct result when used on an object (existing entry)
---------------------------------------------------------------
+## Returns correct result when used on an object (existing entry)
 
 ### Juttle
 
@@ -36,8 +32,7 @@ Returns correct result when used on an object (existing entry)
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns correct result when used on an object (missing entry)
--------------------------------------------------------------
+## Returns correct result when used on an object (missing entry)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/greater-than-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/greater-than-operator.spec.md
@@ -1,8 +1,6 @@
-The `>` operator
-================
+# The `>` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: false, gt: true }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: false, gt: true }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -46,8 +42,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: false, gt: true }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -61,8 +56,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: false, gt: true }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/greater-than-or-equal-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/greater-than-or-equal-operator.spec.md
@@ -1,8 +1,6 @@
-The `>=` operator
-=================
+# The `>=` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: false, gt: true }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: false, gt: true }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -46,8 +42,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: false, gt: true }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -61,8 +56,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: false, gt: true }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/in-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/in-operator.spec.md
@@ -1,8 +1,6 @@
-The `in` operator
-=================
+# The `in` operator
 
-Returns correct result when used on any value and an `Array`
-------------------------------------------------------------
+## Returns correct result when used on any value and an `Array`
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on any value and an `Array`
 
     { "time": "1970-01-01T00:00:00.000Z", in: true, ni: false }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/less-than-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/less-than-operator.spec.md
@@ -1,8 +1,6 @@
-The `<` operator
-================
+# The `<` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: true, gt: false }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: true, gt: false }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -46,8 +42,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: true, gt: false }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -61,8 +56,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, lt: true, gt: false }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/less-than-or-equal-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/less-than-or-equal-operator.spec.md
@@ -1,8 +1,6 @@
-The `<=` operator
-=================
+# The `<=` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: true, gt: false }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: true, gt: false }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -46,8 +42,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: true, gt: false }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -61,8 +56,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: true, lt: true, gt: false }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/match-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/match-operator.spec.md
@@ -1,8 +1,6 @@
-The `=~` operator
-=================
+# The `=~` operator
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", ma: true, nm: false }
 
-Returns correct result when used on a non-`String` and a `String`
------------------------------------------------------------------
+## Returns correct result when used on a non-`String` and a `String`
 
 ### Juttle
 
@@ -28,8 +25,7 @@ Returns correct result when used on a non-`String` and a `String`
 
     { "time": "1970-01-01T00:00:00.000Z", nm: false }
 
-Returns correct result when used on a `String` and a `RegExp`
--------------------------------------------------------------
+## Returns correct result when used on a `String` and a `RegExp`
 
 ### Juttle
 
@@ -42,8 +38,7 @@ Returns correct result when used on a `String` and a `RegExp`
 
     { "time": "1970-01-01T00:00:00.000Z", ma: true, nm: false }
 
-Returns correct result when used on a non-`String` and a `RegExp`
------------------------------------------------------------------
+## Returns correct result when used on a non-`String` and a `RegExp`
 
 ### Juttle
 
@@ -55,8 +50,7 @@ Returns correct result when used on a non-`String` and a `RegExp`
 
     { "time": "1970-01-01T00:00:00.000Z", nm: false }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/modulo-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/modulo-operator.spec.md
@@ -1,8 +1,6 @@
-The `%` operator
-================
+# The `%` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 0 }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:00.000" }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/multiply-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/multiply-operator.spec.md
@@ -1,8 +1,6 @@
-The `*` operator
-================
+# The `*` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 30 }
 
-Returns correct result when used on a `Number` and a `Duration`
----------------------------------------------------------------
+## Returns correct result when used on a `Number` and a `Duration`
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on a `Number` and a `Duration`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:30.000" }
 
-Returns correct result when used on a `Duration` and a `Number`
----------------------------------------------------------------
+## Returns correct result when used on a `Duration` and a `Number`
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Returns correct result when used on a `Duration` and a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:30.000" }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/not-equal-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/not-equal-operator.spec.md
@@ -1,8 +1,6 @@
-The `!=` operator
-=================
+# The `!=` operator
 
-Returns correct result when used on two `Null`s
------------------------------------------------
+## Returns correct result when used on two `Null`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Null`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false }
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -26,8 +23,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -40,8 +36,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `String`s
--------------------------------------------------
+## Returns correct result when used on two `String`s
 
 ### Juttle
 
@@ -54,8 +49,7 @@ Returns correct result when used on two `String`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `RegExp`s
--------------------------------------------------
+## Returns correct result when used on two `RegExp`s
 
 ### Juttle
 
@@ -68,8 +62,7 @@ Returns correct result when used on two `RegExp`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -82,8 +75,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -96,8 +88,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq: false, ne: true }
 
-Returns correct result when used on two `Array`s
-------------------------------------------------
+## Returns correct result when used on two `Array`s
 
 ### Juttle
 
@@ -112,8 +103,7 @@ Returns correct result when used on two `Array`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq1: false, eq2: false, ne1: true, ne2: true }
 
-Returns correct result when used on two `Object`s
--------------------------------------------------
+## Returns correct result when used on two `Object`s
 
 ### Juttle
 
@@ -128,8 +118,7 @@ Returns correct result when used on two `Object`s
 
     { "time": "1970-01-01T00:00:00.000Z", eq1: false, eq2: false, ne1: true, ne2: true }
 
-Returns `true` when used on two values of a different type
-----------------------------------------------------------
+## Returns `true` when used on two values of a different type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/null-coalescing-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/null-coalescing-operator.spec.md
@@ -1,8 +1,6 @@
-The null-coalescing operator
-============================
+# The null-coalescing operator
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/postfix-decrement-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/postfix-decrement-operator.spec.md
@@ -1,8 +1,6 @@
-The postfix `--` operator
-=========================
+# The postfix `--` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: [4, 5] }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/postfix-increment-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/postfix-increment-operator.spec.md
@@ -1,8 +1,6 @@
-The postfix `++` operator
-=========================
+# The postfix `++` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: [6, 5] }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/prefix-decrement-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/prefix-decrement-operator.spec.md
@@ -1,8 +1,6 @@
-The prefix `--` operator
-========================
+# The prefix `--` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: [4, 4] }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/prefix-increment-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/prefix-increment-operator.spec.md
@@ -1,8 +1,6 @@
-The prefix `++` operator
-========================
+# The prefix `++` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: [6, 6] }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/property-access.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/property-access.spec.md
@@ -1,8 +1,6 @@
-Property access
-===============
+# Property access
 
-Returns correct result for module const access inside a function
-----------------------------------------------------------------
+## Returns correct result for module const access inside a function
 
 Regression test for PROD-6873.
 
@@ -18,8 +16,7 @@ Regression test for PROD-6873.
 
     { time: "1970-01-01T00:00:00.000Z", result: true }
 
-Returns correct result when indexing a function call result inside a function
------------------------------------------------------------------------------
+## Returns correct result when indexing a function call result inside a function
 
 Regression test for PROD-6873.
 

--- a/test/runtime/specs/juttle-spec/expressions/reducer-call.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/reducer-call.spec.md
@@ -1,8 +1,6 @@
-A reducer call
-===============
+# A reducer call
 
-Returns correct result when passed required parameters
-------------------------------------------------------
+## Returns correct result when passed required parameters
 
 ### Juttle
 
@@ -21,8 +19,7 @@ Returns correct result when passed required parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters
--------------------------------------------------------------------
+## Returns correct result when passed required and optional parameters
 
 ### Juttle
 
@@ -41,8 +38,7 @@ Returns correct result when passed required and optional parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters
-------------------------------------------------
+## Produces an error when passed too few parameters
 
 ### Juttle
 
@@ -61,8 +57,7 @@ Produces an error when passed too few parameters
 
   * Error: reducer r expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters
--------------------------------------------------
+## Produces an error when passed too many parameters
 
 ### Juttle
 
@@ -81,8 +76,7 @@ Produces an error when passed too many parameters
 
   * Error: reducer r expects 1 to 2 arguments but was called with 3
 
-Returns correct result when passed required parameters (module)
----------------------------------------------------------------
+## Returns correct result when passed required parameters (module)
 
 ### Module `m`
 
@@ -105,8 +99,7 @@ Returns correct result when passed required parameters (module)
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 5] }
 
-Returns correct result when passed required and optional parameters (module)
-----------------------------------------------------------------------------
+## Returns correct result when passed required and optional parameters (module)
 
 ### Module `m`
 
@@ -129,8 +122,7 @@ Returns correct result when passed required and optional parameters (module)
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when passed too few parameters (module)
----------------------------------------------------------
+## Produces an error when passed too few parameters (module)
 
 ### Module `m`
 
@@ -153,8 +145,7 @@ Produces an error when passed too few parameters (module)
 
   * Error: reducer m.r expects 1 to 2 arguments but was called with 0
 
-Produces an error when passed too many parameters (module)
-----------------------------------------------------------
+## Produces an error when passed too many parameters (module)
 
 ### Module `m`
 

--- a/test/runtime/specs/juttle-spec/expressions/shift-left-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/shift-left-operator.spec.md
@@ -1,8 +1,6 @@
-The `<<` operator
-=================
+# The `<<` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 10 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/shift-right-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/shift-right-operator.spec.md
@@ -1,8 +1,6 @@
-The `>>` operator
-=================
+# The `>>` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/shift-right-zero-filled-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/shift-right-zero-filled-operator.spec.md
@@ -1,8 +1,6 @@
-The `>>>` operator
-=================
+# The `>>>` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-and-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-and-operator.spec.md
@@ -1,8 +1,6 @@
-The `&&` operator
-=================
+# The `&&` operator
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -17,8 +15,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", ff: false, ft: false, tf: false, tt: true }
 
-Short-circuits
---------------
+## Short-circuits
 
 ### Juttle
 
@@ -35,8 +32,7 @@ Short-circuits
 
     { "time": "1970-01-01T00:00:00.000Z", result: false }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-not-operator.spec.md
@@ -1,8 +1,6 @@
-The `!` operator
-================
+# The `!` operator
 
-Returns correct result when used on a `Boolean`
------------------------------------------------
+## Returns correct result when used on a `Boolean`
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on a `Boolean`
 
     { "time": "1970-01-01T00:00:00.000Z", f: true, t: false }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-or-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-or-operator.spec.md
@@ -1,8 +1,6 @@
-The `||` operator
-=================
+# The `||` operator
 
-Returns correct result when used on two `Boolean`s
---------------------------------------------------
+## Returns correct result when used on two `Boolean`s
 
 ### Juttle
 
@@ -17,8 +15,7 @@ Returns correct result when used on two `Boolean`s
 
     { "time": "1970-01-01T00:00:00.000Z", ff: false, ft: true, tf: true, tt: true }
 
-Short-circuits
---------------
+## Short-circuits
 
 ### Juttle
 
@@ -34,8 +31,7 @@ Short-circuits
 
     { "time": "1970-01-01T00:00:00.000Z", result: true }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/subtract-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/subtract-operator.spec.md
@@ -1,8 +1,6 @@
-The `-` operator
-================
+# The `-` operator
 
-Returns correct result when used on two `Number`s
--------------------------------------------------
+## Returns correct result when used on two `Number`s
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on two `Number`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns correct result when used on two `Date`s
------------------------------------------------
+## Returns correct result when used on two `Date`s
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on two `Date`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:01.000" }
 
-Returns correct result when used on a `Date` and a `Duration`
--------------------------------------------------------------
+## Returns correct result when used on a `Date` and a `Duration`
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Returns correct result when used on a `Date` and a `Duration`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "2015-01-01T00:00:01.000Z" }
 
-Returns correct result when used on two `Duration`s
----------------------------------------------------
+## Returns correct result when used on two `Duration`s
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns correct result when used on two `Duration`s
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:01.000" }
 
-Produces an error when used on invalid operand type combinations
-----------------------------------------------------------------
+## Produces an error when used on invalid operand type combinations
 
 ### Juttle
 
@@ -59,8 +53,7 @@ Produces an error when used on invalid operand type combinations
 The following testcases should really be in parser tests, but we don't have
 these.
 
-Parses a `-` right before an identifier inside a subexpression
---------------------------------------------------------------
+## Parses a `-` right before an identifier inside a subexpression
 
 ### Juttle
 
@@ -73,8 +66,7 @@ Parses a `-` right before an identifier inside a subexpression
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Parses a `-` right before a non-identifier
-------------------------------------------
+## Parses a `-` right before a non-identifier
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/ternary-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/ternary-operator.spec.md
@@ -1,8 +1,6 @@
-The ternary operator
-====================
+# The ternary operator
 
-Returns correct result when used on a `Boolean`
------------------------------------------------
+## Returns correct result when used on a `Boolean`
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result when used on a `Boolean`
 
     { "time": "1970-01-01T00:00:00.000Z", f: 0, t: 1 }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/unary-minus-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/unary-minus-operator.spec.md
@@ -1,8 +1,6 @@
-The unary `-` operator
-======================
+# The unary `-` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: -5 }
 
-Returns correct result when used on a `Duration`
-------------------------------------------------
+## Returns correct result when used on a `Duration`
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on a `Duration`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "-00:00:05.000" }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/unary-plus-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/unary-plus-operator.spec.md
@@ -1,8 +1,6 @@
-The unary `+` operator
-======================
+# The unary `+` operator
 
-Returns correct result when used on a `Number`
-----------------------------------------------
+## Returns correct result when used on a `Number`
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when used on a `Number`
 
     { "time": "1970-01-01T00:00:00.000Z", result: 5 }
 
-Returns correct result when used on a `Duration`
-------------------------------------------------
+## Returns correct result when used on a `Duration`
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when used on a `Duration`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:05.000" }
 
-Produces an error when used on operand of invalid type
-------------------------------------------------------
+## Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/variable.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/variable.spec.md
@@ -1,8 +1,6 @@
-Variable
-========
+# Variable
 
-Returns a point field value when used in streaming context and the field exists
--------------------------------------------------------------------------------
+## Returns a point field value when used in streaming context and the field exists
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns a point field value when used in streaming context and the field exists
 
     { time: "1970-01-01T00:00:00.000Z", a: 5, b: 5 }
 
-Returns `null` when used in streaming context and the field does not exist
---------------------------------------------------------------------------
+## Returns `null` when used in streaming context and the field does not exist
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns `null` when used in streaming context and the field does not exist
 
     { time: "1970-01-01T00:00:00.000Z", b: null }
 
-(skip PROD-7136) Throws an error when an imported module name is used in a const declaration
----------------------------------------------------------------------------------
+## (skip PROD-7136) Throws an error when an imported module name is used in a const declaration
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Returns `null` when used in streaming context and the field does not exist
 
    * Cannot use a module as a variable
 
-(skip PROD-7136) Throws an error when an imported module name is used in a by list
-------------------------------------------------------------------------
+## (skip PROD-7136) Throws an error when an imported module name is used in a by list
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns `null` when used in streaming context and the field does not exist
 
    * Cannot use a module as a variable
 
-(skip PROD-7136) Throws an error when an imported module name is used in a stream expression
-------------------------------------------------------------------------
+## (skip PROD-7136) Throws an error when an imported module name is used in a stream expression
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Returns `null` when used in streaming context and the field does not exist
 
    * Cannot use a module as a variable
 
-Throws an error when a built-in module name is used in a const declaration
---------------------------------------------------------------------------
+## Throws an error when a built-in module name is used in a const declaration
 
 ### Juttle
 
@@ -67,8 +60,7 @@ Throws an error when a built-in module name is used in a const declaration
 
    * Cannot use a module as a variable
 
-Throws an error when a built-in module name is used in a by list
-----------------------------------------------------------------
+## Throws an error when a built-in module name is used in a by list
 
 ### Juttle
 
@@ -78,8 +70,7 @@ Throws an error when a built-in module name is used in a by list
 
    * Cannot use a module as a variable
 
-Throws an error when a built-in module name is used in a stream expression
---------------------------------------------------------------------------
+## Throws an error when a built-in module name is used in a stream expression
 
 ### Juttle
 
@@ -89,8 +80,7 @@ Throws an error when a built-in module name is used in a stream expression
 
    * Cannot use a module as a variable
 
-Throws an error when a function name is used in a const declaration
--------------------------------------------------------------------
+## Throws an error when a function name is used in a const declaration
 
 ### Juttle
 
@@ -101,8 +91,7 @@ Throws an error when a function name is used in a const declaration
    * Cannot use a function as a variable
 
 
-Throws an error when a function name is used in a by list
----------------------------------------------------------
+## Throws an error when a function name is used in a by list
 
 ### Juttle
 
@@ -113,8 +102,7 @@ Throws an error when a function name is used in a by list
    * Cannot use a function as a variable
 
 
-Throws an error when a function name is used in a stream expression
--------------------------------------------------------------------
+## Throws an error when a function name is used in a stream expression
 
 ### Juttle
 
@@ -125,8 +113,7 @@ Throws an error when a function name is used in a stream expression
    * Cannot use a function as a variable
 
 
-Throws an error when a reducer name is used in a const declaration
-------------------------------------------------------------------
+## Throws an error when a reducer name is used in a const declaration
 
 ### Juttle
 
@@ -142,8 +129,7 @@ Throws an error when a reducer name is used in a const declaration
    * Cannot use a reducer as a variable
 
 
-Throws an error when a reducer name is used in a by list
---------------------------------------------------------
+## Throws an error when a reducer name is used in a by list
 
 ### Juttle
 
@@ -159,8 +145,7 @@ Throws an error when a reducer name is used in a by list
    * Cannot use a reducer as a variable
 
 
-Throws an error when a reducer name is used in a stream expression
-------------------------------------------------------------------
+## Throws an error when a reducer name is used in a stream expression
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/and-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/and-operator.spec.md
@@ -1,8 +1,6 @@
-The `AND` operator
-==================
+# The `AND` operator
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -17,8 +15,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:03.000Z", c: 4, left: true, right: true }
 
-Doesn't short-circuit
----------------------
+## Doesn't short-circuit
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -1,8 +1,6 @@
-Expression filter terms
-=======================
+# Expression filter terms
 
-Allows using the `*"field"` syntax
-----------------------------------
+## Allows using the `*"field"` syntax
 
 Regression test for PROD-6797.
 
@@ -14,8 +12,7 @@ Regression test for PROD-6797.
 
     { time: "1970-01-01T00:00:00.000Z", a: 5 }
 
-Allows using the `*compile-expression` syntax
----------------------------------------------
+## Allows using the `*compile-expression` syntax
 
 ### Juttle
 
@@ -27,8 +24,7 @@ Allows using the `*compile-expression` syntax
 
     { time: "1970-01-01T00:00:00.000Z", a: 5 }
 
-Allows using the `#field"` syntax
----------------------------------
+## Allows using the `#field"` syntax
 
 Regression test for PROD-6797.
 
@@ -40,8 +36,7 @@ Regression test for PROD-6797.
 
     { time: "1970-01-01T00:00:00.000Z", a: 5 }
 
-The `=~` operator: Produces an error for `non-field @ *`
---------------------------------------------------------
+## The `=~` operator: Produces an error for `non-field @ *`
 
 ### Juttle
 
@@ -51,8 +46,7 @@ The `=~` operator: Produces an error for `non-field @ *`
 
   * Invalid filter term. Valid forms are: "field =~ string", "field =~ regexp".
 
-The `=~` operator: Produces an error for `field @ stream-expression`
---------------------------------------------------------------------
+## The `=~` operator: Produces an error for `field @ stream-expression`
 
 ### Juttle
 
@@ -62,8 +56,7 @@ The `=~` operator: Produces an error for `field @ stream-expression`
 
   * Invalid filter term. Valid forms are: "field =~ string", "field =~ regexp".
 
-The `!~` operator: Produces an error for `non-field @ *`
---------------------------------------------------------
+## The `!~` operator: Produces an error for `non-field @ *`
 
 ### Juttle
 
@@ -73,8 +66,7 @@ The `!~` operator: Produces an error for `non-field @ *`
 
   * Invalid filter term. Valid forms are: "field !~ string", "field !~ regexp".
 
-The `!~` operator: Produces an error for `field @ stream-expression`
---------------------------------------------------------------------
+## The `!~` operator: Produces an error for `field @ stream-expression`
 
 ### Juttle
 
@@ -84,8 +76,7 @@ The `!~` operator: Produces an error for `field @ stream-expression`
 
   * Invalid filter term. Valid forms are: "field !~ string", "field !~ regexp".
 
-Other operators: Produces an error for `non-field @ non-field`
---------------------------------------------------------------
+## Other operators: Produces an error for `non-field @ non-field`
 
 ### Juttle
 
@@ -95,8 +86,7 @@ Other operators: Produces an error for `non-field @ non-field`
 
   * Invalid filter term. Valid forms are: "field < value", "value < field".
 
-Other operators: Produces an error for `field @ stream-expression`
-------------------------------------------------------------------
+## Other operators: Produces an error for `field @ stream-expression`
 
 ### Juttle
 
@@ -106,8 +96,7 @@ Other operators: Produces an error for `field @ stream-expression`
 
   * Invalid filter term. Valid forms are: "field < value", "value < field".
 
-Other operators: Produces an error for `stream-expression @ field`
-------------------------------------------------------------------
+## Other operators: Produces an error for `stream-expression @ field`
 
 ### Juttle
 
@@ -117,8 +106,7 @@ Other operators: Produces an error for `stream-expression @ field`
 
   * Invalid filter term. Valid forms are: "field < value", "value < field".
 
-Other operators: Allows `field @ field` in `filter`
----------------------------------------------------
+## Other operators: Allows `field @ field` in `filter`
 
 ### Juttle
 
@@ -131,8 +119,7 @@ Other operators: Allows `field @ field` in `filter`
 
     { time: "1970-01-01T00:00:00.000Z", a: 5, b: 6 }
 
-Other operators: Produces an error for `field @ field` in `read`
-----------------------------------------------------------------
+## Other operators: Produces an error for `field @ field` in `read`
 
 ### Juttle
 
@@ -142,8 +129,7 @@ Other operators: Produces an error for `field @ field` in `read`
 
   * Invalid filter term. Valid forms are: "field < value", "value < field".
 
-The `=~` operator: Produces an error when RHS has an invalid type
------------------------------------------------------------------
+## The `=~` operator: Produces an error when RHS has an invalid type
 
 ### Juttle
 
@@ -153,8 +139,7 @@ The `=~` operator: Produces an error when RHS has an invalid type
 
   * Invalid filter term. Valid forms are: "field =~ string", "field =~ regexp".
 
-The `=~` operator: Returns `false` when LHS is a non-string value
------------------------------------------------------------------
+## The `=~` operator: Returns `false` when LHS is a non-string value
 
 ### Juttle
 
@@ -169,8 +154,7 @@ The `=~` operator: Returns `false` when LHS is a non-string value
     { time: "1970-01-01T00:00:02.000Z", a: "abcd" }
     { time: "1970-01-01T00:00:04.000Z", a: "abcd" }
 
-The `!~` operator: Produces an error when RHS has an invalid type
------------------------------------------------------------------
+## The `!~` operator: Produces an error when RHS has an invalid type
 
 ### Juttle
 
@@ -180,8 +164,7 @@ The `!~` operator: Produces an error when RHS has an invalid type
 
   * Invalid filter term. Valid forms are: "field !~ string", "field !~ regexp".
 
-The `!~` operator: Returns `true` when LHS is a non-string value
-----------------------------------------------------------------
+## The `!~` operator: Returns `true` when LHS is a non-string value
 
 ### Juttle
 
@@ -198,8 +181,7 @@ The `!~` operator: Returns `true` when LHS is a non-string value
     { time: "1970-01-01T00:00:03.000Z", a: null }
     { time: "1970-01-01T00:00:04.000Z", a: "abcd" }
 
-The `in` operator: Produces an error when used on operand of invalid type
--------------------------------------------------------------------------
+## The `in` operator: Produces an error when used on operand of invalid type
 
 ### Juttle
 
@@ -209,8 +191,7 @@ The `in` operator: Produces an error when used on operand of invalid type
 
   * Invalid filter term. Valid forms are: "field in array".
 
-Other operators: Produces an error when used on operand of invalid type
------------------------------------------------------------------------
+## Other operators: Produces an error when used on operand of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/filter-expressions.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/filter-expressions.spec.md
@@ -1,8 +1,6 @@
-Filter expressions
-==================
+# Filter expressions
 
-Parses ambiguous expressions as expression filter terms
--------------------------------------------------------
+## Parses ambiguous expressions as expression filter terms
 
 Regression test for PROD-6646.
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/not-operator.spec.md
@@ -1,8 +1,6 @@
-The `NOT` operator
-==================
+# The `NOT` operator
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/or-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/or-operator.spec.md
@@ -1,8 +1,6 @@
-The `OR` operator
-=================
+# The `OR` operator
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -19,8 +17,7 @@ Returns correct result
     { "time": "1970-01-01T00:00:02.000Z", c: 3, left: true, right: false }
     { "time": "1970-01-01T00:00:03.000Z", c: 4, left: true, right: true }
 
-Doesn't short-circuit
----------------------
+## Doesn't short-circuit
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/simple-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/simple-filter-terms.spec.md
@@ -1,8 +1,6 @@
-Simple filter terms
-===================
+# Simple filter terms
 
-Produces an error when used on term of invalid type
----------------------------------------------------
+## Produces an error when used on term of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/flowgraph-tests.spec.md
+++ b/test/runtime/specs/juttle-spec/flowgraph-tests.spec.md
@@ -1,8 +1,6 @@
-Flowgraph tests
-===============
+# Flowgraph tests
 
-Modifying a point on one branch does not modify it on another.
---------------------------------------------------------------
+## Modifying a point on one branch does not modify it on another.
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Modifying a point on one branch does not modify it on another.
     {"label":"branch1"}
     {"label":"pre"}
 
-Points with `time == null` are handled correctly
-------------------------------------------------
+## Points with `time == null` are handled correctly
 
 Regression test for #351.
 

--- a/test/runtime/specs/juttle-spec/functions-in-subs.spec.md
+++ b/test/runtime/specs/juttle-spec/functions-in-subs.spec.md
@@ -1,10 +1,8 @@
-Tests for functions in subgraph
-===============================
+# Tests for functions in subgraph
 
 
 
-Function used in stream context inside a sub
---------------------------------------------
+## Function used in stream context inside a sub
 
 ### Juttle
 
@@ -22,8 +20,7 @@ Function used in stream context inside a sub
 
 
 
-Function using sub argument (stream context, multiply-instantiated sub)
------------------------------------------------------------------------
+## Function using sub argument (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -39,8 +36,7 @@ Function using sub argument (stream context, multiply-instantiated sub)
     {a: 4}
 
 
-Function-in-function using sub argument (stream context, multiply-instantiated sub)
------------------------------------------------------------------------------------
+## Function-in-function using sub argument (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -56,8 +52,7 @@ Function-in-function using sub argument (stream context, multiply-instantiated s
     {a: 4}
 
 
-Function using const from sub argument (stream context, multiply-instantiated sub)
-----------------------------------------------------------------------------------
+## Function using const from sub argument (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -75,8 +70,7 @@ Function using const from sub argument (stream context, multiply-instantiated su
 
 
 
-Put expression using sub argument (multiply-instantiated sub)
--------------------------------------------------------------
+## Put expression using sub argument (multiply-instantiated sub)
 
 ### Juttle
 
@@ -90,8 +84,7 @@ Put expression using sub argument (multiply-instantiated sub)
     {a: 3}
     {a: 4}
 
-Function using sub argument and stream value (multiply-instantiated sub)
-------------------------------------------------------------------------
+## Function using sub argument and stream value (multiply-instantiated sub)
 
 ### Juttle
 
@@ -106,8 +99,7 @@ Function using sub argument and stream value (multiply-instantiated sub)
     {a: 3}
     {a: 4}
 
-Function using const shadowing sub argument (multiply-instantiated sub)
------------------------------------------------------------------------
+## Function using const shadowing sub argument (multiply-instantiated sub)
 
 ### Juttle
 
@@ -126,8 +118,7 @@ Function using const shadowing sub argument (multiply-instantiated sub)
     {a: 2.5}
 
 
-Math function using sub argument and stream value (stream context, multiply-instantiated sub)
----------------------------------------------------------------------------------------------
+## Math function using sub argument and stream value (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -143,8 +134,7 @@ Math function using sub argument and stream value (stream context, multiply-inst
     {a: 6}
 
 
-Duration function using sub argument and stream value (stream context, multiply-instantiated sub)
--------------------------------------------------------------------------------------------------
+## Duration function using sub argument and stream value (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -159,8 +149,7 @@ Duration function using sub argument and stream value (stream context, multiply-
     {a: 4}
     {a: 6}
 
-Date function using sub argument and stream value (stream context, multiply-instantiated sub)
----------------------------------------------------------------------------------------------
+## Date function using sub argument and stream value (stream context, multiply-instantiated sub)
 
 ### Juttle
 
@@ -177,8 +166,7 @@ Date function using sub argument and stream value (stream context, multiply-inst
 
 
 
-String function using sub argument and stream value (stream context, multiply-instantiated sub)
------------------------------------------------------------------------------------------------
+## String function using sub argument and stream value (stream context, multiply-instantiated sub)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/inputs/options.spec.md
+++ b/test/runtime/specs/juttle-spec/inputs/options.spec.md
@@ -1,8 +1,6 @@
-Input options
-=============
+# Input options
 
-Identifiers in multi-value options are not coerced to strings
--------------------------------------------------------------
+## Identifiers in multi-value options are not coerced to strings
 
 Regression test for #444.
 

--- a/test/runtime/specs/juttle-spec/juttle-calendar-moments.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-calendar-moments.spec.md
@@ -1,8 +1,6 @@
-Juttle calendar moments
-=======================
+# Juttle calendar moments
 
-rejects noninteger calendar durations, humanized
------------------------------------
+## rejects noninteger calendar durations, humanized
 ### Juttle
     emit -limit 1
     | put one = :1.5 months:
@@ -12,8 +10,7 @@ rejects noninteger calendar durations, humanized
 ### Errors
    * Expected
 
-rejects mixed calendar durations for quantization
------------------------------------
+## rejects mixed calendar durations for quantization
 ### Juttle
     emit -from :2014-01-15: -every :month: -limit 5
     | put t=time, m=:1/02.03:04:05:, d=Date.quantize(time, m)
@@ -22,8 +19,7 @@ rejects mixed calendar durations for quantization
 ### Errors
    * Date.quantize doesn't accept mixed calendar intervals:
 
-calendar durations
------------------------------------
+## calendar durations
 ### Juttle
     emit -limit 1
     | put one = :1 month and 3 hours: == :1/0.03:00:00:
@@ -39,8 +35,7 @@ calendar durations
     {"one":true, "two":true, "three":true, "four":true, "five":true, "six":true}
 
 
-calendar duration abbreviations work
-----------------------------------
+## calendar duration abbreviations work
 ### Juttle
     emit -limit 1
     | put one = :-M: == :1 month ago:
@@ -53,8 +48,7 @@ calendar duration abbreviations work
 ### Output
     {"one":true, "two":true, "three":true, "four":true}
 
-math with calendar durations works
-----------------------------------
+## math with calendar durations works
 ### Juttle
     emit -limit 1
     | put one = :now: - :month: == :1 month ago:
@@ -73,8 +67,7 @@ math with calendar durations works
     { "one":true, "two":true, "three":true, "four":true,
       "five":true, "six":true, "seven":true, "eight":true, "nine":true }
 
-emit increments in months
-------------------------------------
+## emit increments in months
 ### Juttle
     emit -from :2000-01-15: -every :month: -limit 5
     | view result
@@ -86,8 +79,7 @@ emit increments in months
     {"time":"2000-04-15T00:00:00.000Z"}
     {"time":"2000-05-15T00:00:00.000Z"}
 
-emit increments in years
-------------------------------------
+## emit increments in years
 ### Juttle
     emit -from :2000-01-15: -every :year: -limit 5
     | view result
@@ -99,8 +91,7 @@ emit increments in years
     {"time":"2003-01-15T00:00:00.000Z"}
     {"time":"2004-01-15T00:00:00.000Z"}
 
-quantize works for weeks
--------------------------
+## quantize works for weeks
 ### Juttle
     emit -from :2014-01-15: -every :week: -limit 5
     | put d=Date.quantize(time, :week:)
@@ -113,8 +104,7 @@ quantize works for weeks
     {"time":"2014-02-05T00:00:00.000Z","d":"2014-01-30T00:00:00.000Z"}
     {"time":"2014-02-12T00:00:00.000Z","d":"2014-02-06T00:00:00.000Z"}
 
-quantize works for months
--------------------------
+## quantize works for months
 ### Juttle
     emit -from :2014-01-15: -every :month: -limit 5
     | put d=Date.quantize(time, :month:)
@@ -127,8 +117,7 @@ quantize works for months
     {"time":"2014-04-15T00:00:00.000Z","d":"2014-04-01T00:00:00.000Z"}
     {"time":"2014-05-15T00:00:00.000Z","d":"2014-05-01T00:00:00.000Z"}
 
-quantize works for years
--------------------------
+## quantize works for years
 ### Juttle
     emit -from :2000-06-15: -every :year: -limit 5
     | put d=Date.quantize(time, :year:)
@@ -141,8 +130,7 @@ quantize works for years
     {"time":"2003-06-15T00:00:00.000Z","d":"2003-01-01T00:00:00.000Z"}
     {"time":"2004-06-15T00:00:00.000Z","d":"2004-01-01T00:00:00.000Z"}
 
-ok to subtract a plain moment from an epsilon moment
--------------------------------------------------------
+## ok to subtract a plain moment from an epsilon moment
 ### Juttle
     emit -from Date.new(0) -limit 1
     | reduce -every :s: t=max(time)
@@ -152,8 +140,7 @@ ok to subtract a plain moment from an epsilon moment
 ### Output
     {"time":"1970-01-01T00:00:01.000Z","t":"1970-01-01T00:00:00.000Z","dt":"00:00:01.000"}
 
-ok to subtract an epsilon moment from a plain moment
--------------------------------------------------------
+## ok to subtract an epsilon moment from a plain moment
 ### Juttle
     emit -from Date.new(0) -limit 1
     | reduce -every :s: t=max(time)
@@ -163,8 +150,7 @@ ok to subtract an epsilon moment from a plain moment
 ### Output
     {"time":"1970-01-01T00:00:01.000Z","t":"1970-01-01T00:00:00.000Z","dt":"-00:00:01.000"}
 
-quantize truncates non-calendar epsilon moments correctly
----------------------------------------------
+## quantize truncates non-calendar epsilon moments correctly
 ### Juttle
     emit -from Date.new(0) -limit 1
     | reduce -every :s: t=max(time)
@@ -174,8 +160,7 @@ quantize truncates non-calendar epsilon moments correctly
 ### Output
     {"time":"1970-01-01T00:00:01.000Z","t":"1970-01-01T00:00:00.000Z","winning":true}
 
-noninteger day constants are handled
----------------------------------------------
+## noninteger day constants are handled
 ### Juttle
     emit -from Date.new(0) -limit 1
     | put halfday = :d:/2
@@ -184,8 +169,7 @@ noninteger day constants are handled
 ### Output
     {"time":"1970-01-01T00:00:00.000Z", "halfday":"12:00:00.000"}
 
-noninteger day math works
----------------------------------------------
+## noninteger day math works
 ### Juttle
     function fraction(interval, n) {
         // defeat the d-bit!
@@ -199,8 +183,7 @@ noninteger day math works
 ### Output
     {"time":"1970-01-01T00:00:00.000Z","before":"1969-12-31T12:00:00.000Z","after":"1970-01-01T12:00:00.000Z"}
 
-noninteger hour constants are handled
----------------------------------------------
+## noninteger hour constants are handled
 ### Juttle
     emit -from Date.new(0) -limit 1
     | put halfhour = :h:/2
@@ -209,8 +192,7 @@ noninteger hour constants are handled
 ### Output
     {"time":"1970-01-01T00:00:00.000Z", "halfhour":"00:30:00.000"}
 
-noninteger hour math works
----------------------------------------------
+## noninteger hour math works
 ### Juttle
     function fraction(interval, n) {
         // defeat the d-bit!
@@ -224,8 +206,7 @@ noninteger hour math works
 ### Output
     {"time":"1970-01-01T00:00:00.000Z","before":"1969-12-31T23:30:00.000Z","after":"1970-01-01T00:30:00.000Z"}
 
-quantize truncates calendar epsilon moments correctly
----------------------------------------------
+## quantize truncates calendar epsilon moments correctly
 ### Juttle
     emit -from Date.new(0) -limit 1
     | reduce -every :month: t=max(time)

--- a/test/runtime/specs/juttle-spec/juttle-moments.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-moments.spec.md
@@ -1,8 +1,6 @@
-Juttle moments
-==============
+# Juttle moments
 
-:now: is the same wherever it is used
--------------------------------------
+## :now: is the same wherever it is used
 ### Juttle
     function f() {
       // the use of Math.random() below is to ensure that f()
@@ -20,8 +18,7 @@ Juttle moments
     {d: "00:00:00.000"}
 
 
-a now-relative moment is the same wherever it is used
-------------------------------------------------------
+## a now-relative moment is the same wherever it is used
 ### Juttle
     function f() { return Math.random() > 0.5 ? :-1d: : :-1d:; }
     const m = :-1d:;
@@ -33,8 +30,7 @@ a now-relative moment is the same wherever it is used
 ### Output
     {d: "00:00:00.000"}
 
-unix time (seconds since the epoch)
------------------------------------------------------------
+## unix time (seconds since the epoch)
 ### Juttle
 
     emit -limit 1
@@ -51,8 +47,7 @@ unix time (seconds since the epoch)
 
     { winning: true }
 
-reject signed unix time
------------------------------------------------------------
+## reject signed unix time
 ### Juttle
 
     emit -limit 1

--- a/test/runtime/specs/juttle-spec/juttle-procs-batch.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-batch.spec.md
@@ -1,8 +1,6 @@
-Juttle batch command
-============================================
+# Juttle batch command
 
-batch -every and interval complains
--------------------------
+## batch -every and interval complains
 ### Juttle
     emit -from :2014-01-15: -limit 6
     | batch -every :2s: :2s:
@@ -13,8 +11,7 @@ batch -every and interval complains
 
    * Specify either batch -every or batch :interval:
 
-batch -every and number complains
--------------------------
+## batch -every and number complains
 no bare numbers with the new -every option
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -26,8 +23,7 @@ no bare numbers with the new -every option
 
    * CompileError: -every wants a duration, got 2
 
-complains if batch -on > -every
--------------------------
+## complains if batch -on > -every
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -39,8 +35,7 @@ complains if batch -on > -every
 
    * CompileError: batch -on cannot be greater than -every
 
-complains if batch -every is negative
--------------------------
+## complains if batch -every is negative
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -52,8 +47,7 @@ complains if batch -every is negative
 
    * CompileError: batch interval must be a positive number or duration.
 
-complains if batch -every is 0
--------------------------
+## complains if batch -every is 0
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -65,8 +59,7 @@ complains if batch -every is 0
 
    * CompileError: batch interval must be a positive number or duration.
 
-complains if batch duration is negative
--------------------------
+## complains if batch duration is negative
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -78,8 +71,7 @@ complains if batch duration is negative
 
    * CompileError: batch interval must be a positive number or duration.
 
-complains if batch duration is 0
--------------------------
+## complains if batch duration is 0
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -91,8 +83,7 @@ complains if batch duration is 0
 
    * CompileError: batch interval must be a positive number or duration.
 
-batching works for months
--------------------------
+## batching works for months
 ### Juttle
     emit -from :2014-01-15: -every :month: -limit 5
     | batch -every :month:
@@ -107,8 +98,7 @@ batching works for months
     {"time":"2014-06-01T00:00:00.000Z","c":1}
 
 
-batching works for years
--------------------------
+## batching works for years
 ### Juttle
     emit -from :2000-01-15: -every :month: -limit 36
     | batch -every :year:
@@ -121,8 +111,7 @@ batching works for years
     {"time":"2003-01-01T00:00:00.000Z","c":12}
 
 
-batch can align on a regular duration
-------------------------------
+## batch can align on a regular duration
 ### Juttle
     emit -from :2014-01-01: -every :10 minute: -limit 30
     | batch -every :hour: -on :00:30:00:
@@ -137,8 +126,7 @@ batch can align on a regular duration
     {"time":"2014-01-01T04:30:00.000Z","c":6}
     {"time":"2014-01-01T05:30:00.000Z","c":3}
 
-batch can align on a regular duration with a calendar interval
-------------------------------------------------------------
+## batch can align on a regular duration with a calendar interval
 ### Juttle
     emit -from :2014-01-01: -every :day: -limit 60
     | batch -every :month: -on :day 10:
@@ -151,8 +139,7 @@ batch can align on a regular duration with a calendar interval
     { "c": 20, "time": "2014-03-10T00:00:00.000Z"  }
 
 
-batch can align on a date with a calendar interval
-------------------------------------------------------------
+## batch can align on a date with a calendar interval
 ### Juttle
     emit -from :2014-01-01: -every :day: -limit 70
     | batch -every :month: -on :day 20 of this month:
@@ -165,8 +152,7 @@ batch can align on a date with a calendar interval
     { "c": 20, "time": "2014-03-20T00:00:00.000Z"  }
 
 
-batch with short interval can handle a very large time gap
-------------------------------------------------------------
+## batch with short interval can handle a very large time gap
 ### Juttle
     // The merge of two different streams will cause separate calls
     // to batch's consume() for pts1 and pts2.  With a large gap in
@@ -189,8 +175,7 @@ batch with short interval can handle a very large time gap
     { "time": "2015-03-21T00:00:00.000Z", "what": "middle" }
     { "time": "2015-03-21T00:01:00.000Z", "what": "end" }
 
-initial historic batch ignores deprecated historic tick
--------------------------------------------------
+## initial historic batch ignores deprecated historic tick
 (leave out actual ticks from result so test does not break when we
 eventually remove historic ticks)
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-filter.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-filter.spec.md
@@ -1,8 +1,6 @@
-Juttle "filter" processor
-=========================
+# Juttle "filter" processor
 
-Warns and drops points on a runtime error
------------------------------------------
+## Warns and drops points on a runtime error
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-join.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-join.spec.md
@@ -1,8 +1,6 @@
-Join tests
-======================================================
+# Join tests
 
-join -table syntax: complains about out-of-range table
-----------------------------------------------------
+## join -table syntax: complains about out-of-range table
 ###Juttle
     emit -from Date.new(0) -limit 1
     | (put foo=1; put bar=2; put baz=3)
@@ -11,8 +9,7 @@ join -table syntax: complains about out-of-range table
 ### Errors
    * -table must be an input number (1, 2, ...).
 
-join -table syntax: complains about nonnumeric table
-----------------------------------------------------
+## join -table syntax: complains about nonnumeric table
 ###Juttle
     emit -from Date.new(0) -limit 1
     | (put foo=1; put bar=2; put baz=3)
@@ -21,8 +18,7 @@ join -table syntax: complains about nonnumeric table
 ### Errors
    * -table must be an input number (1, 2, ...).
 
-join -table syntax: complains of -outer and -table for same input
-----------------------------------------------------
+## join -table syntax: complains of -outer and -table for same input
 ###Juttle
     emit -from Date.new(0) -limit 1
     | (put foo=1; put bar=2; put baz=3)
@@ -31,8 +27,7 @@ join -table syntax: complains of -outer and -table for same input
 ### Errors
    * -table and -outer cannot be specified for the same input
 
-(skip) join against a batched table complains
-------------------------------------------------------
+## (skip) join against a batched table complains
 XXX we specifie the proper error output here, and it shows up in
 the test output, yet the test fails.
 
@@ -52,16 +47,14 @@ the test output, yet the test fails.
 ### Errors
    * -table input cannot be batched.
 
-complains about unknown options
----------------------------------
+## complains about unknown options
 ### Juttle
     emit -limit 1 | join -failure 1 foo, bar | remove time | view result
 
 ### Errors
    * CompileError: unknown join option failure.
 
-not everything can be a table
-------------------------------------------------------
+## not everything can be a table
 ### Juttle
     emit -from Date.new(0) -limit 1 |
     join -table 1 |  view result
@@ -69,8 +62,7 @@ not everything can be a table
 ### Errors
    * at least one input must not be a table
 
-System Test C4107 Scenario 2: join 2 event streams using once to generate every combination possible
-------------------------------------------------------
+## System Test C4107 Scenario 2: join 2 event streams using once to generate every combination possible
 ### Juttle
     const services = [
     {"source_type": "event", "time": :now:+:0s:, "name": "C4107.<test:runid>.services", "space": "default", "service": "collector" },
@@ -100,8 +92,7 @@ System Test C4107 Scenario 2: join 2 event streams using once to generate every 
     {"service":"processor","env":"staging.dev.jut.io"}
     {"service":"processor","env":"testing.dev.jut.io"}
 
-System Test C4105 Scenario: join metric stream with a small event stream using nearest option to dictate the joining groups
-------------------------------------------------------------------------------
+## System Test C4105 Scenario: join metric stream with a small event stream using nearest option to dictate the joining groups
 ### Juttle
     const series1 =
     [
@@ -138,8 +129,7 @@ System Test C4105 Scenario: join metric stream with a small event stream using n
     {"time":"2010-01-01T00:00:07.000Z","value":35,"group":"B"}
     {"time":"2010-01-01T00:00:10.000Z","value":45,"group":"C"}
 
-handles -once with no data
-------------------------------------------------------
+## handles -once with no data
 ### Juttle
     (emit -every :1s: -from :-2s: -to :now:
     |( filter name="foo"
@@ -151,8 +141,7 @@ handles -once with no data
     {ok:true}
 
 
-handles -once with live ticks and no data
-------------------------------------------------------
+## handles -once with live ticks and no data
 ### Juttle
     (emit -every :2s: -from :now: -to :+4s:
     |( filter name="foo"
@@ -163,8 +152,7 @@ handles -once with live ticks and no data
 ### Output
     {ok:true}
 
-joins 3 1-point streams
-------------------------------------------------------
+## joins 3 1-point streams
 ### Juttle
     emit -from :2010-01-01: -limit 1
     | ( put foo=1; put bar=2; put baz=3)
@@ -173,8 +161,7 @@ joins 3 1-point streams
 ### Output
     { "time":"2010-01-01T00:00:00.000Z", "foo":1, "bar":2, "baz":3 }
 
-joins 3 1-point streams with nested points
-------------------------------------------------------
+## joins 3 1-point streams with nested points
 ### Juttle
     emit -from :2010-01-01: -limit 1
     | ( put foo={ i: 1 }; put bar={ i: 2 }; put baz={ i: 3 })
@@ -183,8 +170,7 @@ joins 3 1-point streams with nested points
 ### Output
     { "time":"2010-01-01T00:00:00.000Z", "foo":{"i":1}, "bar":{"i":2}, "baz":{"i":3} }
 
-joins an unbatched stream against an advancing batched table and a fixed batched table
---------------------------------------------------------------------------------------
+## joins an unbatched stream against an advancing batched table and a fixed batched table
 ### Juttle
     ( emit -hz 1000 -from Date.new(0) -limit 9
         | batch .003 | put batch=Math.floor(Duration.milliseconds(time-:0:)/3)
@@ -208,8 +194,7 @@ joins an unbatched stream against an advancing batched table and a fixed batched
     {"time":"1970-01-01T00:00:01.007Z","peek":"peek-2.2","frean":"frean-0.2","cookie":"cookie-7"}
     {"time":"1970-01-01T00:00:01.008Z","peek":"peek-2.3","frean":"frean-0.3","cookie":"cookie-8"}
 
-single join of unbatched points against two batched tables with -once
---------------------------------------------------------------------------------------
+## single join of unbatched points against two batched tables with -once
 ### Juttle
     ( emit -hz 1000 -from Date.new(0) -limit 3
         | batch .003 | put batch=Math.floor(Duration.milliseconds(time-:0:)/3)
@@ -233,8 +218,7 @@ single join of unbatched points against two batched tables with -once
     {"time":"1970-01-01T00:00:01.000Z","peek":"peek-0.3","frean":"frean-0.3","cookie":"cookie-5"}
     {"time":"1970-01-01T00:00:01.000Z","peek":"peek-0.3","frean":"frean-0.3","cookie":"cookie-8"}
 
-3-way version of HSNB cascaded join nearest, 1 batched, -outer
------------------------------------------------------------
+## 3-way version of HSNB cascaded join nearest, 1 batched, -outer
 ### Juttle
     ( emit -limit 3 -from Date.new(0) | put first=true, n=count()
     ; emit -limit 4 -from Date.new(0) | put second=true, m=count() | batch 1
@@ -248,8 +232,7 @@ single join of unbatched points against two batched tables with -once
     {"time":"1970-01-01T00:00:03.000Z","first":true,"n":3,"second":true,"m":3,"third":true,"p":3}
     {"time":"1970-01-01T00:00:04.000Z","first":true,"n":3,"second":true,"m":4,"third":true,"p":4}
 
-3-way version of HSNB cascaded join nearest, 2 batched -outer
------------------------------------------------------------
+## 3-way version of HSNB cascaded join nearest, 2 batched -outer
 ### Juttle
     ( emit -limit 3 -from Date.new(0) | put first=true, n=count()
     ; emit -limit 4 -from Date.new(0) | put second=true, m=count() | batch 1
@@ -264,8 +247,7 @@ single join of unbatched points against two batched tables with -once
     {"time":"1970-01-01T00:00:04.000Z","first":true,"n":3,"second":true,"m":4,"third":true,"p":4}
     {"time":"1970-01-01T00:00:05.000Z","first":true,"n":3,"second":true,"m":4,"third":true,"p":5}
 
-3-way version of RSNB: join two point streams against a sequence of batches using -outer
------------------------------------------------------------
+## 3-way version of RSNB: join two point streams against a sequence of batches using -outer
 ### Juttle
     ( emit -hz 1000 -from :now: -limit 9
       | batch -every :.003s: -on :now:
@@ -290,8 +272,7 @@ single join of unbatched points against two batched tables with -once
     {"bar":"bar-8","bag":"bag-8","assy":"baz-1.2","batch":1,"assy_id":2}
     {"bar":"bar-9","bag":"bag-9","assy":"baz-1.3","batch":1,"assy_id":3}
 
-3-way version of RSNB: join two point streams against a sequence of batches without -outer
------------------------------------------------------------
+## 3-way version of RSNB: join two point streams against a sequence of batches without -outer
 Not something you would do, but a workout for arrival order handling.
 Results start with eps-3 secs because the batch gets to be a leader, and
 other fields repeat whenever batch gets to be a leader
@@ -320,8 +301,7 @@ other fields repeat whenever batch gets to be a leader
     {"bar":"bar-9","bag":"bag-9","assy":"baz-1.3","batch":1,"assy_id":3}
     {"bar":"bar-9","bag":"bag-9","assy":"baz-2.3","batch":2,"assy_id":3}
 
-outer join syntax: complains about out-of-range outer
-----------------------------------------------------
+## outer join syntax: complains about out-of-range outer
 ###Juttle
     emit -from Date.new(0) -limit 1
     | (put foo=1; put bar=2; put baz=3)
@@ -330,8 +310,7 @@ outer join syntax: complains about out-of-range outer
 ### Errors
    * -outer must be an input number (1, 2, ...).
 
-outer join syntax: complains about non-numeric outer
-------------------------------------------------------
+## outer join syntax: complains about non-numeric outer
 ### Juttle
     emit -from Date.new(0) -limit 1 |
     join -outer true |  view result
@@ -339,8 +318,7 @@ outer join syntax: complains about non-numeric outer
 ### Errors
    * -outer must be an input number (1, 2, ...).
 
-outer join of a point stream of ids against a table of names
-------------------------------------------------------
+## outer join of a point stream of ids against a table of names
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"fred"},
@@ -359,8 +337,7 @@ outer join of a point stream of ids against a table of names
     {time:"1970-01-01T00:00:04.000Z", "id":5, "n":5 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-outer join of a point stream of nested ids against a table of names
--------------------------------------------------------------------
+## outer join of a point stream of nested ids against a table of names
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":{i: 1}, "name":"fred"},
@@ -379,8 +356,7 @@ outer join of a point stream of nested ids against a table of names
     {time:"1970-01-01T00:00:04.000Z", "id":{i: 5}, "n":5 }
     {time:"1970-01-01T00:00:05.000Z", "id":{i: 1}, "name":"fred", "n":6 }
 
-outer join of two point streams with ids against a table of names
-------------------------------------------------------
+## outer join of two point streams with ids against a table of names
 verify we pick up the match with input 2 even when there is no match with input 1
 ### Juttle
     const names = [
@@ -402,8 +378,7 @@ verify we pick up the match with input 2 even when there is no match with input 
     {"time":"1970-01-01T00:00:05.000Z","id":1,"n":6,"name":"fred","m":12}
 
 
-outer join with overlapping fields keeps the value from input 1
-------------------------------------------------------------------------
+## outer join with overlapping fields keeps the value from input 1
 ### Juttle
     const one = [
     {"userid":1234,"last":"bigboote","time":"2015-02-12T17:10:21"},
@@ -426,8 +401,7 @@ outer join with overlapping fields keeps the value from input 1
 ### Output
     {"first":"john","last":"bigboote","userid":1234}
 
-outer join with overlapping fields keeps the value from input 2
-------------------------------------------------------------------------
+## outer join with overlapping fields keeps the value from input 2
 ### Juttle
     const one = [
     {"userid":1234,"last":"bigboote","time":"2015-02-12T17:10:21"},
@@ -450,8 +424,7 @@ outer join with overlapping fields keeps the value from input 2
 ### Output
     {"first":"john","last":"smallberries","userid":1234}
 
-outer join with overlapping fields keeps the value from input 3
-------------------------------------------------------------------------
+## outer join with overlapping fields keeps the value from input 3
 ### Juttle
     const one = [
     {"userid":1234,"last":"bigboote","time":"2015-02-12T17:10:21"},
@@ -474,8 +447,7 @@ outer join with overlapping fields keeps the value from input 3
 ### Output
     {"first":"john","last":"ya ya","userid":1234}
 
-single-stream join by a field
---------------------------------------
+## single-stream join by a field
 ### Juttle
     emit -from :2000-01-01: -limit 1
     |(put region="north",  group="bar",  peek="frean", n=1
@@ -504,8 +476,7 @@ single-stream join by a field
       "time": "2000-01-01T00:00:00.000Z"
     }
 
-single-stream join by a nested field
---------------------------------------
+## single-stream join by a nested field
 ### Juttle
     emit -from :2000-01-01: -limit 1
     |(put region="north",  group="bar",  peek={foo: "frean"}, n=1
@@ -534,8 +505,7 @@ single-stream join by a nested field
       "time": "2000-01-01T00:00:00.000Z"
     }
 
-single-stream groups by batch when batched
---------------------------------------
+## single-stream groups by batch when batched
 ### Juttle
     const points=[
     {  "time": "2014-01-01T00:00:00.000Z", "name": "fred",   "value": 10 },
@@ -566,8 +536,7 @@ single-stream groups by batch when batched
       "time": "2014-01-01T00:00:06.000Z"
     }
 
-single-stream can fake an sql table join, batched
---------------------------------------
+## single-stream can fake an sql table join, batched
 ### Juttle
     const points=[
     { "time": "2014-01-01T00:00:00.000Z", "id":1, name:"first", "value": "fred"},
@@ -594,8 +563,7 @@ single-stream can fake an sql table join, batched
     {"time":"2014-01-01T00:00:20.000Z","id":4,"first":"betty","last":"rubble"}
     {"time":"2014-01-01T00:00:20.000Z","id":5,"first":"dino","last":"de laurentis"}
 
-single-stream can fake a table join, unbatched
---------------------------------------
+## single-stream can fake a table join, unbatched
 ### Juttle
     const points = [
     { "time": "2014-01-01T00:00:00", "id":1, name:"first", "value": "fred"},
@@ -621,8 +589,7 @@ single-stream can fake a table join, unbatched
     {"time":"2014-01-01T00:00:00.000Z","id":4,"first":"betty","last":"rubble"}
     {"time":"2014-01-01T00:00:00.000Z","id":5,"first":"dino","last":"de laurentis"}
 
-single-stream with dereferencing puts really is the inverse of split
---------------------------------------
+## single-stream with dereferencing puts really is the inverse of split
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | put foo="bar", bleat="blort", peek="frean", cookie="serious"
@@ -640,8 +607,7 @@ single-stream with dereferencing puts really is the inverse of split
       "time": "1970-01-01T00:00:00.000Z"
     }
 
-single-stream doesn't crash on null or undefined joinfield value
-----------------------------------------------------------
+## single-stream doesn't crash on null or undefined joinfield value
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | (put n=0; put key=null, n=1; put key=true, n=2; put key=false, n=3)
@@ -655,8 +621,7 @@ single-stream doesn't crash on null or undefined joinfield value
     { key: true,  n: 2 }
     { key: false, n: 3 }
 
-single-stream treats null and undefined as distinct key values for joining
-----------------------------------------------------------
+## single-stream treats null and undefined as distinct key values for joining
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | (
@@ -674,8 +639,7 @@ single-stream treats null and undefined as distinct key values for joining
     { n0: 0, n2: 0, color: "black", n5: 0 }
     { key: null, n1: 0, n3: 0, color: "gray", n4: 0 }
 
-single-stream likes all types for joinkeys
-----------------------------------------------------------
+## single-stream likes all types for joinkeys
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | (
@@ -695,8 +659,7 @@ single-stream likes all types for joinkeys
     { key: true, v3: 3, color: "green" }
     { key: "s", v5: 5, color: "brown" }
 
-outer-join with empty stream produces points
-------------------------------------------------------------------
+## outer-join with empty stream produces points
 ### Juttle
     (emit -limit 5 -from Date.new(0)
      | put id=count(), foo = 1;
@@ -712,8 +675,7 @@ outer-join with empty stream produces points
     { id: 4, foo: 1 }
     { id: 5, foo: 1 }
 
-outer-join with sparse stream produces points
-------------------------------------------------------------------
+## outer-join with sparse stream produces points
 ### Juttle
     (emit -limit 4 -from Date.new(0)
      | put id=count(), foo = 1;
@@ -730,8 +692,7 @@ outer-join with sparse stream produces points
     { id: 3, foo: 1 }
     { id: 4, bar: 1, mod: 0, foo: 1 }
 
-join on time works like join -maxoffset :0s:
----------------------------------------------------------------
+## join on time works like join -maxoffset :0s:
 ### Juttle
     ( emit -every :1s:  -from Date.new(0) -limit 6 | put a=count()
     ; emit -every :2s:  -from Date.new(0) -limit 3 | put b=count()
@@ -743,8 +704,7 @@ join on time works like join -maxoffset :0s:
     {time: "1970-01-01T00:00:02.000Z", a:3, b:2}
     {time: "1970-01-01T00:00:04.000Z", a:5, b:3}
 
-join on time with -nearest is just join -nearest
----------------------------------------------------------------
+## join on time with -nearest is just join -nearest
 ### Juttle
     ( emit -every :1s:  -from Date.new(0) -limit 6 | put a=count()
     ; emit -every :2s:  -from Date.new(0) -limit 3 | put b=count()
@@ -758,8 +718,7 @@ join on time with -nearest is just join -nearest
     {time: "1970-01-01T00:00:04.000Z", a:5, b:3}
     {time: "1970-01-01T00:00:05.000Z", a:6, b:3}
 
-join on time with -zip is just join -zip
----------------------------------------------------------------
+## join on time with -zip is just join -zip
 ### Juttle
     ( emit -every :1s:  -from Date.new(0) -limit 6 | put a=count()
     ; emit -every :2s:  -from Date.new(0) -limit 3 | put b=count()
@@ -771,8 +730,7 @@ join on time with -zip is just join -zip
     {time: "1970-01-01T00:00:04.000Z", a:5, b:3}
 
 
-outer join of a point stream of ids against a -table of names from the past
-------------------------------------------------------
+## outer join of a point stream of ids against a -table of names from the past
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"fred"},
@@ -791,8 +749,7 @@ outer join of a point stream of ids against a -table of names from the past
     {time:"1970-01-01T00:00:04.000Z", "id":5, "n":5 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-inner join of a point stream of ids against a -table of names from the past
-------------------------------------------------------
+## inner join of a point stream of ids against a -table of names from the past
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"fred"},
@@ -809,8 +766,7 @@ inner join of a point stream of ids against a -table of names from the past
     {time:"1970-01-01T00:00:02.000Z", "id":3, "name":"dino", "n":3 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-outer join of a point stream of ids against a -table of names from the future
-------------------------------------------------------
+## outer join of a point stream of ids against a -table of names from the future
 ### Juttle
     const names = [
         {time:"1980-01-01T00:00:00.000Z", "id":1, "name":"fred"},
@@ -829,8 +785,7 @@ outer join of a point stream of ids against a -table of names from the future
     {time:"1970-01-01T00:00:04.000Z", "id":5, "n":5 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-inner join of a point stream of ids against a -table of names from the future
-------------------------------------------------------
+## inner join of a point stream of ids against a -table of names from the future
 ### Juttle
     const names = [
         {time:"1980-01-01T00:00:00.000Z", "id":1, "name":"fred"},
@@ -847,8 +802,7 @@ inner join of a point stream of ids against a -table of names from the future
     {time:"1970-01-01T00:00:02.000Z", "id":3, "name":"dino", "n":3 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-outer join of two point streams with ids against two -tables
-------------------------------------------------------
+## outer join of two point streams with ids against two -tables
 verify we pick up the match with input 2 even when there is no match with input 1
 ### Juttle
     const names = [
@@ -876,8 +830,7 @@ verify we pick up the match with input 2 even when there is no match with input 
     {"time":"1970-01-01T00:00:05.000Z","id":1,"n":6,"name":"fred","m":12,"flavor":"vanilla"}
 
 
-inner join of a point stream #1 of ids against a stream of -table of names advances table
-------------------------------------------------------
+## inner join of a point stream #1 of ids against a stream of -table of names advances table
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"FRED"},
@@ -897,8 +850,7 @@ inner join of a point stream #1 of ids against a stream of -table of names advan
     {time:"1970-01-01T00:00:02.000Z", "id":3, "name":"DINO", "n":3 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-inner join of a point stream #2 of ids against a stream of -table of names advances table
-------------------------------------------------------
+## inner join of a point stream #2 of ids against a stream of -table of names advances table
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"FRED"},
@@ -918,8 +870,7 @@ inner join of a point stream #2 of ids against a stream of -table of names advan
     {time:"1970-01-01T00:00:02.000Z", "id":3, "name":"DINO", "n":3 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-outer join of a point stream #1 of ids against a stream of -table of names advances table
-------------------------------------------------------
+## outer join of a point stream #1 of ids against a stream of -table of names advances table
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"FRED"},
@@ -941,8 +892,7 @@ outer join of a point stream #1 of ids against a stream of -table of names advan
     {time:"1970-01-01T00:00:04.000Z", "id":5, "n":5 }
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
-outer join of a point stream #2 of ids against a stream of -table of names advances table
-------------------------------------------------------
+## outer join of a point stream #2 of ids against a stream of -table of names advances table
 ### Juttle
     const names = [
         {time:"1970-01-01T00:00:00.000Z", "id":1, "name":"FRED"},
@@ -965,8 +915,7 @@ outer join of a point stream #2 of ids against a stream of -table of names advan
     {time:"1970-01-01T00:00:05.000Z", "id":1, "name":"fred", "n":6 }
 
 
-inner join of a batched point stream of ids against a stream of -table of names shuns the future
-------------------------------------------------------
+## inner join of a batched point stream of ids against a stream of -table of names shuns the future
 what happens in the future, stays in the future: a single table from the future
 will get used (earlier test) but if you are sending a stream of them your
 timestamps better make sense.
@@ -991,8 +940,7 @@ timestamps better make sense.
     {time:"1970-01-01T00:00:09.000Z", "id":2, "name":"WILMA", "n":7 }
     {time:"1970-01-01T00:00:09.000Z", "id":3, "name":"DINO", "n":8 }
 
-ticks advance -table in live outer join of a point stream of ids
-------------------------------------------------------
+## ticks advance -table in live outer join of a point stream of ids
 because a tick arrives between the first and 2nd table update, the first is
 marked complete and participates in early joins. Later joins get the second table.
 
@@ -1021,8 +969,7 @@ marked complete and participates in early joins. Later joins get the second tabl
     {"id":2, "name":"wilma", "n":7 }
     {"id":3, "name":"dino", "n":8 }
 
-implicit timeless table joins still work
------------------------------------------------------------
+## implicit timeless table joins still work
 ### Juttle
     const read_pts = [
             {"source_type": "metric", "time": :yesterday: + :0s:, "name": "C4078.minutes_used", "user_id": 2, "value": 5},
@@ -1054,8 +1001,7 @@ implicit timeless table joins still work
     {        "user_id": 2,        "username": "Bart Simpson",        "total_minutes_used": 5    }
     {        "user_id": 3,        "username": "Lisa Simpson",        "total_minutes_used": 10    }
 
-test for PROD-8738, cannot set property complete_time
---------------------------------------------------------
+## test for PROD-8738, cannot set property complete_time
 ### Juttle
     (
         emit -limit 1 -from :10s ago: -every :10s: | put name='bar';
@@ -1068,8 +1014,7 @@ test for PROD-8738, cannot set property complete_time
 ### Output
     { value: 1 }
 
-test for PROD-10061, outer join with empty stream forwards the outer points
------------------------------------------------------------------------
+## test for PROD-10061, outer join with empty stream forwards the outer points
 ### Juttle
     (
         emit -limit 1 -from :0: | put x = 1, y = 2;
@@ -1091,8 +1036,7 @@ test for PROD-10061, outer join with empty stream forwards the outer points
     {"time":"1970-01-01T00:00:08.000Z","x":1,"z":9}
     {"time":"1970-01-01T00:00:09.000Z","x":1,"z":10}
 
-test for PROD-10061, outer join with empty stream and -table forwards the outer points
------------------------------------------------------------------------
+## test for PROD-10061, outer join with empty stream and -table forwards the outer points
 ### Juttle
     (
         emit -limit 1 -from :0: | put x = 1, y = 2;
@@ -1114,8 +1058,7 @@ test for PROD-10061, outer join with empty stream and -table forwards the outer 
     {"time":"1970-01-01T00:00:08.000Z","x":1,"z":9}
     {"time":"1970-01-01T00:00:09.000Z","x":1,"z":10}
 
-test for PROD-10061, outer join with empty -table stream does the join
------------------------------------------------------------------------
+## test for PROD-10061, outer join with empty -table stream does the join
 ### Juttle
     (
         emit -limit 1 -from :0: | put x = 1, y = 2;

--- a/test/runtime/specs/juttle-spec/juttle-procs-keep.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-keep.spec.md
@@ -1,8 +1,6 @@
-Juttle "keep" processor
-=======================
+# Juttle "keep" processor
 
-Keeps specified fields
-----------------------
+## Keeps specified fields
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Keeps specified fields
     { a: 1, b: 2, c: 3 }
 
 
-Ignores fields that don't exist in processed points
----------------------------------------------------
+## Ignores fields that don't exist in processed points
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-pace.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-pace.spec.md
@@ -1,8 +1,6 @@
-Juttle pace command
-============================================
+# Juttle pace command
 
-pace -every and -x complains
--------------------------
+## pace -every and -x complains
 ### Juttle
     emit -from :2014-01-15: -limit 6
     | pace -every :2s: -x 2
@@ -13,8 +11,7 @@ pace -every and -x complains
 
    * Specify either output period with -every or time speedup with -x
 
-pace -every and number complains
--------------------------
+## pace -every and number complains
 ### Juttle
     emit -from :2014-01-15: -limit 6
     | pace -every 2
@@ -25,8 +22,7 @@ pace -every and number complains
 
    * CompileError: -every wants a duration, got 2
 
-complains if -x is not a number
--------------------------
+## complains if -x is not a number
 ### Juttle
     emit -from :2014-01-15: -limit 6
     | pace -x :minute:
@@ -37,8 +33,7 @@ complains if -x is not a number
 
    * CompileError: -x wants a number, got :00:01:00.000:
 
-complains if -from is not a moment
--------------------------
+## complains if -from is not a moment
 ### Juttle
     emit -from :2014-01-15: -limit 6
     | pace -from 0
@@ -50,8 +45,7 @@ complains if -from is not a moment
    * CompileError: -from wants a moment, got 0
 
 
-plain pacer kicks history out at its real rate
--------------------------
+## plain pacer kicks history out at its real rate
 ### Juttle
     emit -from Date.new(0) -limit 2
     | pace
@@ -65,8 +59,7 @@ plain pacer kicks history out at its real rate
     { time: "1970-01-01T00:00:00.000Z", dt: 0 }
     { time: "1970-01-01T00:00:01.000Z", dt: 1 }
 
-pacer re-labels tick times with -from
--------------------------
+## pacer re-labels tick times with -from
 ### Juttle
     emit -from Date.new(0) -limit 2
     | pace -from :2014-01-01:
@@ -80,8 +73,7 @@ pacer re-labels tick times with -from
     { time: "2014-01-01T00:00:00.000Z", dt: 0 }
     { time: "2014-01-01T00:00:01.000Z", dt: 1 }
 
-pacer runs at double its real rate with -x
--------------------------
+## pacer runs at double its real rate with -x
 ### Juttle
     emit -from Date.new(0) -limit 3
     | pace -from :2014-01-01: -x 2
@@ -96,8 +88,7 @@ pacer runs at double its real rate with -x
     { time: "2014-01-01T00:00:01.000Z", dt: 0.5 }
     { time: "2014-01-01T00:00:02.000Z", dt: 0.5 }
 
-pacer outputs every 2 seconds with -every
--------------------------
+## pacer outputs every 2 seconds with -every
 note that the put window is over the natural data times, not wall time
 ### Juttle
     emit -from Date.new(0) -every :minute: -limit 3
@@ -113,8 +104,7 @@ note that the put window is over the natural data times, not wall time
     { time: "2014-01-01T00:01:00.000Z", dt: 2 }
     { time: "2014-01-01T00:02:00.000Z", dt: 2 }
 
-pacer outputs a batch every second with -every
--------------------------
+## pacer outputs a batch every second with -every
 ### Juttle
     emit -from Date.new(0) -limit 6
     | batch -every :2s:

--- a/test/runtime/specs/juttle-spec/juttle-procs-put-paranoia.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-put-paranoia.spec.md
@@ -1,13 +1,11 @@
-A paranoid workout of put reducer calling conventions.
-====================================================
+# A paranoid workout of put reducer calling conventions.
 These are thoroughly unpleasant to read, but they are thorough.  Every
 put environment in which a reducer can be invoked is covered here.  This
 is for reducer lifecycle testing, not reducer correctness, so all
 tests use avg (a reducer with expire()) and first (a reducer without
 expire).
 
-The basic set, fed a steady stream.
----------------------------------------------
+## The basic set, fed a steady stream.
 * we don't test -acc true -over :dur:, or batched -over :dur:,
 because -over performs a reset at every point in order to replay
 the correct window of points, and its interaction with other resetting
@@ -76,8 +74,7 @@ behavior is unspecified.
     { ID: 6, T: 3.5, a: 5.5 }
 
 
-The basic set, fed a steady stream of two groups
----------------------------------------------
+## The basic set, fed a steady stream of two groups
 group A results are same as single-group stream, and group B's
 results are same as group A's plus 10.
 * 3 is to verify assignment sequencing, and is skipped until PROD-3312
@@ -184,8 +181,7 @@ results are same as group A's plus 10.
     { ID: 6, T: 8, name: "B", a: 14.5 }
     { ID: 6, T: 8.5, name: "B", a: 15.5 }
 
-The basic set, fed a stream sparser than batch and -over
----------------------------------------------
+## The basic set, fed a stream sparser than batch and -over
 * 3 is to verify assignment sequencing, and is skipped until PROD-3312
 * 6 verifies windowed points are safe from overwriting
 
@@ -229,8 +225,7 @@ The basic set, fed a stream sparser than batch and -over
     { ID: 6, T: 8, a: 16 }
     { ID: 6, T: 12, a: 24 }
 
-The basic set, fed a stream of two groups sparser than batch and -over.
----------------------------------------------
+## The basic set, fed a stream of two groups sparser than batch and -over.
 group A results are same as single-group stream, and group B"s
 results are same as group As plus 10.
 * 3 is to verify assignment sequencing, and is skipped until PROD-3312

--- a/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
@@ -1,8 +1,6 @@
-Juttle "put" processor
-======================
+# Juttle "put" processor
 
-Allows direct assignment to the `time` field
----------------------------------------------------
+## Allows direct assignment to the `time` field
 
 ### Juttle
 
@@ -14,8 +12,7 @@ Allows direct assignment to the `time` field
     { time: "1970-01-01T00:01:01.000Z" }
     { time: "1970-01-01T00:01:02.000Z" }
 
-Allows indirect assignment to the `time` field
------------------------------------------------------
+## Allows indirect assignment to the `time` field
 
 ### Juttle
 
@@ -27,8 +24,7 @@ Allows indirect assignment to the `time` field
     { time: "1970-01-01T00:00:01.000Z" }
     { time: "1970-01-01T00:00:02.000Z" }
 
-complains about non-time assignment to the `time` field
------------------------------------------------------
+## complains about non-time assignment to the `time` field
 
 ### Juttle
 
@@ -38,8 +34,7 @@ complains about non-time assignment to the `time` field
 
    * Invalid type assigned to time: duration (00:00:01.000).
 
-complains about out-of-order assignment to the `time` field with a reducer
------------------------------------------------------
+## complains about out-of-order assignment to the `time` field with a reducer
 
 ### Juttle
 
@@ -53,8 +48,7 @@ complains about out-of-order assignment to the `time` field with a reducer
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
     { time: "1970-01-01T00:00:00.000Z", n: 3 }
 
-complains about out-of-order assignment to the `time` field with non-reducer expression
------------------------------------------------------
+## complains about out-of-order assignment to the `time` field with non-reducer expression
 
 ### Juttle
 
@@ -68,8 +62,7 @@ complains about out-of-order assignment to the `time` field with non-reducer exp
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
     { time: "1970-01-01T00:00:00.000Z", n: 3 }
 
-the -acc option suppresses reducer reset
------------------------------------------------------
+## the -acc option suppresses reducer reset
 
 ### Juttle
 
@@ -85,8 +78,7 @@ the -acc option suppresses reducer reset
     { time: "1970-01-01T00:00:02.000Z", c: 3 }
     { time: "1970-01-01T00:00:03.000Z", c: 4 }
 
-sequential assignments work with reducers
------------------------------------------------------
+## sequential assignments work with reducers
 
 ### Juttle
 
@@ -102,8 +94,7 @@ sequential assignments work with reducers
     { c: 3, c2: 9, two: false, again: 9, notagain: 1, ternary: 2 }
     { c: 4, c2: 16, two: false, again: 16, notagain: 1, ternary: null }
 
-sequential assignments with -over show proper results of partial windows
-------------------------------------------------------------------------
+## sequential assignments with -over show proper results of partial windows
 note the ternary count is only incremented when the condition is true.
 it gives a count of odds or evens in the current window.
 
@@ -123,8 +114,7 @@ it gives a count of odds or evens in the current window.
     { i: 4, c: 3, d: 3 }
     { i: 5, c: 3, d: 3 }
 
-assignments with -from and -over hide their results from you but not from themselves
-------------------------------------------------------------------------------------
+## assignments with -from and -over hide their results from you but not from themselves
 Like the previous test, but final result points between 0..3s are suppressed.
 intermediate sequential assignments for these points are processed as normal,
 so that the window is loaded with conforming points. this is why the first value
@@ -146,8 +136,7 @@ of d is 2 instead of 3.
     { i: 4, c: 3, d: 3 }
     { i: 5, c: 3, d: 3 }
 
-Warns and drops points on a runtime error
------------------------------------------
+## Warns and drops points on a runtime error
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce-over.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce-over.spec.md
@@ -1,5 +1,4 @@
-Juttle reduce processor, windowed -over mode
-=========================================
+# Juttle reduce processor, windowed -over mode
 These tests give -over a workout. -over specifies a window of time
 over which each reducer computation should operate (all points within
 that window). Partial windows (at the beginning or end of a stream)
@@ -10,8 +9,7 @@ the same, in the unbatched reduce specify -from/-to equal to the beginning
 and ending epochs of the data (the batched reducer is fed these epochs as
 marks by the upstream batch, so they needn't be specified for batched operation)
 
-complains if -over is not a duration
-------------------------------------
+## complains if -over is not a duration
 ### Juttle
 
     reduce -every :s: -over 0.01 count() |  view result
@@ -20,8 +18,7 @@ complains if -over is not a duration
 
    * -over wants a duration, got 0.01
 
-put with -over works
-------------------------------------
+## put with -over works
 ### Juttle
 
     emit -from Date.new(0) -limit 6 | put -over :3s: c = count() | view result
@@ -35,8 +32,7 @@ put with -over works
     {"time": "1970-01-01T00:00:04.000Z", "c": 3}
     {"time": "1970-01-01T00:00:05.000Z", "c": 3}
 
-put with -over and -from works
-------------------------------------
+## put with -over and -from works
 ### Juttle
 
     emit -from Date.new(0) -limit 6 | put -from Date.new(0) -over :3s: c = count() | view result
@@ -50,8 +46,7 @@ put with -over and -from works
     {"time": "1970-01-01T00:00:04.000Z", "c": 3}
     {"time": "1970-01-01T00:00:05.000Z", "c": 3}
 
-put with -over -by works
-------------------------------------
+## put with -over -by works
 ### Juttle
 
     emit -points [
@@ -81,8 +76,7 @@ put with -over -by works
     { "time": "1970-01-01T00:00:06.000Z",
       "color": "blue", "c": 3 }
 
-put with -over trumps batches (they are just not relevant) but forwards them
-------------------------------------
+## put with -over trumps batches (they are just not relevant) but forwards them
 specifying -over specifies reset behavior as well, and we've decided
 this should trump any batch present.
 ### Juttle
@@ -102,8 +96,7 @@ this should trump any batch present.
     {"time": "1970-01-01T00:00:04.000Z", "over": 3, "under": 1 }
     {"time": "1970-01-01T00:00:05.000Z", "over": 3, "under": 2 }
 
-put with -over downstream from a reduce works
-------------------------------------
+## put with -over downstream from a reduce works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -133,8 +126,7 @@ put with -over downstream from a reduce works
       "over": 2
     }
 
-one-shot reduce with -over works
----------------------------------
+## one-shot reduce with -over works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -145,8 +137,7 @@ one-shot reduce with -over works
 
     { "over": 3 }
 
-batch-driven reduce with -over same as batch
--------------------------------------------------------
+## batch-driven reduce with -over same as batch
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -158,8 +149,7 @@ batch-driven reduce with -over same as batch
     { "time": "1970-01-01T00:00:03.000Z", "over": 3}
     { "time": "1970-01-01T00:00:06.000Z", "over": 3}
 
-batch-driven reduce with -over less than batch works
--------------------------------------------------------
+## batch-driven reduce with -over less than batch works
 ### Juttle
 
     emit -from Date.new(0) -limit 8
@@ -171,8 +161,7 @@ batch-driven reduce with -over less than batch works
     { "time": "1970-01-01T00:00:04.000Z", "over": 3}
     { "time": "1970-01-01T00:00:08.000Z", "over": 3}
 
-batch-driven reduce with -over greater than batch works
--------------------------------------------------------
+## batch-driven reduce with -over greater than batch works
 ### Juttle
 
     emit -from Date.new(0) -limit 9
@@ -185,8 +174,7 @@ batch-driven reduce with -over greater than batch works
     { "time": "1970-01-01T00:00:06.000Z", "over": 4}
     { "time": "1970-01-01T00:00:09.000Z", "over": 4}
 
-batch-driven reduce with -over downstream from a reduce works
--------------------------------------------------------
+## batch-driven reduce with -over downstream from a reduce works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -199,8 +187,7 @@ batch-driven reduce with -over downstream from a reduce works
     { "time": "1970-01-01T00:00:03.000Z", "over": 1}
     { "time": "1970-01-01T00:00:06.000Z", "over": 1}
 
-every-driven reduce with -over === -every is same as batch reduce
--------------------------------------------------------
+## every-driven reduce with -over === -every is same as batch reduce
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -212,8 +199,7 @@ every-driven reduce with -over === -every is same as batch reduce
     { "time": "1970-01-01T00:00:06.000Z", "over": 3}
 
 
-every-driven reduce with -over less than -every works
--------------------------------------------------------
+## every-driven reduce with -over less than -every works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -224,8 +210,7 @@ every-driven reduce with -over less than -every works
     { "time": "1970-01-01T00:00:03.000Z", "over": 2}
     { "time": "1970-01-01T00:00:06.000Z", "over": 2}
 
-every-driven reduce with -over greater than -every works
--------------------------------------------------------
+## every-driven reduce with -over greater than -every works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -236,8 +221,7 @@ every-driven reduce with -over greater than -every works
     { "time": "1970-01-01T00:00:03.000Z", "over": 3}
     { "time": "1970-01-01T00:00:06.000Z", "over": 4}
 
-cascade of every-driven reducers, first
-----------------------------------
+## cascade of every-driven reducers, first
 ### Juttle
 
     emit -from Date.new(0) -limit 3
@@ -252,8 +236,7 @@ cascade of every-driven reducers, first
     {"time":"1970-01-01T00:00:02.000Z","first3":"1970-01-01T00:00:01.000Z"}
     {"time":"1970-01-01T00:00:03.000Z","first3":"1970-01-01T00:00:02.000Z"}
 
-cascade of every-driven reducers, last
-----------------------------------
+## cascade of every-driven reducers, last
 ### Juttle
 
     emit -from Date.new(0) -limit 3
@@ -268,8 +251,7 @@ cascade of every-driven reducers, last
     {"time":"1970-01-01T00:00:02.000Z","last3":"1970-01-01T00:00:01.000Z"}
     {"time":"1970-01-01T00:00:03.000Z","last3":"1970-01-01T00:00:02.000Z"}
 
-cascade of batch-driven reducers, first
-----------------------------------
+## cascade of batch-driven reducers, first
 ### Juttle
 
     emit -from Date.new(0) -limit 3
@@ -285,8 +267,7 @@ cascade of batch-driven reducers, first
     {"time":"1970-01-01T00:00:02.000Z","first3":"1970-01-01T00:00:01.000Z"}
     {"time":"1970-01-01T00:00:03.000Z","first3":"1970-01-01T00:00:02.000Z"}
 
-cascade of batch-driven reducers, last
-----------------------------------
+## cascade of batch-driven reducers, last
 ### Juttle
 
     emit -from Date.new(0) -limit 3
@@ -302,8 +283,7 @@ cascade of batch-driven reducers, last
     {"time":"1970-01-01T00:00:02.000Z","last3":"1970-01-01T00:00:01.000Z"}
     {"time":"1970-01-01T00:00:03.000Z","last3":"1970-01-01T00:00:02.000Z"}
 
-every-driven reduce with -every faster than data and -over longer
--------------------------------------------------------
+## every-driven reduce with -every faster than data and -over longer
 
 ### Juttle
 
@@ -327,8 +307,7 @@ every-driven reduce with -every faster than data and -over longer
     {"time":"1970-01-01T00:00:12.000Z","over":1}
     {"time": "1970-01-01T00:00:13.000Z","over":2}
 
-reduce -every with -from/-to and no -over complains
-------------------------------
+## reduce -every with -from/-to and no -over complains
 
 ### Juttle
 
@@ -341,8 +320,7 @@ reduce -every with -from/-to and no -over complains
    * only when -over is specified
 
 
-batch reduce with -from/-to and no -over complains
-------------------------------
+## batch reduce with -from/-to and no -over complains
 
 ### Juttle
 
@@ -356,8 +334,7 @@ batch reduce with -from/-to and no -over complains
    * only when -over is specified
 
 
-reduce -every with leading partial window result suppressed using -from
-------------------------------
+## reduce -every with leading partial window result suppressed using -from
 
 ### Juttle
 
@@ -373,8 +350,7 @@ reduce -every with leading partial window result suppressed using -from
       "time": "1970-01-03T12:00:00.000Z"
     }
 
-reduce -every with trailing partial window result suppressed using -to
-------------------------------
+## reduce -every with trailing partial window result suppressed using -to
 
 ### Juttle
 
@@ -390,8 +366,7 @@ reduce -every with trailing partial window result suppressed using -to
       "time": "1970-01-02T12:00:00.000Z"
     }
 
-batch reduce with leading partial window result suppressed using -from
-------------------------------
+## batch reduce with leading partial window result suppressed using -from
 
 ### Juttle
 
@@ -408,8 +383,7 @@ batch reduce with leading partial window result suppressed using -from
       "time": "1970-01-03T12:00:00.000Z"
     }
 
-batch reduce with trailing partial window result suppressed using -to
-------------------------------
+## batch reduce with trailing partial window result suppressed using -to
 
 ### Juttle
 
@@ -426,8 +400,7 @@ batch reduce with trailing partial window result suppressed using -to
       "time": "1970-01-02T12:00:00.000Z"
     }
 
-reduce -every with -over, long partial windows suppressed using -to and -from
-------------------------------
+## reduce -every with -over, long partial windows suppressed using -to and -from
 
 ### Juttle
 
@@ -439,8 +412,7 @@ reduce -every with -over, long partial windows suppressed using -to and -from
     {"hours": 48, "time": "1970-01-03T12:00:00.000Z"}
     {"hours": 48, "time": "1970-01-04T12:00:00.000Z"}
 
-batch reduce with -over, long partial windows suppressed using -to and -from
-------------------------------
+## batch reduce with -over, long partial windows suppressed using -to and -from
 
 ### Juttle
 
@@ -453,8 +425,7 @@ batch reduce with -over, long partial windows suppressed using -to and -from
     {"hours": 48, "time": "1970-01-03T12:00:00.000Z"}
     {"hours": 48, "time": "1970-01-04T12:00:00.000Z"}
 
-every-driven reduce with -every faster than data and -over longer, ragged windows suppressed
--------------------------------------------------------
+## every-driven reduce with -every faster than data and -over longer, ragged windows suppressed
 
 ### Juttle
 
@@ -475,8 +446,7 @@ every-driven reduce with -every faster than data and -over longer, ragged window
     {"time":"1970-01-01T00:00:12.000Z","over":1}
     {"time":"1970-01-01T00:00:13.000Z","over":2}
 
-every-driven reduce is aligned with its start time, not the epoch
-----------------------------------------------------------------
+## every-driven reduce is aligned with its start time, not the epoch
 ### Juttle
 
     emit -every :1s: -from :-3s: -to :+1.1s:
@@ -488,8 +458,7 @@ every-driven reduce is aligned with its start time, not the epoch
 
     { "N": 3 }
 
-(skip)PROD-7471 every-driven reduce triggers an advance on ticks outside the window, ahead of eof
-----------------------------------------------------------------
+## (skip)PROD-7471 every-driven reduce triggers an advance on ticks outside the window, ahead of eof
 XXX when PROD-7331 merges, make this test fast.
 
 ### Juttle
@@ -504,8 +473,7 @@ XXX when PROD-7331 merges, make this test fast.
     {"N": 1}
     {"tick": true}
 
-(skip)PROD-7471 one-shot reduce -over/-to triggers an advance on ticks outside the window, ahead of eof
-----------------------------------------------------------------
+## (skip)PROD-7471 one-shot reduce -over/-to triggers an advance on ticks outside the window, ahead of eof
 XXX when PROD-7331 merges, make this test fast.
 
 ### Juttle
@@ -520,8 +488,7 @@ XXX when PROD-7331 merges, make this test fast.
     {"N": 1}
     {"tick": true}
 
-every-driven reduce triggers an advance on data outside the window, ahead of eof
-----------------------------------------------------------------
+## every-driven reduce triggers an advance on data outside the window, ahead of eof
 XXX when PROD-7331 merges, make this test fast.
 
 ### Juttle
@@ -535,8 +502,7 @@ XXX when PROD-7331 merges, make this test fast.
 ### Output
     { "winning":true }
 
-one-shot reduce -over/-to triggers an advance on data outside the window, ahead of eof
-----------------------------------------------------------------
+## one-shot reduce -over/-to triggers an advance on data outside the window, ahead of eof
 XXX when PROD-7331 merges, make this test fast.
 
 ### Juttle
@@ -550,8 +516,7 @@ XXX when PROD-7331 merges, make this test fast.
 ### Output
     { "winning":true }
 
-windowed count works (custom expire method)
--------------------------------------------
+## windowed count works (custom expire method)
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -562,8 +527,7 @@ windowed count works (custom expire method)
 
     { "over": 3 }
 
-windowed avg works (custom expire method)
--------------------------------------------
+## windowed avg works (custom expire method)
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -578,8 +542,7 @@ windowed avg works (custom expire method)
     {"time":"1970-01-01T00:00:03.000Z","over":1}
     {"time":"1970-01-01T00:00:04.000Z","over":2}
 
-windowed sum works (custom expire method)
--------------------------------------------
+## windowed sum works (custom expire method)
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -594,8 +557,7 @@ windowed sum works (custom expire method)
     {"time":"1970-01-01T00:00:03.000Z","over":3}
     {"time":"1970-01-01T00:00:04.000Z","over":6}
 
-windowed sigma works (custom expire method)
--------------------------------------------
+## windowed sigma works (custom expire method)
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -610,8 +572,7 @@ windowed sigma works (custom expire method)
     {"time":"1970-01-01T00:00:03.000Z","over":1}
     {"time":"1970-01-01T00:00:04.000Z","over":1}
 
-windowed min works
--------------------------------------------
+## windowed min works
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -626,8 +587,7 @@ windowed min works
     {"time":"1970-01-01T00:00:03.000Z","over":0}
     {"time":"1970-01-01T00:00:04.000Z","over":1}
 
-windowed max works
--------------------------------------------
+## windowed max works
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -642,8 +602,7 @@ windowed max works
     {"time":"1970-01-01T00:00:03.000Z","over":2}
     {"time":"1970-01-01T00:00:04.000Z","over":3}
 
-windowed first works
--------------------------------------------
+## windowed first works
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -658,8 +617,7 @@ windowed first works
     {"time":"1970-01-01T00:00:03.000Z","over":0}
     {"time":"1970-01-01T00:00:04.000Z","over":1}
 
-windowed last works
--------------------------------------------
+## windowed last works
 ### Juttle
 
     emit -from Date.new(0) -limit 4
@@ -674,8 +632,7 @@ windowed last works
     {"time":"1970-01-01T00:00:03.000Z","over":2}
     {"time":"1970-01-01T00:00:04.000Z","over":3}
 
-windowed pluck works
--------------------------------------------
+## windowed pluck works
 ### Juttle
 
     emit -from Date.new(0) -limit 6
@@ -692,8 +649,7 @@ windowed pluck works
     {"time":"1970-01-01T00:00:05.000Z","over":[2,3,4]}
     {"time":"1970-01-01T00:00:06.000Z","over":[3,4,5]}
 
-windowed percentile works
--------------------------------------------
+## windowed percentile works
 (consult pluck output to convince yourself)
 
 ### Juttle
@@ -712,8 +668,7 @@ windowed percentile works
     {"time":"1970-01-01T00:00:05.000Z","over":3}
     {"time":"1970-01-01T00:00:06.000Z","over":4}
 
-windowed count_unique works
--------------------------------------------
+## windowed count_unique works
 
 ### Juttle
 
@@ -731,8 +686,7 @@ windowed count_unique works
     {"time":"1970-01-01T00:00:05.000Z","over":2}
     {"time":"1970-01-01T00:00:06.000Z","over":2}
 
-custom windowed reducers work with expire
-------------------------------------------------------------
+## custom windowed reducers work with expire
 ### Juttle
 
     reducer count_odd(fieldname) {
@@ -790,8 +744,7 @@ custom windowed reducers work with expire
       "nodd": 2
     }
 
-custom windowed reducers work without expire
-------------------------------------------------------------
+## custom windowed reducers work without expire
 ### Juttle
 
     reducer count_odd(fieldname) {

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
@@ -1,13 +1,11 @@
-A paranoid workout of reduce reducer calling conventions.
-====================================================
+# A paranoid workout of reduce reducer calling conventions.
 These are thoroughly unpleasant to read, but they are thorough.  Every
 reduce environment in which a reducer can be invoked is covered here.  This
 is for reducer lifecycle testing, not reducer correctness, so all
 tests use avg (a reducer with expire()) and first (a reducer without
 expire).
 
-The basic set, fed a steady stream.
----------------------------------------------
+## The basic set, fed a steady stream.
 * we don't test -reset false -over :dur: because -over controls
 resetting in order to replay the correct window of points at each epoch.
 * we don't test -reset false -over :dur: because -over controls
@@ -62,8 +60,7 @@ resetting in order to replay the correct window of points at each epoch.
     { ID: 7, a: 2.5, f: 0, t: 6 }
     { ID: 7, a: 3.5, f: 0, t: 8 }
 
-The basic set, fed a steady stream of two groups
--------------------------------------------------
+## The basic set, fed a steady stream of two groups
 group A results are same as single-group stream, and group B's
 results are same as group A's plus 10.
 
@@ -177,8 +174,7 @@ results are same as group A's plus 10.
     { name: "A", ID: 11, a: 5.5, f: 4, t: 8 }
     { name: "B", ID: 11, a: 15.5, f: 14, t: 8 }
 
-The basic set, fed a stream sparser than -every but not -over
--------------------------------------------------------------
+## The basic set, fed a stream sparser than -every but not -over
 an empty epoch might not be empty when it is windowed over a longer stretch of time.
 because these reduces are not groupby, reducers are run every epoch, even for an empty window.
 * 't' in the output is the batch end time as seconds.
@@ -250,8 +246,7 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     { ID: 7, a: 4, f: 0, t: 12 }
     { ID: 7, a: 6, f: 0, t: 14 }
 
-The basic set, fed a stream of two groups sparser than -every but not -over.
---------------------------------------------------------------------------
+## The basic set, fed a stream of two groups sparser than -every but not -over.
 an empty epoch might not be empty when it is windowed over a longer stretch of time.
 for non empty windows, group A results are same as single-group stream, and group B's
 results are same as group A's plus 10.
@@ -417,8 +412,7 @@ a group witness affects reset/teardown, and this is not true in a non-groupby se
     { name: "A", ID: 11, a: 12, f: 12, t: 14 }
     { name: "B", ID: 11, a: 22, f: 22, t: 14 }
 
-The basic set, fed a stream sparser than -every and -over
----------------------------------------------
+## The basic set, fed a stream sparser than -every and -over
 because these reduces are not groupby, reducers are run every epoch, even for an empty window.
 * 't' in the output is the batch end time as seconds.
 ID=last(ID) is a placeholder so that ID appears first in output, for readability
@@ -525,8 +519,7 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     { ID: 7, a: 8, f: 0, t: 24 }
     { ID: 7, a: 12, f: 0, t: 26 }
 
-The basic set, fed a stream of two groups sparser than -every and -over.
----------------------------------------------
+## The basic set, fed a stream of two groups sparser than -every and -over.
 you know the drill. nonempty group A results are same as single-group stream, and group B's
 results are same as group A's plus 10.
 Unlike the single stream case, empty group window results should not be reported

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -1,9 +1,7 @@
 
-Juttle "reduce" processor (-every epoch mode)
-=========================================
+# Juttle "reduce" processor (-every epoch mode)
 
-complains if -every is not a duration
---------------------------------------
+## complains if -every is not a duration
 
 ### Juttle
 
@@ -14,8 +12,7 @@ complains if -every is not a duration
    * -every wants a duration, got 0.01
 
 
-complains if -on is not a duration or moment
-----------------------------------------------
+## complains if -on is not a duration or moment
 
 ### Juttle
 
@@ -26,8 +23,7 @@ complains if -on is not a duration or moment
    * -on wants a duration or moment, got 1
 
 
-complains if -on > -every
--------------------------
+## complains if -on > -every
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -38,8 +34,7 @@ complains if -on > -every
 
    * CompileError: reduce -on cannot be greater than -every
 
-complains if reduce -every is negative
--------------------------
+## complains if reduce -every is negative
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -50,8 +45,7 @@ complains if reduce -every is negative
 
    * CompileError: reduce -every must be a positive duration.
 
-complains if reduce -every is 0
--------------------------
+## complains if reduce -every is 0
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -62,8 +56,7 @@ complains if reduce -every is 0
 
    * CompileError: reduce -every must be a positive duration.
 
-complains if reduce -every null -on notnull
------------------------------------------------------
+## complains if reduce -every null -on notnull
 
 ### Juttle
     emit -limit 10 -from Date.new(0)
@@ -75,8 +68,7 @@ complains if reduce -every null -on notnull
 
    * CompileError: reduce -on requires -every
 
-complains if reduce -forget without by
--------------------------
+## complains if reduce -forget without by
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -87,8 +79,7 @@ complains if reduce -forget without by
 
    * CompileError: -forget option only applies when using "by"
 
-complains if reduce -forget -reset false
--------------------------
+## complains if reduce -forget -reset false
 
 ### Juttle
     emit -from :2014-01-15: -limit 6
@@ -100,8 +91,7 @@ complains if reduce -forget -reset false
    * CompileError: cannot -forget when -reset false
 
 
-complains about a bogus option
-----------------------------------------------
+## complains about a bogus option
 
 ### Juttle
 
@@ -111,8 +101,7 @@ complains about a bogus option
 
    * unknown reduce option failure.
 
-treats reduce -every null -on null as if no every was specified
------------------------------------------------------
+## treats reduce -every null -on null as if no every was specified
 this lets us add optional -every -on parameters to subs with
 default values of null for when no -every is specified.
 
@@ -126,8 +115,7 @@ default values of null for when no -every is specified.
     {count: 5, time: "1970-01-01T00:00:05.000Z"}
     {count: 5, time: "1970-01-01T00:00:10.000Z"}
 
-basic reduce -every, historic
-------------------------------
+## basic reduce -every, historic
 
 ### Juttle
 
@@ -141,8 +129,7 @@ basic reduce -every, historic
     {"a": 2, "time": "1970-01-01T00:00:00.004Z"}
     {"a": 2, "time": "1970-01-01T00:00:00.006Z"}
 
-basic reduce -every, realtime
-------------------------------
+## basic reduce -every, realtime
 
 ### Juttle
 
@@ -157,8 +144,7 @@ basic reduce -every, realtime
     {"a": 2}
     {"a": 2}
 
-reduce -every without teardown (-acc 1)
-----------------------------------------
+## reduce -every without teardown (-acc 1)
 
 ### Juttle
 
@@ -172,8 +158,7 @@ reduce -every without teardown (-acc 1)
     { "min": 1, "time": "1970-01-01T00:00:00.005Z"}
     { "min": 1, "time": "1970-01-01T00:00:00.010Z"}
 
-reduce -every without teardown (-reset false)
-----------------------------------------
+## reduce -every without teardown (-reset false)
 
 ### Juttle
 
@@ -187,8 +172,7 @@ reduce -every without teardown (-reset false)
     { "min": 1, "time": "1970-01-01T00:00:00.005Z"}
     { "min": 1, "time": "1970-01-01T00:00:00.010Z"}
 
-reduce -every emits marks at batch boundaries
----------------------------------------------
+## reduce -every emits marks at batch boundaries
 
 ### Juttle
 
@@ -207,8 +191,7 @@ reduce -every emits marks at batch boundaries
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.006Z"}
     {"mark": true, "time": "1970-01-01T00:00:00.006Z"}
 
-cascade of every-driven reducers
-----------------------------------
+## cascade of every-driven reducers
 
 ### Juttle
 
@@ -224,8 +207,7 @@ cascade of every-driven reducers
     {"time":"1970-01-01T00:00:02.000Z","last3":"1970-01-01T00:00:01.000Z"}
     {"time":"1970-01-01T00:00:03.000Z","last3":"1970-01-01T00:00:02.000Z"}
 
-accepts a sub containing a windowed reducer
--------------------------------------------
+## accepts a sub containing a windowed reducer
 
 ### Juttle
 
@@ -241,8 +223,7 @@ accepts a sub containing a windowed reducer
     {"a": 1}
     {"a": 1}
 
-reduce with calendar intervals
-------------------------------
+## reduce with calendar intervals
 
 ### Juttle
 
@@ -301,8 +282,7 @@ reduce with calendar intervals
       "days": 31
     }
 
-reduce with calendar intervals and alignment
-------------------------------
+## reduce with calendar intervals and alignment
 
 ### Juttle
 
@@ -328,8 +308,7 @@ reduce with calendar intervals and alignment
       "days": 31
     }
 
-reduce with regular intervals and alignment
-------------------------------
+## reduce with regular intervals and alignment
 
 ### Juttle
 
@@ -348,8 +327,7 @@ reduce with regular intervals and alignment
       "time": "1970-01-03T12:00:00.000Z"
     }
 
-reduce with undefined field
----------------------------
+## reduce with undefined field
 
 ### Juttle
 
@@ -365,8 +343,7 @@ reduce with undefined field
     { "count": 5, "x": 1, "y": null }
 
 
-custom reducer is torn down at batch epochs
-------------------------------------------------------------
+## custom reducer is torn down at batch epochs
 
 ### Juttle
 
@@ -391,8 +368,7 @@ custom reducer is torn down at batch epochs
     { time: "1970-01-01T00:00:10.000Z", kount: 5 }
 
 
-custom reducer is torn down at reduce epochs
-------------------------------------------------------------
+## custom reducer is torn down at reduce epochs
 
 ### Juttle
 
@@ -416,8 +392,7 @@ custom reducer is torn down at reduce epochs
     { time: "1970-01-01T00:00:10.000Z", kount: 5 }
 
 
-Warns and drops points on a runtime error
------------------------------------------
+## Warns and drops points on a runtime error
 
 ### Juttle
 
@@ -437,8 +412,7 @@ Warns and drops points on a runtime error
 
   * Invalid operand types for ">": null and number (0).
 
-Allows direct assignment to the `time` field
----------------------------------------------------
+## Allows direct assignment to the `time` field
 
 ### Juttle
 
@@ -450,8 +424,7 @@ Allows direct assignment to the `time` field
     { time: "1970-01-01T00:01:02.000Z" }
     { time: "1970-01-01T00:01:04.000Z" }
 
-complains about out-of-order points
------------------------------------
+## complains about out-of-order points
 
 ### Juttle
 
@@ -466,8 +439,7 @@ complains about out-of-order points
 
    * out-of-order point(s) dropped by reduce
 
-complains about non-time assignment to the `time` field in -every mode
------------------------------------------------------
+## complains about non-time assignment to the `time` field in -every mode
 
 ### Juttle
 
@@ -477,8 +449,7 @@ complains about non-time assignment to the `time` field in -every mode
 
    * Invalid type assigned to time: duration (00:00:01.000).
 
-complains about non-time assignment to the `time` field in batch mode
------------------------------------------------------
+## complains about non-time assignment to the `time` field in batch mode
 
 ### Juttle
 
@@ -488,8 +459,7 @@ complains about non-time assignment to the `time` field in batch mode
 
    * Invalid type assigned to time: duration (00:00:01.000).
 
-complains about out-of-order assignment to the `time` field in -every mode
------------------------------------------------------
+## complains about out-of-order assignment to the `time` field in -every mode
 
 ### Juttle
 
@@ -501,8 +471,7 @@ complains about out-of-order assignment to the `time` field in -every mode
    * out-of-order assignment of time 1969-12-31T23:59:56.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
    * out-of-order assignment of time 1969-12-31T23:59:55.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped
 
-complains about out-of-order assignment to the `time` field in batch mode
------------------------------------------------------
+## complains about out-of-order assignment to the `time` field in batch mode
 
 ### Juttle
 
@@ -512,8 +481,7 @@ complains about out-of-order assignment to the `time` field in batch mode
 
    * out-of-order assignment of time 1969-12-31T23:59:58.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
 
-complains about out-of-order assignment to the `time` field with -every
------------------------------------------------------
+## complains about out-of-order assignment to the `time` field with -every
 
 ### Juttle
 
@@ -530,8 +498,7 @@ complains about out-of-order assignment to the `time` field with -every
 ### Output
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
 
-emits grouped results in order when time is assigned
------------------------------------------------------
+## emits grouped results in order when time is assigned
 ### Juttle
     emit -from Date.new(0) -limit 20
     | put n=count()

--- a/test/runtime/specs/juttle-spec/juttle-procs-remove.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-remove.spec.md
@@ -1,8 +1,6 @@
-Juttle "remove" processor
-=========================
+# Juttle "remove" processor
 
-Removes specified fields
-------------------------
+## Removes specified fields
 
 ### Juttle
 
@@ -14,8 +12,7 @@ Removes specified fields
     { time: "1970-01-01T00:00:01.000Z", d: 4 }
     { time: "1970-01-01T00:00:02.000Z", d: 4 }
 
-Ignores fields that don't exist in processed points
----------------------------------------------------
+## Ignores fields that don't exist in processed points
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-skip.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-skip.spec.md
@@ -1,8 +1,6 @@
-Juttle "skip" processor
-======================
+# Juttle "skip" processor
 
-skips a single point with no argument
----------------------------------------------------
+## skips a single point with no argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ skips a single point with no argument
     {}
     {}
 
-skips N points with argument
----------------------------------------------------
+## skips N points with argument
 
 ### Juttle
 
@@ -25,8 +22,7 @@ skips N points with argument
     {}
     {}
 
-skips points by field, no argument
----------------------------------------------------
+## skips points by field, no argument
 
 ### Juttle
     emit -from Date.new(0) -limit 6
@@ -38,8 +34,7 @@ skips points by field, no argument
     {id:2}
     {id:3}
 
-skips points by array/object field, no argument
----------------------------------------------------
+## skips points by array/object field, no argument
 
 ### Juttle
     emit -from Date.new(0) -limit 6
@@ -51,8 +46,7 @@ skips points by array/object field, no argument
     {o:{id:2}}
     {o:{id:3}}
 
-skips points by field, numeric argument
----------------------------------------------------
+## skips points by field, numeric argument
 
 ### Juttle
     emit -from Date.new(0) -limit 9
@@ -64,8 +58,7 @@ skips points by field, numeric argument
     {id:2}
     {id:3}
 
-skips points by array/object field, numeric argument
-----------------------------------------------------
+## skips points by array/object field, numeric argument
 
 ### Juttle
     emit -from Date.new(0) -limit 9
@@ -77,8 +70,7 @@ skips points by array/object field, numeric argument
     {o:{id:2}}
     {o:{id:3}}
 
-complains about nonnumeric argument
----------------------------------------------------
+## complains about nonnumeric argument
 
 ### Juttle
     emit -from Date.new(0) -limit 9 | skip "foo" | view result

--- a/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
@@ -1,8 +1,6 @@
-Juttle "sort" processor
-=======================
+# Juttle "sort" processor
 
-Limits: non-batched flow
-------------------------
+## Limits: non-batched flow
 
 ### Juttle
 
@@ -14,8 +12,7 @@ Limits: non-batched flow
     {"c":2}
     {"c":3}
 
-Limits: non-batched flow, point by point
-----------------------------------------
+## Limits: non-batched flow, point by point
 
 ### Juttle
 
@@ -27,8 +24,7 @@ Limits: non-batched flow, point by point
     {"c":2}
     {"c":3}
 
-Limits: batched flow
---------------------
+## Limits: batched flow
 
 ### Juttle
 
@@ -44,8 +40,7 @@ Limits: batched flow
     {"c":2}
     {"c":3}
 
-Limits: non-batched flow, point by point, by grouping
------------------------------------------------------
+## Limits: non-batched flow, point by point, by grouping
 
 ### Juttle
 
@@ -56,8 +51,7 @@ Limits: non-batched flow, point by point, by grouping
     {"c":1,"d":1}
     {"c":2,"d":0}
 
-Limits: batched flow, by grouping
----------------------------------
+## Limits: batched flow, by grouping
 
 ### Juttle
 
@@ -71,8 +65,7 @@ Limits: batched flow, by grouping
     {"c":1,"d":1}
     {"c":2,"d":0}
 
-Timestamps: unbatched flow
---------------------------
+## Timestamps: unbatched flow
 
 ### Juttle
 
@@ -85,8 +78,7 @@ Timestamps: unbatched flow
     {"a":2}
     {"a":3}
 
-Timestamps: unbatched flow, grouping
-------------------------------------
+## Timestamps: unbatched flow, grouping
 
 ### Juttle
 
@@ -99,8 +91,7 @@ Timestamps: unbatched flow, grouping
     {"a":0,"b":0}
     {"a":2,"b":0}
 
-Timestamps: batched flow
-------------------------
+## Timestamps: batched flow
 
 ### Juttle
 
@@ -113,8 +104,7 @@ Timestamps: batched flow
     {"time":"1970-01-01T00:00:00.400Z","a":0}
     {"time":"1970-01-01T00:00:00.400Z","a":1}
 
-Timestamps: batched flow, with grouping
----------------------------------------
+## Timestamps: batched flow, with grouping
 
 ### Juttle
 
@@ -127,8 +117,7 @@ Timestamps: batched flow, with grouping
     {"time":"1970-01-01T00:00:00.400Z","a":1,"b":1}
     {"time":"1970-01-01T00:00:00.400Z","a":0,"b":0}
 
-Nested fields - arrays
----------------------------------------
+## Nested fields - arrays
 
 ### Juttle
 
@@ -144,8 +133,7 @@ Nested fields - arrays
     {"arr": [2,2,3], "value": 2}
     {"arr": [3,2,3], "value": 3}
 
-Nested fields - array length affects sorting
---------------------------------------------
+## Nested fields - array length affects sorting
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-split.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-split.spec.md
@@ -1,8 +1,6 @@
-Juttle "split" processor
-=======================
+# Juttle "split" processor
 
-splits a named field
----------------------
+## splits a named field
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put foo="bar", bleat="blort", peek="frean"
@@ -13,8 +11,7 @@ splits a named field
     {time: "2000-01-01T00:00:00.000Z", name:"foo",   value:"bar",   peek:"frean"}
     {time: "2000-01-01T00:00:00.000Z", name:"bleat", value:"blort", peek:"frean"}
 
-splits with no named fields
----------------------
+## splits with no named fields
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put foo="bar", bleat="blort", peek="frean"
@@ -26,8 +23,7 @@ splits with no named fields
     {time: "2000-01-01T00:00:00.000Z", name:"bleat", value:"blort"}
     {time: "2000-01-01T00:00:00.000Z", name:"peek", value:"frean"}
 
-splits an array
-------------------
+## splits an array
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put a=String.split("we will rock you"," "), bleat="blort", peek="frean"
@@ -41,8 +37,7 @@ splits an array
     {time: "2000-01-01T00:00:00.000Z", name:"a",   value:"you",   peek:"frean"}
     {time: "2000-01-01T00:00:00.000Z", name:"bleat", value:"blort", peek:"frean"}
 
-doesnt split an array
-------------------
+## doesnt split an array
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put a=String.split("we will rock you"," "), bleat="blort", peek="frean"
@@ -53,8 +48,7 @@ doesnt split an array
     {time: "2000-01-01T00:00:00.000Z", name:"a",   value:["we", "will", "rock", "you"],  peek:"frean"}
     {time: "2000-01-01T00:00:00.000Z", name:"bleat", value:"blort", peek:"frean"}
 
-doesn't split an object
------------------------
+## doesn't split an object
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put a={"we":"will","rock":"you"}, bleat="blort", peek="frean"
@@ -65,8 +59,7 @@ doesn't split an object
     {time: "2000-01-01T00:00:00.000Z", name:"a",   value:{"we":"will","rock":"you"}, peek:"frean"}
     {time: "2000-01-01T00:00:00.000Z", name:"bleat", value:"blort", peek:"frean"}
 
-splits points without time
-------------------
+## splits points without time
 ### Juttle
     emit -from :2000-01-01: -limit 1
     | put foo="bar", bleat="blort", peek="frean", cookie="serious"
@@ -79,16 +72,14 @@ splits points without time
     {name:"bleat", value:"blort", peek:"frean", cookie:"serious"}
 
 
-complains about unknown options
----------------------------------
+## complains about unknown options
 ### Juttle
     emit -limit 1 | split -arrays 0 -failure 1 foo, bar | remove time | view result
 
 ### Errors
    * unknown
 
-complains about missing split fields
----------------------------------
+## complains about missing split fields
 ### Juttle
     emit -limit 1
     | put foo="bar", bleat="blort", peek="frean", cookie="serious"
@@ -99,8 +90,7 @@ complains about missing split fields
 ### Warnings
    * field "bar" does not exist
 
-complains about the presence of name as split field
------------------------------------------------------------------------------------------
+## complains about the presence of name as split field
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | split peek, cookie, name
@@ -109,8 +99,7 @@ complains about the presence of name as split field
 ### Errors
    * CompileError: Cannot split on name
 
-is not confused by the presence of name or value fields in points
------------------------------------------------------------------------------------------
+## is not confused by the presence of name or value fields in points
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | put foo="bar", bleat="blort", peek="frean", cookie="serious", name="joe", value="bigdata"
@@ -133,8 +122,7 @@ is not confused by the presence of name or value fields in points
         "time": "1970-01-01T00:00:00.000Z"
     }
 
-default splits on all fields but name and time
------------------------------------------------------------------------------------------
+## default splits on all fields but name and time
 ### Juttle
     emit -limit 1 -from Date.new(0)
     | put foo="bar", bleat="blort", peek="frean", cookie="serious", name="joe", value="bigdata"

--- a/test/runtime/specs/juttle-spec/juttle-procs-unbatch.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-unbatch.spec.md
@@ -1,8 +1,6 @@
-Juttle unbatch command
-======================
+# Juttle unbatch command
 
-unbatch with an argument complains
-----------------------------------
+## unbatch with an argument complains
 
 ### Juttle
     emit -from :2015-01-1: -limit 2 | unbatch -every :minute: | view result
@@ -11,8 +9,7 @@ unbatch with an argument complains
    * SyntaxError
 
 
-unbatch unbatches
------------------
+## unbatch unbatches
 
 ### Juttle
     emit -from :2015-01-01: -limit 20

--- a/test/runtime/specs/juttle-spec/juttle-procs-uniq.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-uniq.spec.md
@@ -1,8 +1,6 @@
-Juttle uniq processor
-======================
+# Juttle uniq processor
 
-uniq on all fields
--------------------
+## uniq on all fields
 
 ### Juttle
 
@@ -20,8 +18,7 @@ uniq on all fields
     {time: "1970-01-01T00:00:03.000Z", rate: "00:00:04.000"}
 
 
-uniq on a duration
--------------------
+## uniq on a duration
 
 ### Juttle
     emit -from Date.new(0) -limit 5
@@ -36,8 +33,7 @@ uniq on a duration
     {time: "1970-01-01T00:00:01.000Z", foo: "00:00:01.000", rate: "00:00:02.000"}
     {time: "1970-01-01T00:00:03.000Z", foo: "00:00:03.000", rate: "00:00:04.000"}
 
-uniq on a non-scalar field
-----------------------------
+## uniq on a non-scalar field
 
 ### Juttle
     emit -from Date.new(0) -limit 5
@@ -52,8 +48,7 @@ uniq on a non-scalar field
     {time: "1970-01-01T00:00:01.000Z", foo: 1, obj: { i: 2 }}
     {time: "1970-01-01T00:00:03.000Z", foo: 3, obj: { i: 4 }}
 
-uniq on multiple fields
-------------------------
+## uniq on multiple fields
 
 ### Juttle
 
@@ -70,8 +65,7 @@ uniq on multiple fields
     {time: "1970-01-01T00:00:03.000Z", foo: "00:00:03.000", rate: "00:00:04.000", test: "00:00:01.000"}
     {time: "1970-01-01T00:00:04.000Z", foo: "00:00:04.000", rate: "00:00:04.000", test: "00:00:00.000"}
 
-uniq by
---------
+## uniq by
 
 ### Juttle
 
@@ -100,8 +94,7 @@ uniq by
     { x:3, y:2, n:7 }
     { x:4, y:2, n:9 }
 
-uniq by on all fields
-----------------------
+## uniq by on all fields
 
 ### Juttle
 
@@ -134,8 +127,7 @@ uniq by on all fields
     { x:3, y:2, n:8 }
     { x:4, y:2, n:9 }
 
-uniq by a non-scalar field
-----------------------------
+## uniq by a non-scalar field
 
 ### Juttle
     emit -from Date.new(0) -limit 9
@@ -154,8 +146,7 @@ uniq by a non-scalar field
     { x:{ i:4 }, y:2, n:9 }
 
 
-uniq with batched input
-------------------------
+## uniq with batched input
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-spec.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-spec.spec.md
@@ -1,8 +1,6 @@
-JuttleSpec tests
-=====================
+# JuttleSpec tests
 
-Syntax error, partial match
---------------------------------
+## Syntax error, partial match
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Syntax error, partial match
 
    * SyntaxError: Expected
 
-Runtime error, partial match
---------------------------------
+## Runtime error, partial match
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Runtime error, partial match
 
    * CompileError: unknown
 
-Warning, partial match
---------------------------------
+## Warning, partial match
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Warning, partial match
 
    * field "foo" does not exist
 
-(skip) Ticks without time
-----------------------------------
+## (skip) Ticks without time
 
 ### Juttle
 
@@ -47,8 +42,7 @@ Warning, partial match
     {"tick": true}
     {}
 
-Marks without time
-----------------------------------
+## Marks without time
 
 ### Juttle
 
@@ -62,8 +56,7 @@ Marks without time
     {"time": "1970-01-01T00:00:01.000Z"}
     {"mark": true}
 
-Marks with time
-----------------------------------
+## Marks with time
 
 ### Juttle
 
@@ -77,8 +70,7 @@ Marks with time
     {"time": "1970-01-01T00:00:01.000Z"}
     {"time": "1970-01-01T00:00:02.000Z", "mark": true}
 
-Array/Object values
--------------------
+## Array/Object values
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
@@ -1,8 +1,6 @@
-Juttle stochastic adapter
-================================================
+# Juttle stochastic adapter
 
-stochastic with no time options complains
------------------------------------------
+## stochastic with no time options complains
 ### Juttle
     read stochastic -source "cdn" | view result
 
@@ -11,8 +9,7 @@ stochastic with no time options complains
    * One of -from, -to, or -last must be specified to define a query time range
 
 
-stochastic with bad type complains
--------------------------
+## stochastic with bad type complains
 ### Juttle
     read stochastic -last :day: -source "cdn" -type 'bleat' | view result
 
@@ -20,8 +17,7 @@ stochastic with bad type complains
 
    * -type must be "metric" or "event"
 
-stochastic with FTS complains
--------------------------
+## stochastic with FTS complains
 ### Juttle
     read stochastic -last :day: -source "cdn" -last :day: "Never gonna get it" | view result
 
@@ -29,8 +25,7 @@ stochastic with FTS complains
 
    * CompileError: Free text search is not implemented for stochastic adapter.
 
-historic read
---------------------
+## historic read
 ### Juttle
     read stochastic -source "cdn" -nhosts 3 -from Date.new(0) -to Date.new(60)
     | reduce count() by host, service
@@ -50,8 +45,7 @@ historic read
     { "host":"nyc.2", "service":"index", "count":422 }
     { "host":"nyc.2", "service":"authentication", "count":422 }
 
-historic read with source and a filter
---------------------------------------
+## historic read with source and a filter
 ### Juttle
     read stochastic -source "cdn" -nhosts 3 -from Date.new(0) -to Date.new(60)
         host="sea.0" AND service != "index"
@@ -63,8 +57,7 @@ historic read with source and a filter
     { "host":"sea.0", "service":"search", "count":422 }
     { "host":"sea.0", "service":"authentication", "count":422 }
 
-historic read with source and a filter containing NOT
------------------------------------------------------
+## historic read with source and a filter containing NOT
 
 Regression test for PROD-8651.
 
@@ -79,8 +72,7 @@ Regression test for PROD-8651.
     { "host":"sea.0", "service":"search", "count":422 }
     { "host":"sea.0", "service":"authentication", "count":422 }
 
-historic read with source and -type metric
---------------------
+## historic read with source and -type metric
 ### Juttle
     read stochastic -source "cdn" -nhosts 3 -from Date.new(0) -to Date.new(60) -type 'metric'
     | reduce count()
@@ -89,8 +81,7 @@ historic read with source and -type metric
 ### Output
     { "count":4164 }
 
-historic read with -source and -type event
---------------------
+## historic read with -source and -type event
 ### Juttle
     read stochastic -source "cdn" -nhosts 3 -from Date.new(0) -to Date.new(600) -type 'event'
     | reduce count()
@@ -99,8 +90,7 @@ historic read with -source and -type event
 ### Output
     { "count":6 }
 
-don't choke on missing fields
--------------------------------
+## don't choke on missing fields
 ### Juttle
     read stochastic -source "cdn" -from Date.new(0) -to Date.new(60) host ~ "sea.0" AND value > 10
     | reduce avg(value) by host, service
@@ -111,8 +101,7 @@ don't choke on missing fields
     { "host": "sea.0", "service": "authentication", avg: 77.13041087896356 }
     { "host": "sea.0", "service": "index", avg: 54.38183514813025 }
 
-don't swallow legitimate errors
--------------------------------
+## don't swallow legitimate errors
 ### Juttle
     read stochastic -source "cdn" -from Date.new(0) -to Date.new(60) host ~ "sea.0" AND host > 10
     | view result
@@ -121,8 +110,7 @@ don't swallow legitimate errors
 
    * Invalid operand types for ">": string (sea.0) and number (10).
 
-source "search_cluster" outputs something
--------------------------------
+## source "search_cluster" outputs something
 ### Juttle
     read stochastic -source "srch_cluster" -from Date.new(0) -to Date.new(10)
     | reduce count() by host 
@@ -135,8 +123,7 @@ source "search_cluster" outputs something
     { "host": "sea.3", "count": 238 }
     { "host": "sjc.4", "count": 238 }
 
-source "saas" outputs something
--------------------------------
+## source "saas" outputs something
 ### Juttle
     read stochastic -source "saas" -from Date.new(0) -to Date.new(10)
     | reduce count() by host 
@@ -149,8 +136,7 @@ source "saas" outputs something
     { "host": "us-west.3", "count": 310 }
     { "host": "us-east.4", "count": 310 }
 
-source "ecommerce" outputs something
--------------------------------
+## source "ecommerce" outputs something
 ### Juttle
     read stochastic -source "ecommerce" -from Date.new(0) -to Date.new(10)
     | reduce count() by host 
@@ -163,8 +149,7 @@ source "ecommerce" outputs something
 	{ "host": "us-west.3", "count": 310 }
     { "host": "us-east.4", "count": 310 }
 
-source "badone" fails as expected
--------------------------
+## source "badone" fails as expected
 ### Juttle
     read stochastic -source "badone" -last :1m: | view result
 

--- a/test/runtime/specs/juttle-spec/juttle-tests.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-tests.spec.md
@@ -1,8 +1,6 @@
-Juttle tests
-============
+# Juttle tests
 
-simple emit
---------------
+## simple emit
 
 ### Juttle
 
@@ -21,8 +19,7 @@ simple emit
     { time: "1970-01-01T00:00:00.008Z"}
     { time: "1970-01-01T00:00:00.009Z"}
 
-simple test1
-------------
+## simple test1
 
 ### Juttle
 
@@ -32,8 +29,7 @@ simple test1
 
     { time: "1970-01-01T00:00:00.000Z", x: "$80B"}
 
-simple emit2
----------------
+## simple emit2
 
 ### Juttle
 
@@ -52,8 +48,7 @@ simple emit2
     { time: "1970-01-01T00:00:00.008Z"}
     { time: "1970-01-01T00:00:00.009Z"}
 
-simple module test
-------------------
+## simple module test
 
 ### Module `M1`
 
@@ -68,8 +63,7 @@ simple module test
 
     { time: "1970-01-01T00:00:00.000Z", x:10}
 
-reduce shortcut with a Module
------------------------------
+## reduce shortcut with a Module
 
 ### Module `utils`
 
@@ -88,8 +82,7 @@ reduce shortcut with a Module
 
     { adder:10 }
 
-merge is the nondelaying merge
--------------------------------
+## merge is the nondelaying merge
 verify that merge does not hang onto points that could be forwarded immediately
 
 ### Juttle

--- a/test/runtime/specs/juttle-spec/literals.spec.md
+++ b/test/runtime/specs/juttle-spec/literals.spec.md
@@ -1,8 +1,6 @@
-Juttle literals
-===============
+# Juttle literals
 
-Null
-----
+## Null
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Null
 
     { time: "1970-01-01T00:00:00.000Z", n: null }
 
-Booleans
---------
+## Booleans
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/literals/number.spec.md
+++ b/test/runtime/specs/juttle-spec/literals/number.spec.md
@@ -1,8 +1,6 @@
-Number literal
-==============
+# Number literal
 
-Simple number
--------------
+## Simple number
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Simple number
 
     { time: "1970-01-01T00:00:00.000Z", n: 5 }
 
-Infinity
---------
+## Infinity
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Infinity
 
     { time: "1970-01-01T00:00:00.000Z", n: Infinity }
 
-NaN
----
+## NaN
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/literals/string.spec.md
+++ b/test/runtime/specs/juttle-spec/literals/string.spec.md
@@ -1,8 +1,6 @@
-String literal
-==============
+# String literal
 
-Simple string
--------------
+## Simple string
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Simple string
 
     { time: "1970-01-01T00:00:00.000Z", s: "abcd" }
 
-Interpolated string (`Null`)
-----------------------------
+## Interpolated string (`Null`)
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Interpolated string (`Null`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "null" }
 
-Interpolated string (`Boolean`)
--------------------------------
+## Interpolated string (`Boolean`)
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Interpolated string (`Boolean`)
 
     { time: "1970-01-01T00:00:00.000Z", s1: "true", s2: "false" }
 
-Interpolated string (`Number`)
-------------------------------
+## Interpolated string (`Number`)
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Interpolated string (`Number`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "5" }
 
-Interpolated string (`String`)
-------------------------------
+## Interpolated string (`String`)
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Interpolated string (`String`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "abcd" }
 
-Interpolated string (`RegExp`)
-------------------------------
+## Interpolated string (`RegExp`)
 
 ### Juttle
 
@@ -67,8 +60,7 @@ Interpolated string (`RegExp`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "/abcd/" }
 
-Interpolated string (`Date`)
-----------------------------
+## Interpolated string (`Date`)
 
 ### Juttle
 
@@ -78,8 +70,7 @@ Interpolated string (`Date`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "2015-01-01T00:00:05.000Z" }
 
-Interpolated string (`Duration`)
---------------------------------
+## Interpolated string (`Duration`)
 
 ### Juttle
 
@@ -89,8 +80,7 @@ Interpolated string (`Duration`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "00:00:05.000" }
 
-Interpolated string (`Array`)
------------------------------
+## Interpolated string (`Array`)
 
 ### Juttle
 
@@ -100,8 +90,7 @@ Interpolated string (`Array`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "[ 1, 2, 3 ]" }
 
-Interpolated string (`Object`)
-------------------------------
+## Interpolated string (`Object`)
 
 ### Juttle
 
@@ -111,8 +100,7 @@ Interpolated string (`Object`)
 
     { time: "1970-01-01T00:00:00.000Z", s: "{ a: 1, b: 2, c: 3 }" }
 
-Interpolated string (complex expression)
-----------------------------------------
+## Interpolated string (complex expression)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/concat.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/concat.spec.md
@@ -1,8 +1,6 @@
-The `Array.concat` function
-============================
+# The `Array.concat` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of incorrect type
 
   * Invalid argument type for "Array.concat": expected array, received null.
 
-Concatenation works as expected
--------------------------------
+## Concatenation works as expected
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/index-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/index-of.spec.md
@@ -1,8 +1,6 @@
-The `Array.indexOf` function
-=============================
+# The `Array.indexOf` function
 
-Returns correct result with string search
-----------------------
+## Returns correct result with string search
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result with string search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns correct result with number search
-----------------------
+## Returns correct result with number search
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result with number search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 0 }
 
-Returns correct result with non-primitive search
-----------------------
+## Returns correct result with non-primitive search
 
 ### Juttle
     const a = ['a'];
@@ -34,8 +30,7 @@ Returns correct result with non-primitive search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns correct result when item not found
---------------------------------------------
+## Returns correct result when item not found
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns correct result when item not found
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Returns correct result when non-primitive item not found
---------------------------------------------
+## Returns correct result when non-primitive item not found
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Returns correct result when non-primitive item not found
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Produces an error when passed argument `array` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `array` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/join.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/join.spec.md
@@ -1,8 +1,6 @@
-The `Array.join` function
-==============================
+# The `Array.join` function
 
-Produces an error when passed argument `array` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `array` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `array` of invalid type
 
   * Invalid argument type for "Array.join": expected array, received null.
 
-Produces an error when passed argument `joiner` of invalid type
-------------------------------------------------------------------
+## Produces an error when passed argument `joiner` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `joiner` of invalid type
 
   * Invalid argument type for "Array.join": expected string, received null.
 
-Splits array into an array based on a separator
-------------------------------------------------
+## Splits array into an array based on a separator
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Splits array into an array based on a separator
 
     { people: "joe,meg,bob,may" }
 
-Returns a string with a single element
---------------------------------------
+## Returns a string with a single element
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/last-index-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/last-index-of.spec.md
@@ -1,8 +1,6 @@
-The `Array.lastIndexOf` function
-=============================
+# The `Array.lastIndexOf` function
 
-Returns correct result with string search
-----------------------
+## Returns correct result with string search
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result with string search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Returns correct result with number search
-----------------------
+## Returns correct result with number search
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result with number search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Returns correct result with non-primitive search
-----------------------
+## Returns correct result with non-primitive search
 
 ### Juttle
     const a = ['a'];
@@ -34,8 +30,7 @@ Returns correct result with non-primitive search
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Returns correct result when item not found
---------------------------------------------
+## Returns correct result when item not found
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns correct result when item not found
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Returns correct result when non-primitive item not found
---------------------------------------------
+## Returns correct result when non-primitive item not found
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Returns correct result when non-primitive item not found
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Produces an error when passed argument `array` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `array` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/length.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/length.spec.md
@@ -1,8 +1,6 @@
-The `Array.length` function
-============================
+# The `Array.length` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/pop.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/pop.spec.md
@@ -1,8 +1,6 @@
-The `Array.pop` function
-============================
+# The `Array.pop` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: "b", array: ["a"] }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/push.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/push.spec.md
@@ -1,8 +1,6 @@
-The `Array.push` function
-==============================
+# The `Array.push` function
 
-Produces an error when passed argument `array` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `array` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `array` of invalid type
 
   * Invalid argument type for "Array.push": expected array, received null.
 
-Pushes an element
---------------------------------------
+## Pushes an element
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/reverse.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/reverse.spec.md
@@ -1,8 +1,6 @@
-The `Array.reverse` function
-============================
+# The `Array.reverse` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: ["b", "a"], array: ["b", "a"] }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/shift.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/shift.spec.md
@@ -1,8 +1,6 @@
-The `Array.shift` function
-============================
+# The `Array.shift` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: "a", array: ["b"] }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/slice.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/slice.spec.md
@@ -1,8 +1,6 @@
-The `Array.slice` function
-==============================
+# The `Array.slice` function
 
-Produces an error when passed argument `array` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `array` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `array` of invalid type
 
   * Invalid argument type for "Array.slice": expected array, received null.
 
-Produces an error when passed argument `begin` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `begin` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `begin` of invalid type
 
   * Invalid argument type for "Array.slice": expected number, received null.
 
-Produces an error when passed argument `end` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `end` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `end` of invalid type
 
   * Invalid argument type for "Array.slice": expected number, received null.
 
-Slices an array
---------------------------------------
+## Slices an array
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/sort.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/sort.spec.md
@@ -1,8 +1,6 @@
-The `Array.sort` function
-============================
+# The `Array.sort` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: ["a", "b", "c"], array: ["a", "b", "c"] }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/splice.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/splice.spec.md
@@ -1,8 +1,6 @@
-The `Array.splice` function
-==============================
+# The `Array.splice` function
 
-Produces an error when passed argument `array` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `array` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `array` of invalid type
 
   * Invalid argument type for "Array.splice": expected array, received null.
 
-Produces an error when passed argument `begin` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `begin` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `begin` of invalid type
 
   * Invalid argument type for "Array.splice": expected number, received null.
 
-Produces an error when passed argument `end` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `end` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `end` of invalid type
 
   * Invalid argument type for "Array.splice": expected number, received null.
 
-Splices an array
---------------------------------------
+## Splices an array
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Array.toString` function
-==============================
+# The `Array.toString` function
 
-Returns correct result when passed a string
--------------------------------------------
+## Returns correct result when passed a string
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a string
 
     { result: "[ \"hello\" ]" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/array/unshift.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/array/unshift.spec.md
@@ -1,8 +1,6 @@
-The `Array.unshift` function
-==============================
+# The `Array.unshift` function
 
-Produces an error when passed argument `array` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `array` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `array` of invalid type
 
   * Invalid argument type for "Array.unshift": expected array, received null.
 
-Unshifts an element
---------------------------------------
+## Unshifts an element
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/boolean/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/boolean/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Boolean.toString` function
-===============================
+# The `Boolean.toString` function
 
-Returns correct result when passed `true`
------------------------------------------
+## Returns correct result when passed `true`
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed `true`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "true" }
 
-Returns correct result when passed `false`
-------------------------------------------
+## Returns correct result when passed `false`
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result when passed `false`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "false" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/elapsed.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/elapsed.spec.md
@@ -1,8 +1,6 @@
-The `Date.elapsed` function
-===========================
+# The `Date.elapsed` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/end-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/end-of.spec.md
@@ -1,8 +1,6 @@
-The `Date.endOf` function
-=========================
+# The `Date.endOf` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `date` of invalid type
 
   * Invalid argument type for "Date.endOf": expected date, received null.
 
-Produces an error when passed argument `unit` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `unit` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/format.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/format.spec.md
@@ -1,8 +1,6 @@
-The `Date.format` function
-==========================
+# The `Date.format` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `date` of invalid type
 
   * Invalid argument type for "Date.format": expected date, received null.
 
-Produces an error when passed argument `format` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `format` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `format` of invalid type
 
   * Invalid argument type for "Date.format": expected string, received number (23).
 
-Produces an error when passed argument `tzstring` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `tzstring` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `tzstring` of invalid type
 
   * Invalid argument type for "Date.format": expected string, received null.
 
-Formats a date in different timezones (and doesnt care about Standard or DST)
-----------------------------------------------------------------------------
+## Formats a date in different timezones (and doesnt care about Standard or DST)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/formatTz.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/formatTz.spec.md
@@ -1,8 +1,6 @@
-The `Date.formatTz` function
-==========================
+# The `Date.formatTz` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `date` of invalid type
 
   * Invalid argument type for "Date.formatTz": expected date, received null.
 
-Produces an error when passed argument `tzstring` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `tzstring` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `tzstring` of invalid type
 
   * Invalid argument type for "Date.formatTz": expected string, received number (23).
 
-Formats a date in different timezones (and doesnt care about Standard or DST)
-----------------------------------------------------------------------------
+## Formats a date in different timezones (and doesnt care about Standard or DST)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/get.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/get.spec.md
@@ -1,8 +1,6 @@
-The `Date.get` function
-=======================
+# The `Date.get` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `date` of invalid type
 
   * Invalid argument type for "Date.get": expected date, received null.
 
-Produces an error when passed argument `unit` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `unit` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/new.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/new.spec.md
@@ -1,8 +1,6 @@
-The `Date.new` function
-=======================
+# The `Date.new` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of invalid type
 
   * Invalid argument type for "Date.new": expected number or string, received null.
 
-Produces an error when passed a string with an invalid date
------------------------------------------------------------
+## Produces an error when passed a string with an invalid date
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/parse.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/parse.spec.md
@@ -1,8 +1,6 @@
-The `Date.parse` function
-==========================
+# The `Date.parse` function
 
-Produces an error when passed argument `s` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `s` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `s` of invalid type
 
   * Invalid argument type for "Date.parse": expected string, received date (2015-01-01T00:00:00.000Z).
 
-Produces an error when passed argument `format` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `format` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `format` of invalid type
 
   * Invalid argument type for "Date.parse": expected string, received null.
 
-Complains of badly-formed dates
----------------------------------------------------------
+## Complains of badly-formed dates
 
 ### Juttle
 
@@ -35,8 +31,7 @@ Complains of badly-formed dates
   * Unable to parse date: "bad date"
 
 
-Parses a custom-formatted date
-------------------------------------------------------------
+## Parses a custom-formatted date
 
 ### Juttle
 
@@ -51,8 +46,7 @@ Parses a custom-formatted date
 
     { winning: true }
 
-Complains of dates not matching a specified format
----------------------------------------------------------
+## Complains of dates not matching a specified format
 
 ### Juttle
 
@@ -65,8 +59,7 @@ Complains of dates not matching a specified format
   * Unable to parse date: "2015-05-06T19:26:07Z"
 
 
-Parses Juttle-style date variants
-------------------------------------------------------------
+## Parses Juttle-style date variants
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/quantize.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/quantize.spec.md
@@ -1,8 +1,6 @@
-The `Date.quantize` function
-============================
+# The `Date.quantize` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `date` of invalid type
 
   * Invalid argument type for "Date.quantize": expected date, received null.
 
-Produces an error when passed argument `duration` of invalid type
------------------------------------------------------------------
+## Produces an error when passed argument `duration` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/start-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/start-of.spec.md
@@ -1,8 +1,6 @@
-The `Date.startOf` function
-===========================
+# The `Date.startOf` function
 
-Produces an error when passed argument `date` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `date` of invalid type
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Produces an error when passed argument `date` of invalid type
   * Invalid argument type for "Date.startOf": expected date, received null.
 
 
-Produces an error when passed argument `unit` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `unit` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Date.toString` function
-==============================
+# The `Date.toString` function
 
-Returns correct result when passed a date
------------------------------------------
+## Returns correct result when passed a date
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a date
 
     { "time": "1970-01-01T00:00:00.000Z", result: "2015-01-01T00:00:00.000Z" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/unix.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/unix.spec.md
@@ -1,8 +1,6 @@
-The `Date.unix` function
-========================
+# The `Date.unix` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/date/unixms.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/date/unixms.spec.md
@@ -1,8 +1,6 @@
-The `Date.unixms` function
-==========================
+# The `Date.unixms` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/at.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/at.spec.md
@@ -1,8 +1,6 @@
-The `Duration.as` function
-===========================
+# The `Duration.as` function
 
-Produces an error when passed argument `duration` of invalid type
------------------------------------------------------------------
+## Produces an error when passed argument `duration` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `duration` of invalid type
 
   * Invalid argument type for "Duration.as": expected duration, received null.
 
-Produces an error when passed argument `unit` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `unit` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/format.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/format.spec.md
@@ -1,8 +1,6 @@
-The `Duration.format` function
-==============================
+# The `Duration.format` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of invalid type
 
   * Invalid argument type for "Duration.format": expected duration, received null.
 
-formats durations with no format string
----------------------------------------------------------
+## formats durations with no format string
 
 ### Juttle
 
@@ -25,8 +22,7 @@ formats durations with no format string
 
     { time: "1970-01-01T00:00:00.000Z", result: "0d 22:10"}
 
-formats durations with a format string
----------------------------------------------------------
+## formats durations with a format string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/get.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/get.spec.md
@@ -1,8 +1,6 @@
-The `Duration.get` function
-===========================
+# The `Duration.get` function
 
-Produces an error when passed argument `duration` of invalid type
------------------------------------------------------------------
+## Produces an error when passed argument `duration` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `duration` of invalid type
 
   * Invalid argument type for "Duration.get": expected duration, received null.
 
-Produces an error when passed argument `unit` of invalid type
--------------------------------------------------------------
+## Produces an error when passed argument `unit` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/milliseconds.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/milliseconds.spec.md
@@ -1,8 +1,6 @@
-The `Duration.milliseconds` function
-====================================
+# The `Duration.milliseconds` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/new.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/new.spec.md
@@ -1,8 +1,6 @@
-The `Duration.new` function
-===========================
+# The `Duration.new` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/seconds.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/seconds.spec.md
@@ -1,8 +1,6 @@
-The `Duration.seconds` function
-===============================
+# The `Duration.seconds` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/duration/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/duration/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Duration.toString` function
-================================
+# The `Duration.toString` function
 
-Returns correct result when passed a duration
----------------------------------------------
+## Returns correct result when passed a duration
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a duration
 
     { "time": "1970-01-01T00:00:00.000Z", result: "00:00:05.000" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/json/parse.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/json/parse.spec.md
@@ -1,8 +1,6 @@
-The `JSON.parse` function
-=============================
+# The `JSON.parse` function
 
-Returns correct result with array
----------------------------------
+## Returns correct result with array
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result with array
 
     { "time": "1970-01-01T00:00:00.000Z", "result": [1, 2, 3] }
 
-Returns correct result with a nested object
--------------------------------------------
+## Returns correct result with a nested object
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result with a nested object
 
     { "time": "1970-01-01T00:00:00.000Z", "result": [1, 2, { "key": "value" }] }
 
-Produces an error when argument `string` cannot be parsed
---------------------------------------------------------
+## Produces an error when argument `string` cannot be parsed
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when argument `string` cannot be parsed
 
   * Unexpected end of input in string ([1,2,)
 
-Produces an error when argument `string` is not a string
---------------------------------------------------------------
+## Produces an error when argument `string` is not a string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/json/stringify.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/json/stringify.spec.md
@@ -1,8 +1,6 @@
-The `JSON.stringify` function
-=============================
+# The `JSON.stringify` function
 
-Returns correct result with array
----------------------------------
+## Returns correct result with array
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Returns correct result with array
 
     { "time": "1970-01-01T00:00:00.000Z", "array": [1, 2, 3], "result": "[1,2,3]" }
 
-Returns correct result with a nested object
--------------------------------------------
+## Returns correct result with a nested object
 
 ### Juttle
 
@@ -29,8 +26,7 @@ Returns correct result with a nested object
 
     { "time": "1970-01-01T00:00:00.000Z", "nested": [1, 2, { "key": "value" }], "result": "[1,2,{\"key\":\"value\"}]" }
 
-Returns correct result with a moment
-------------------------------------
+## Returns correct result with a moment
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math.spec.md
@@ -1,8 +1,6 @@
-The `Math.*` functions from ES5.1.
-=======================================================
+# The `Math.*` functions from ES5.1.
 
-All the constants are here
---------------------------
+## All the constants are here
 
 ### Juttle
 
@@ -24,8 +22,7 @@ All the constants are here
     "SQRT2":1.4142135623730951
     }
 
-All the functions are here
---------------------------
+## All the functions are here
 Since these are currently implemented as direct javascript
 Math.* invocations, we merely test for existence,
 to catch any accidental language removals.

--- a/test/runtime/specs/juttle-spec/modules/math/abs.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/abs.spec.md
@@ -1,8 +1,6 @@
-The `Math.abs` function
-=======================
+# The `Math.abs` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/acos.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/acos.spec.md
@@ -1,8 +1,6 @@
-The `Math.acos` function
-========================
+# The `Math.acos` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/asin.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/asin.spec.md
@@ -1,8 +1,6 @@
-The `Math.asin` function
-========================
+# The `Math.asin` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/atan.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/atan.spec.md
@@ -1,8 +1,6 @@
-The `Math.atan` function
-========================
+# The `Math.atan` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/atan2.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/atan2.spec.md
@@ -1,8 +1,6 @@
-The `Math.atan2` function
-=========================
+# The `Math.atan2` function
 
-Produces an error when passed argument `y` of incorrect type
-------------------------------------------------------------
+## Produces an error when passed argument `y` of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `y` of incorrect type
 
   * Invalid argument type for "Math.atan2": expected number, received null.
 
-Produces an error when passed argument `x` of incorrect type
-------------------------------------------------------------
+## Produces an error when passed argument `x` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/ceil.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/ceil.spec.md
@@ -1,8 +1,6 @@
-The `Math.ceil` function
-========================
+# The `Math.ceil` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/cos.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/cos.spec.md
@@ -1,8 +1,6 @@
-The `Math.cos` function
-=======================
+# The `Math.cos` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/exp.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/exp.spec.md
@@ -1,8 +1,6 @@
-The `Math.exp` function
-=======================
+# The `Math.exp` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/floor.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/floor.spec.md
@@ -1,8 +1,6 @@
-The `Math.floor` function
-=========================
+# The `Math.floor` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/log.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/log.spec.md
@@ -1,8 +1,6 @@
-The `Math.log` function
-=======================
+# The `Math.log` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/max.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/max.spec.md
@@ -1,8 +1,6 @@
-The `Math.max` function
-=======================
+# The `Math.max` function
 
-Produces an error when passed an argument of incorrect type
-------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/min.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/min.spec.md
@@ -1,8 +1,6 @@
-The `Math.min` function
-=======================
+# The `Math.min` function
 
-Produces an error when passed an argument of incorrect type
-------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/pow.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/pow.spec.md
@@ -1,8 +1,6 @@
-The `Math.pow` function
-=======================
+# The `Math.pow` function
 
-Produces an error when passed argument `x` of incorrect type
-------------------------------------------------------------
+## Produces an error when passed argument `x` of incorrect type
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Produces an error when passed argument `x` of incorrect type
   * Invalid argument type for "Math.pow": expected number, received null.
 
 
-Produces an error when passed argument `y` of incorrect type
-------------------------------------------------------------
+## Produces an error when passed argument `y` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/round.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/round.spec.md
@@ -1,8 +1,6 @@
-The `Math.round` function
-=========================
+# The `Math.round` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/seed.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/seed.spec.md
@@ -1,8 +1,6 @@
-The `Math.seed` function
-========================
+# The `Math.seed` function
 
-seed wants a number
--------------------------
+## seed wants a number
 ### Juttle
     const seed = Math.seed("juttle");
     emit -from Date.new(0) -limit 5
@@ -13,8 +11,7 @@ seed wants a number
 
   * Invalid argument type for "Math.seed": expected number, received string (juttle).
 
-Seeded RNG is predictable
--------------------------
+## Seeded RNG is predictable
 ### Juttle
     const seed = Math.seed(42);
     emit -from Date.new(0) -limit 5

--- a/test/runtime/specs/juttle-spec/modules/math/sin.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/sin.spec.md
@@ -1,8 +1,6 @@
-The `Math.sin` function
-=======================
+# The `Math.sin` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/sqrt.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/sqrt.spec.md
@@ -1,8 +1,6 @@
-The `Math.sqrt` function
-========================
+# The `Math.sqrt` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/math/tan.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math/tan.spec.md
@@ -1,8 +1,6 @@
-The `Math.tan` function
-=======================
+# The `Math.tan` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/null/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/null/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Null.toString` function
-============================
+# The `Null.toString` function
 
-Returns correct result when passed `null`
------------------------------------------
+## Returns correct result when passed `null`
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed `null`
 
     { "time": "1970-01-01T00:00:00.000Z", result: "null" }
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/number/constants.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/number/constants.spec.md
@@ -1,8 +1,6 @@
-`Number` constants
-==================
+# `Number` constants
 
-All `Number` constants are present
-----------------------------------
+## All `Number` constants are present
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/number/from-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/number/from-string.spec.md
@@ -1,9 +1,7 @@
-The `Number.fromString` function
-==============================
+# The `Number.fromString` function
 
 
-Returns correct result when passed a string representation of an integer
------------------------------------------------------------------------
+## Returns correct result when passed a string representation of an integer
 
 ### Juttle
 
@@ -14,8 +12,7 @@ Returns correct result when passed a string representation of an integer
     { "time": "1970-01-01T00:00:00.000Z", result: 1}
 
 
-Returns correct result when passed a string representation of a float
----------------------------------------------------------------------
+## Returns correct result when passed a string representation of a float
 
 ### Juttle
 
@@ -26,8 +23,7 @@ Returns correct result when passed a string representation of a float
     { "time": "1970-01-01T00:00:00.000Z", result: 1.345}
 
 
-Returns correct result when passed a string representation of an negative integer
---------------------------------------------------------------------------------
+## Returns correct result when passed a string representation of an negative integer
 
 ### Juttle
 
@@ -38,8 +34,7 @@ Returns correct result when passed a string representation of an negative intege
     { "time": "1970-01-01T00:00:00.000Z", result: -1}
 
 
-Returns correct result when passed a string representation of a negative float
-------------------------------------------------------------------------------
+## Returns correct result when passed a string representation of a negative float
 
 ### Juttle
 
@@ -51,8 +46,7 @@ Returns correct result when passed a string representation of a negative float
 
 
 
-Returns NaN when passed a string not representing a number
-----------------------------------------------------------
+## Returns NaN when passed a string not representing a number
 
 ### Juttle
 
@@ -63,8 +57,7 @@ Returns NaN when passed a string not representing a number
     { "time": "1970-01-01T00:00:00.000Z", result: NaN}
 
 
-Returns NaN when passed a non-string
-------------------------------------
+## Returns NaN when passed a non-string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/number/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/number/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Number.toString` function
-==============================
+# The `Number.toString` function
 
-Returns correct result when passed a number
--------------------------------------------
+## Returns correct result when passed a number
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a number
 
     { "time": "1970-01-01T00:00:00.000Z", result: "5" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/object/keys.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/object/keys.spec.md
@@ -1,8 +1,6 @@
-The `Object.keys` function
-=============================
+# The `Object.keys` function
 
-Returns correct result with no keys
-----------------------
+## Returns correct result with no keys
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result with no keys
 
     { "time": "1970-01-01T00:00:00.000Z", result: [] }
 
-Returns correct result with one key
-----------------------
+## Returns correct result with one key
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result with one key
 
     { "time": "1970-01-01T00:00:00.000Z", result: ["a"] }
 
-Returns correct result with multiple keys
-----------------------
+## Returns correct result with multiple keys
 
 ### Juttle
 
@@ -40,8 +36,7 @@ Returns correct result with multiple keys
     { value: "a" }
     { value: "b" }
 
-Produces an error when passed argument `object` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `object` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/object/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/object/to-string.spec.md
@@ -1,8 +1,6 @@
-The `Object.toString` function
-==============================
+# The `Object.toString` function
 
-Returns correct result when passed an object
--------------------------------------------
+## Returns correct result when passed an object
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed an object
 
     { result: "{ x: 1 }" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/object/values.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/object/values.spec.md
@@ -1,8 +1,6 @@
-The `Object.values` function
-=============================
+# The `Object.values` function
 
-Returns correct result with no values
-----------------------
+## Returns correct result with no values
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result with no values
 
     { "time": "1970-01-01T00:00:00.000Z", result: [] }
 
-Returns correct result with one key
-----------------------
+## Returns correct result with one key
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result with one key
 
     { "time": "1970-01-01T00:00:00.000Z", result: [1] }
 
-Returns correct result with multiple values
-----------------------
+## Returns correct result with multiple values
 
 ### Juttle
 
@@ -40,8 +36,7 @@ Returns correct result with multiple values
     { value: 1 }
     { value: 2 }
 
-Produces an error when passed argument `object` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `object` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/regexp/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/regexp/to-string.spec.md
@@ -1,8 +1,6 @@
-The `RegExp.toString` function
-==============================
+# The `RegExp.toString` function
 
-Returns correct result when passed a regexp
--------------------------------------------
+## Returns correct result when passed a regexp
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a regexp
 
     { "time": "1970-01-01T00:00:00.000Z", result: "/abcd/i" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/char-at.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/char-at.spec.md
@@ -1,8 +1,6 @@
-The `String.charAt` function
-============================
+# The `String.charAt` function
 
-Produces an error when passed a non-string first argument
------------------------------------------------------------
+## Produces an error when passed a non-string first argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Produces an error when passed a non-string first argument
   * Invalid argument type for "String.charAt": expected string, received null.
 
 
-Produces an error when passed a non-number second argument
------------------------------------------------------------
+## Produces an error when passed a non-number second argument
 
 ### Juttle
 
@@ -24,8 +21,7 @@ Produces an error when passed a non-number second argument
 
   * Invalid argument type for "String.charAt": expected number, received string (potatoes).
 
-charAt works as expected
--------------------------------
+## charAt works as expected
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/char-code-at.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/char-code-at.spec.md
@@ -1,8 +1,6 @@
-The `String.charCodeAt` function
-============================
+# The `String.charCodeAt` function
 
-Produces an error when passed a non-string first argument
------------------------------------------------------------
+## Produces an error when passed a non-string first argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Produces an error when passed a non-string first argument
   * Invalid argument type for "String.charCodeAt": expected string, received null.
 
 
-Produces an error when passed a non-number second argument
------------------------------------------------------------
+## Produces an error when passed a non-number second argument
 
 ### Juttle
 
@@ -24,8 +21,7 @@ Produces an error when passed a non-number second argument
 
   * Invalid argument type for "String.charCodeAt": expected number, received string (potatoes).
 
-charCodeAt works as expected
--------------------------------
+## charCodeAt works as expected
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/concat.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/concat.spec.md
@@ -1,8 +1,6 @@
-The `String.concat` function
-============================
+# The `String.concat` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of incorrect type
 
   * Invalid argument type for "String.concat": expected string, received null.
 
-Concatenation works as expected
--------------------------------
+## Concatenation works as expected
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/from-char-code.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/from-char-code.spec.md
@@ -1,8 +1,6 @@
-The `String.fromCharCode` function
-============================
+# The `String.fromCharCode` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of incorrect type
 
   * Invalid argument type for "String.fromCharCode": expected number, received null.
 
-fromCharCode works as expected
--------------------------------
+## fromCharCode works as expected
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/index-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/index-of.spec.md
@@ -1,8 +1,6 @@
-The `String.indexOf` function
-=============================
+# The `String.indexOf` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result
 
     { "time": "1970-01-01T00:00:00.000Z", result: 2 }
 
-Returns correct result when string not found
---------------------------------------------
+## Returns correct result when string not found
 
 ### Juttle
 
@@ -24,8 +21,7 @@ Returns correct result when string not found
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
 
-Is case-sensitive
------------------
+## Is case-sensitive
 
 ### Juttle
 
@@ -35,8 +31,7 @@ Is case-sensitive
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Produces an error when passed argument `string` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `string` of incorrect type
 
 ### Juttle
 
@@ -46,8 +41,7 @@ Produces an error when passed argument `string` of incorrect type
 
   * Invalid argument type for "String.indexOf": expected string, received null.
 
-Produces an error when passed argument `searchString` of incorrect type
------------------------------------------------------------------------
+## Produces an error when passed argument `searchString` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/last-index-of.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/last-index-of.spec.md
@@ -1,8 +1,6 @@
-The `String.lastIndexOf` function
-=================================
+# The `String.lastIndexOf` function
 
-Returns correct result
-----------------------
+## Returns correct result
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Returns correct result
     { "time": "1970-01-01T00:00:00.000Z", result: 3 }
 
 
-Returns correct result when string not found
---------------------------------------------
+## Returns correct result when string not found
 
 ### Juttle
 
@@ -24,8 +21,7 @@ Returns correct result when string not found
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Produces an error when passed argument `string` of incorrect type
------------------------------------------------------------------
+## Produces an error when passed argument `string` of incorrect type
 
 ### Juttle
 
@@ -35,8 +31,7 @@ Produces an error when passed argument `string` of incorrect type
 
   * Invalid argument type for "String.lastIndexOf": expected string, received null.
 
-Produces an error when passed argument `searchString` of incorrect type
------------------------------------------------------------------------
+## Produces an error when passed argument `searchString` of incorrect type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/length.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/length.spec.md
@@ -1,8 +1,6 @@
-The `String.length` function
-============================
+# The `String.length` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of incorrect type
 
   * Invalid argument type for "String.length": expected string, received null.
 
-Returns the string length
---------------------------------------
+## Returns the string length
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/match.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/match.spec.md
@@ -1,8 +1,6 @@
-The `String.match` function
-==============================
+# The `String.match` function
 
-Returns match info when the match is successful
-----------------------------------------------------
+## Returns match info when the match is successful
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns match info when the match is successful
 
     { "time": "1970-01-01T00:00:00.000Z", result: ["bc"] }
 
-Returns `null` when the match is unsuccessful
---------------------------------------------
+## Returns `null` when the match is unsuccessful
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns `null` when the match is unsuccessful
 
     { "time": "1970-01-01T00:00:00.000Z", result: null }
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `string` of invalid type
 
   * Invalid argument type for "String.match": expected string, received null.
 
-Produces an error when passed argument `regexp` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `regexp` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/replace.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/replace.spec.md
@@ -1,8 +1,6 @@
-The `String.replace` function
-==============================
+# The `String.replace` function
 
-Returns correct result for String.replace with string
------------------------------------------------------
+## Returns correct result for String.replace with string
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result for String.replace with string
 
     { "time": "1970-01-01T00:00:00.000Z", result: "hayreplacehay" }
 
-Returns correct result for String.replace with regex
-----------------------------------------------------
+## Returns correct result for String.replace with regex
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns correct result for String.replace with regex
 
         { "time": "1970-01-01T00:00:00.000Z", result: "hayreplacehay" }
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `string` of invalid type
 
   * Invalid argument type for "String.replace": expected string, received null.
 
-Produces an error when passed argument `searchValue` of invalid type
---------------------------------------------------------------------
+## Produces an error when passed argument `searchValue` of invalid type
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Produces an error when passed argument `searchValue` of invalid type
 
   * Invalid argument type for "String.replace": expected string or regular expression, received null.
 
-Produces an error when passed argument `replaceValue` of invalid type
----------------------------------------------------------------------
+## Produces an error when passed argument `replaceValue` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/search.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/search.spec.md
@@ -1,8 +1,6 @@
-The `String.search` function
-==============================
+# The `String.search` function
 
-Returns match position when the search is successful
-----------------------------------------------------
+## Returns match position when the search is successful
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns match position when the search is successful
 
     { "time": "1970-01-01T00:00:00.000Z", result: 1 }
 
-Returns `-1` when the search is unsuccessful
---------------------------------------------
+## Returns `-1` when the search is unsuccessful
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Returns `-1` when the search is unsuccessful
 
     { "time": "1970-01-01T00:00:00.000Z", result: -1 }
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `string` of invalid type
 
   * Invalid argument type for "String.search": expected string, received null.
 
-Produces an error when passed argument `regexp` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `regexp` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/slice.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/slice.spec.md
@@ -1,8 +1,6 @@
-The `String.slice` function
-===========================
+# The `String.slice` function
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `string` of invalid type
 
   * Invalid argument type for "String.slice": expected string, received null.
 
-Produces an error when passed argument `start` of invalid type
---------------------------------------------------------------
+## Produces an error when passed argument `start` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `start` of invalid type
 
   * Invalid argument type for "String.slice": expected number, received null.
 
-Produces an error when passed argument `end` of invalid type
-------------------------------------------------------------
+## Produces an error when passed argument `end` of invalid type
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Produces an error when passed argument `end` of invalid type
 
   * Invalid argument type for "String.slice": expected number, received null.
 
-Returns the correct end slice of a string
------------------------------------------
+## Returns the correct end slice of a string
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Returns the correct end slice of a string
 
     { message: "Buzz" } 
 
-Returns the correct head slice of the string
---------------------------------------------
+## Returns the correct head slice of the string
 
 ### Juttle
 
@@ -56,8 +50,7 @@ Returns the correct head slice of the string
 
     { message: "Fizz" } 
 
-Returns the correct middle slice of the string
-----------------------------------------------
+## Returns the correct middle slice of the string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/split.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/split.spec.md
@@ -1,8 +1,6 @@
-The `String.split` function
-==============================
+# The `String.split` function
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed argument `string` of invalid type
 
   * Invalid argument type for "String.split": expected string, received null.
 
-Produces an error when passed argument `separator` of invalid type
-------------------------------------------------------------------
+## Produces an error when passed argument `separator` of invalid type
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Produces an error when passed argument `separator` of invalid type
 
   * Invalid argument type for "String.split": expected string or regular expression, received null.
 
-Splits string into an array based on a separator
-------------------------------------------------
+## Splits string into an array based on a separator
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Splits string into an array based on a separator
 
     { elements: ["joe","meg","bob","may"] } 
 
-Returns a list with a single element
---------------------------------------
+## Returns a list with a single element
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/substr.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/substr.spec.md
@@ -1,8 +1,6 @@
-The `String.substr` function
-===========================
+# The `String.substr` function
 
-Produces an error when passed argument `string` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `string` of invalid type
 
 ### Juttle
 
@@ -13,8 +11,7 @@ Produces an error when passed argument `string` of invalid type
   * Invalid argument type for "String.substr": expected string, received null.
 
 
-Produces an error when passed argument `start` of invalid type
---------------------------------------------------------------
+## Produces an error when passed argument `start` of invalid type
 
 ### Juttle
 
@@ -25,8 +22,7 @@ Produces an error when passed argument `start` of invalid type
   * Invalid argument type for "String.substr": expected number, received null.
 
 
-Produces an error when passed argument `length` of invalid type
----------------------------------------------------------------
+## Produces an error when passed argument `length` of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/to-lower-case.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/to-lower-case.spec.md
@@ -1,8 +1,6 @@
-The `String.toLowerCase` function
-=================================
+# The `String.toLowerCase` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of invalid type
 
   * Invalid argument type for "String.toLowerCase": expected string, received null.
 
-Returns the expected lowercase string
--------------------------------------
+## Returns the expected lowercase string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/to-string.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/to-string.spec.md
@@ -1,8 +1,6 @@
-The `String.toString` function
-==============================
+# The `String.toString` function
 
-Returns correct result when passed a string
--------------------------------------------
+## Returns correct result when passed a string
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Returns correct result when passed a string
 
     { result: "abcd" }
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/to-upper-case.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/to-upper-case.spec.md
@@ -1,8 +1,6 @@
-The `String.toUpperCase` function
-=================================
+# The `String.toUpperCase` function
 
-Produces an error when passed an argument of invalid type
----------------------------------------------------------
+## Produces an error when passed an argument of invalid type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of invalid type
 
   * Invalid argument type for "String.toUpperCase": expected string, received null.
 
-Returns the expected uppercase string
--------------------------------------
+## Returns the expected uppercase string
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/modules/string/trim.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/string/trim.spec.md
@@ -1,8 +1,6 @@
-The `String.trim` function
-============================
+# The `String.trim` function
 
-Produces an error when passed an argument of incorrect type
------------------------------------------------------------
+## Produces an error when passed an argument of incorrect type
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Produces an error when passed an argument of incorrect type
 
   * Invalid argument type for "String.trim": expected string, received null.
 
-Returns the string trim
---------------------------------------
+## Returns the string trim
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/moments-infinite.spec.md
+++ b/test/runtime/specs/juttle-spec/moments-infinite.spec.md
@@ -1,8 +1,6 @@
-Juttle moments, infinite dates
-==============================
+# Juttle moments, infinite dates
 
-can assign :beginning: and :end: to a field
--------------------------------------------
+## can assign :beginning: and :end: to a field
 
 ### Juttle
     const long_time = :1000000y:;
@@ -16,8 +14,7 @@ can assign :beginning: and :end: to a field
     {b: "-Infinity", e: "Infinity"}
 
 
-can assign :beginning: and :end: to a field (runtime function)
---------------------------------------------------------------
+## can assign :beginning: and :end: to a field (runtime function)
 
 ### Juttle
     const long_time = :1000000y:;
@@ -36,8 +33,7 @@ can assign :beginning: and :end: to a field (runtime function)
     {b: "-Infinity", e: "Infinity"}
 
 
-can add/substract durations to :beginning:
-------------------------------------------
+## can add/substract durations to :beginning:
 
 ### Juttle
     const long_time = :1000000y:;
@@ -51,8 +47,7 @@ can add/substract durations to :beginning:
     {b: "-Infinity", c: "-Infinity", d: "-Infinity"}
 
 
-can add/substract durations to :end:
-------------------------------------------
+## can add/substract durations to :end:
 
 ### Juttle
     const long_time = :1000000y:;
@@ -66,8 +61,7 @@ can add/substract durations to :end:
     {b: "Infinity", c: "Infinity", d: "Infinity"}
 
 
-Programmatic :end: (in a put expression)
-------------------------------------
+## Programmatic :end: (in a put expression)
 
 ### Juttle
 
@@ -81,8 +75,7 @@ Programmatic :end: (in a put expression)
     {foo: true}
 
 
-Programmatic :end: (as const)
--------------------------
+## Programmatic :end: (as const)
 
 ### Juttle
 
@@ -98,8 +91,7 @@ Programmatic :end: (as const)
     {foo: true}
 
 
-Programmatic :end: (in a stream-context function)
---------------------------------------------
+## Programmatic :end: (in a stream-context function)
 
 ### Juttle
 
@@ -115,8 +107,7 @@ Programmatic :end: (in a stream-context function)
     {foo: true}
 
 
-Programmatic :beginning: (in a put expression)
----------------------------------------------
+## Programmatic :beginning: (in a put expression)
 
 ### Juttle
 
@@ -130,8 +121,7 @@ Programmatic :beginning: (in a put expression)
     {foo: false}
 
 
-Programmatic :beginning: (as const)
------------------------------------
+## Programmatic :beginning: (as const)
 
 ### Juttle
 
@@ -147,8 +137,7 @@ Programmatic :beginning: (as const)
     {foo: false}
 
 
-Programmatic :beginning: (in a stream-context function)
--------------------------------------------------------
+## Programmatic :beginning: (in a stream-context function)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/optimization/optimize-head.spec.md
+++ b/test/runtime/specs/juttle-spec/optimization/optimize-head.spec.md
@@ -1,8 +1,6 @@
-Head optimization
-=================
+# Head optimization
 
-Can optimize head if the adapter supports it
---------------------------------------------
+## Can optimize head if the adapter supports it
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Can optimize head if the adapter supports it
 
     { type: "head", limit: 10 }
 
-Can optimize head with an implicit limit
---------------------------------------------
+## Can optimize head with an implicit limit
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Can optimize head with an implicit limit
 
     { type: "head", limit: 1 }
 
-Does not optimize head if the adapter doesn't support it
---------------------------------------------------------
+## Does not optimize head if the adapter doesn't support it
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Does not optimize head if the adapter doesn't support it
 
     { type: "disabled", reason: "unsupported_optimization" }
 
-Does not optimize head if unsupported options are passed
---------------------------------------------------------
+## Does not optimize head if unsupported options are passed
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/optimization/optimize-read.spec.md
+++ b/test/runtime/specs/juttle-spec/optimization/optimize-read.spec.md
@@ -1,8 +1,6 @@
-Read Optimization
-=================
+# Read Optimization
 
-Does not optimize read followed by a sink
------------------------------------------
+## Does not optimize read followed by a sink
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Does not optimize read followed by a sink
 
     { type: "disabled", reason: "not_optimizable" }
 
-Does not optimize if read has multiple outputs
-----------------------------------------------
+## Does not optimize if read has multiple outputs
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Does not optimize if read has multiple outputs
 
     { type: "disabled", reason: "read_multiple_outputs" }
 
-Does not optimize if the downstream node has multiple inputs
-------------------------------------------------------------
+## Does not optimize if the downstream node has multiple inputs
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/optimization/optimize-tail.spec.md
+++ b/test/runtime/specs/juttle-spec/optimization/optimize-tail.spec.md
@@ -1,8 +1,6 @@
-Tail optimization
-=================
+# Tail optimization
 
-Can optimize tail if the adapter supports it
---------------------------------------------
+## Can optimize tail if the adapter supports it
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Can optimize tail if the adapter supports it
 
     { type: "tail", limit: 10 }
 
-Can optimize tail with an implicit limit
---------------------------------------------
+## Can optimize tail with an implicit limit
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Can optimize tail with an implicit limit
 
     { type: "tail", limit: 1 }
 
-Does not optimize tail if the adapter doesn't support it
---------------------------------------------------------
+## Does not optimize tail if the adapter doesn't support it
 
 ### Juttle
 
@@ -34,8 +30,7 @@ Does not optimize tail if the adapter doesn't support it
 
     { type: "disabled", reason: "unsupported_optimization" }
 
-Does not optimize tail if unsupported options are passed
---------------------------------------------------------
+## Does not optimize tail if unsupported options are passed
 
 ### Juttle
 
@@ -45,8 +40,7 @@ Does not optimize tail if unsupported options are passed
 
     { type: "disabled", reason: "unsupported_tail_option" }
 
-Does not optimize tail by
---------------------------------------------------------
+## Does not optimize tail by
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
+++ b/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
@@ -1,11 +1,9 @@
-Field dereference operator ambiguity
-====================================
+# Field dereference operator ambiguity
 
 Tests resolution of an ambiguity where `*` can be considered either a
 multiplication operator or a field dereference operator.
 
-Parses toplevel `*` as multiplication with no whitespace before and no whitespace after
----------------------------------------------------------------------------------------
+## Parses toplevel `*` as multiplication with no whitespace before and no whitespace after
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Parses toplevel `*` as multiplication with no whitespace before and no whitespac
 
   * Error: Invalid operand types for "*": duration (00:01:00.000) and string (name).
 
-Parses toplevel `*` as multiplication with no whitespace before and whitespace after
-------------------------------------------------------------------------------------
+## Parses toplevel `*` as multiplication with no whitespace before and whitespace after
 
 ### Juttle
 
@@ -26,8 +23,7 @@ Parses toplevel `*` as multiplication with no whitespace before and whitespace a
 
   * Error: Invalid operand types for "*": duration (00:01:00.000) and string (name).
 
-Parses toplevel `*` as field dereference with whitespace before and no whitespace after
----------------------------------------------------------------------------------------
+## Parses toplevel `*` as field dereference with whitespace before and no whitespace after
 
 ### Juttle
 
@@ -39,8 +35,7 @@ Parses toplevel `*` as field dereference with whitespace before and no whitespac
 
   * Invalid filter term. Valid forms are: "field == value", "value == field".
 
-Parses toplevel `*` as multiplication with whitespace before and whitespace after
----------------------------------------------------------------------------------
+## Parses toplevel `*` as multiplication with whitespace before and whitespace after
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/parser/new-sink-syntax.spec.md
+++ b/test/runtime/specs/juttle-spec/parser/new-sink-syntax.spec.md
@@ -1,8 +1,6 @@
-New sink syntax
-===============
+# New sink syntax
 
-Parses new sink sytnax
-----------------------
+## Parses new sink sytnax
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Parses new sink sytnax
 
     { time: "1970-01-01T00:00:00.000Z" }
 
-Parses new sink sytnax (with options)
--------------------------------------
+## Parses new sink sytnax (with options)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/procs/emit.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/emit.spec.md
@@ -1,8 +1,6 @@
-The `emit` processor
-=======================
+# The `emit` processor
 
-Complains about unknown options
----------------------------------
+## Complains about unknown options
 ### Juttle
     emit -failure true
     | view result
@@ -10,8 +8,7 @@ Complains about unknown options
 ### Errors
    * unknown emit option failure.
 
-Complains if -limit isnt a number
-----------------------------------------
+## Complains if -limit isnt a number
 
 ### Juttle
 
@@ -21,8 +18,7 @@ Complains if -limit isnt a number
 
    * CompileError: -limit wants a number, got "no limits!"
 
-Complains if -hz isnt a number
-----------------------------------------
+## Complains if -hz isnt a number
 
 ### Juttle
 
@@ -32,8 +28,7 @@ Complains if -hz isnt a number
 
    * CompileError: -hz wants a number, got "so good"
 
-Complains if -every isnt a duration
-----------------------------------------
+## Complains if -every isnt a duration
 
 ### Juttle
 
@@ -43,8 +38,7 @@ Complains if -every isnt a duration
 
    * CompileError: -every wants a duration, got "so often"
 
-Complains if -from isnt a moment
-----------------------------------------
+## Complains if -from isnt a moment
 
 ### Juttle
 
@@ -54,8 +48,7 @@ Complains if -from isnt a moment
 
    * CompileError: -from wants a moment, got "never"
 
-Complains if -to isnt a moment
-----------------------------------------
+## Complains if -to isnt a moment
 
 ### Juttle
 
@@ -65,8 +58,7 @@ Complains if -to isnt a moment
 
    * CompileError: -to wants a moment, got "never"
 
-Complains if -last isnt a duration
-----------------------------------------
+## Complains if -last isnt a duration
 
 ### Juttle
 
@@ -76,8 +68,7 @@ Complains if -last isnt a duration
 
    * CompileError: -last wants a duration, got "never"
 
-Complains if -last and -from are specified
-------------------------------------------
+## Complains if -last and -from are specified
 
 ### Juttle
 
@@ -87,8 +78,7 @@ Complains if -last and -from are specified
 
    * CompileError: -last option should not be combined with -from or -to
 
-Complains if -last and -to are specified
-----------------------------------------
+## Complains if -last and -to are specified
 
 ### Juttle
 
@@ -98,8 +88,7 @@ Complains if -last and -to are specified
 
    * CompileError: -last option should not be combined with -from or -to
 
-Complains if -from and -to and -last are specified
-----------------------------------------
+## Complains if -from and -to and -last are specified
 
 ### Juttle
 
@@ -109,8 +98,7 @@ Complains if -from and -to and -last are specified
 
    * CompileError: -last option should not be combined with -from or -to
 
-Complains if -limit and -to are specified
-----------------------------------------
+## Complains if -limit and -to are specified
 
 ### Juttle
 
@@ -120,8 +108,7 @@ Complains if -limit and -to are specified
 
    * -to option should not be combined with -limit
 
-Complains if -limit and -last are specified
-----------------------------------------
+## Complains if -limit and -last are specified
 
 ### Juttle
 
@@ -131,8 +118,7 @@ Complains if -limit and -last are specified
 
    * -to option should not be combined with -limit
 
-Complains about -points that are not an array
-----------------------------------------------------
+## Complains about -points that are not an array
 
 ### Juttle
 
@@ -142,8 +128,7 @@ Complains about -points that are not an array
 
    * CompileError: emit -points wants an array of points
 
-Complains about -points that are not an array of objects
-----------------------------------------------------
+## Complains about -points that are not an array of objects
 
 ### Juttle
 
@@ -153,8 +138,7 @@ Complains about -points that are not an array of objects
 
    * CompileError: emit -points wants an array of points
 
-Complains about -points and -limit
-----------------------------------------------------
+## Complains about -points and -limit
 
 ### Juttle
 
@@ -164,8 +148,7 @@ Complains about -points and -limit
 
    * CompileError: -points option should not be combined with -limit
 
-Complains about -points and -to
-----------------------------------------------------
+## Complains about -points and -to
 
 ### Juttle
 
@@ -175,8 +158,7 @@ Complains about -points and -to
 
    * CompileError: -points option should not be combined with -from, -to, or -last
 
-Complains about -points and -last
-----------------------------------------------------
+## Complains about -points and -last
 
 ### Juttle
 
@@ -186,8 +168,7 @@ Complains about -points and -last
 
    * CompileError: -points option should not be combined with -from, -to, or -last
 
-Complains about -points with -from
-----------------------------------------------------
+## Complains about -points with -from
 
 ### Juttle
 
@@ -197,8 +178,7 @@ Complains about -points with -from
 
    * CompileError: -points option should not be combined with -from, -to, or -last
 
-Complains about a mix of timeful and timeless -points
-----------------------------------------------------
+## Complains about a mix of timeful and timeless -points
 
 ### Juttle
 
@@ -208,8 +188,7 @@ Complains about a mix of timeful and timeless -points
 
    * CompileError: emit -points must all have timestamps or have no timestamps
 
-Emits 1 point by default
------------------------------------------------------------
+## Emits 1 point by default
 
 ### Juttle
 
@@ -221,8 +200,7 @@ Emits 1 point by default
 
     { count: 1 }
 
-Emits live points by default
------------------------------------------------------------
+## Emits live points by default
 
 ### Juttle
 
@@ -238,8 +216,7 @@ Emits live points by default
     { n: 2, dt: "00:00:01.000" }
     { n: 3, dt: "00:00:02.000" }
 
-Does not emit ticks if points are generated every second
------------------------------------------------------------
+## Does not emit ticks if points are generated every second
 
 ### Juttle
 
@@ -254,8 +231,7 @@ Does not emit ticks if points are generated every second
     { n: 2, dt: "00:00:01.000" }
     { n: 3, dt: "00:00:02.000" }
 
-emits ticks in between long gaps in the points
-----------------------------------------------------------
+## emits ticks in between long gaps in the points
 
 ### Juttle
 
@@ -274,8 +250,7 @@ emits ticks in between long gaps in the points
     { tick: true, dt: "00:00:05.000" }
     { n: 3, dt: "00:00:06.000" }
 
-Does not emit any points with `-limit 0`
-----------------------------------------
+## Does not emit any points with `-limit 0`
 
 ### Juttle
 
@@ -287,8 +262,7 @@ Does not emit any points with `-limit 0`
 
 ```
 
-Emits limited points with -to
-----------------------------------------
+## Emits limited points with -to
 
 ### Juttle
 
@@ -303,8 +277,7 @@ Emits limited points with -to
     { n: 2, dt: "00:00:01.000" }
     { n: 3, dt: "00:00:02.000" }
 
-Emits properly spaced and limited points with -every
-----------------------------------------
+## Emits properly spaced and limited points with -every
 
 ### Juttle
 
@@ -319,8 +292,7 @@ Emits properly spaced and limited points with -every
     { n: 2, dt: "00:00:02.000" }
     { n: 3, dt: "00:00:04.000" }
 
-Emits properly spaced and limited points with -hz
-----------------------------------------
+## Emits properly spaced and limited points with -hz
 
 ### Juttle
 
@@ -335,8 +307,7 @@ Emits properly spaced and limited points with -hz
     { n: 2, dt: "00:00:02.000" }
     { n: 3, dt: "00:00:04.000" }
 
-Emits historic points with -from
-----------------------------------------------------
+## Emits historic points with -from
 
 ### Juttle
 
@@ -354,8 +325,7 @@ Emits historic points with -from
     { "time": "1970-01-01T00:00:01.000Z" }
     { "time": "1970-01-01T00:00:02.000Z" }
 
-Emits the right points when -from, -to, and -every are specified
-----------------------------------------------------
+## Emits the right points when -from, -to, and -every are specified
 
 ### Juttle
 
@@ -368,8 +338,7 @@ Emits the right points when -from, -to, and -every are specified
     { "time": "1970-01-01T00:00:06.000Z" }
     { "time": "1970-01-01T00:00:09.000Z" }
 
-Emits the right number of points when -from, -to, and -every are specified
-----------------------------------------------------
+## Emits the right number of points when -from, -to, and -every are specified
 
 ### Juttle
 
@@ -381,8 +350,7 @@ Emits the right number of points when -from, -to, and -every are specified
 
     { "count": 5 }
 
-Emits the right number of points when -last and -every are specified
-----------------------------------------------------
+## Emits the right number of points when -last and -every are specified
 
 ### Juttle
 
@@ -394,8 +362,7 @@ Emits the right number of points when -last and -every are specified
 
     { "count": 5 }
 
-Emits historic and live points with -from
-----------------------------------------------------
+## Emits historic and live points with -from
 
 ### Juttle
 
@@ -414,8 +381,7 @@ Emits historic and live points with -from
     { tick: true }
     { n: 5, dt: "00:00:04.000" }
 
-Emits historic and live points with -points
-----------------------------------------------------
+## Emits historic and live points with -points
 
 ### Juttle
 
@@ -435,8 +401,7 @@ Emits historic and live points with -points
     { tick: true }
     { n: 5, dt: "00:00:04.000" }
 
-Parses time string and numbers in -points
-----------------------------------------------------
+## Parses time string and numbers in -points
 
 ### Juttle
 
@@ -455,8 +420,7 @@ Parses time string and numbers in -points
     { time: "1970-01-01T00:00:01.000Z" }
     { time: "1970-01-01T00:00:02.000Z" }
 
-Complains when no points are given
-----------------------------------
+## Complains when no points are given
 
 ### Juttle
 
@@ -468,8 +432,7 @@ Complains when no points are given
     { count: 0 }
 
 
-Complains about bad time formatting in -points
-----------------------------------------------------
+## Complains about bad time formatting in -points
 
 ### Juttle
 
@@ -479,8 +442,7 @@ Complains about bad time formatting in -points
 ### Errors
    * the time field must contain a number or a string representing time.
 
-Does not add timestamps and ticks with timeless -points
---------------------------------------------------------
+## Does not add timestamps and ticks with timeless -points
 
 ### Juttle
 
@@ -496,8 +458,7 @@ Does not add timestamps and ticks with timeless -points
     { n: 4 }
     { n: 5 }
 
-Emits correct number of points when -from and -every are set
-------------------------------------------------------------
+## Emits correct number of points when -from and -every are set
 
 ### Juttle
 
@@ -508,8 +469,7 @@ Emits correct number of points when -from and -every are set
 ### Output
     { count: 24 }
 
-Emits correct number of points when -from/-to and -every are set
-----------------------------------------------------------------
+## Emits correct number of points when -from/-to and -every are set
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/procs/head.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/head.spec.md
@@ -1,8 +1,6 @@
-The `head` processor
-====================
+# The `head` processor
 
-Uses `1` as the default argument value
---------------------------------------
+## Uses `1` as the default argument value
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Uses `1` as the default argument value
 
     { time: "1970-01-01T00:00:00.000Z" }
 
-Inverts negative argument values
---------------------------------
+## Inverts negative argument values
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/procs/options.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/options.spec.md
@@ -1,8 +1,6 @@
-Proc options
-============
+# Proc options
 
-Identifiers in multi-value options are not coerced to strings
--------------------------------------------------------------
+## Identifiers in multi-value options are not coerced to strings
 
 Regression test for #444.
 

--- a/test/runtime/specs/juttle-spec/procs/sequence.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/sequence.spec.md
@@ -1,8 +1,6 @@
-Sequence tests
-======================================================
+# Sequence tests
 
-matching sequence of numbers
-----------------------------
+## matching sequence of numbers
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put c = count()
@@ -15,8 +13,7 @@ matching sequence of numbers
 
 
 
-matching sequence of numbers (with by grouping)
------------------------------------------------
+## matching sequence of numbers (with by grouping)
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put c = count()
@@ -34,8 +31,7 @@ matching sequence of numbers (with by grouping)
     { host: "foo", c: 7, _seqno: 1}
 
 
-matching sequence of numbers and hosts
---------------------------------------
+## matching sequence of numbers and hosts
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put c = count()
@@ -49,8 +45,7 @@ matching sequence of numbers and hosts
     { time: "1970-01-01T00:00:06.000Z", host: "foo", c: 7, _seqno: 0}
 
 
-matching _interleaved_ sequences of numbers (with by grouping)
---------------------------------------------------------------
+## matching _interleaved_ sequences of numbers (with by grouping)
 
 ### Juttle
     // The goal is to verify that points are output in time-order, even though the
@@ -71,8 +66,7 @@ matching _interleaved_ sequences of numbers (with by grouping)
 
 
 
-non-matching sequence of numbers
---------------------------------
+## non-matching sequence of numbers
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put c = count()
@@ -85,8 +79,7 @@ non-matching sequence of numbers
 ```
 
 
-non-matching sequence of numbers and hosts (with by grouping)
-------------------------------------------------------------
+## non-matching sequence of numbers and hosts (with by grouping)
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put c = count()

--- a/test/runtime/specs/juttle-spec/procs/skip.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/skip.spec.md
@@ -1,8 +1,6 @@
-The `skip` processor
-====================
+# The `skip` processor
 
-Uses `1` as the default argument value
---------------------------------------
+## Uses `1` as the default argument value
 
 ### Juttle
 
@@ -15,8 +13,7 @@ Uses `1` as the default argument value
     { time: "1970-01-01T00:00:03.000Z" }
     { time: "1970-01-01T00:00:04.000Z" }
 
-Inverts negative argument values
---------------------------------
+## Inverts negative argument values
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/procs/tail.spec.md
+++ b/test/runtime/specs/juttle-spec/procs/tail.spec.md
@@ -1,8 +1,6 @@
-The `tail` processor
-====================
+# The `tail` processor
 
-Uses `1` as the default argument value
---------------------------------------
+## Uses `1` as the default argument value
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Uses `1` as the default argument value
 
     { time: "1970-01-01T00:00:04.000Z" }
 
-Inverts negative argument values
---------------------------------
+## Inverts negative argument values
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/program-elements/function-definition.spec.md
+++ b/test/runtime/specs/juttle-spec/program-elements/function-definition.spec.md
@@ -1,8 +1,6 @@
-Function definition
-===================
+# Function definition
 
-Returns `null` when no `return` statement is executed
------------------------------------------------------
+## Returns `null` when no `return` statement is executed
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducer-scopes.spec.md
+++ b/test/runtime/specs/juttle-spec/reducer-scopes.spec.md
@@ -1,10 +1,8 @@
-Tests for reducers in subgraphs
-===============================
+# Tests for reducers in subgraphs
 
 
 
-Reducer using reducer arg
-------------------------------
+## Reducer using reducer arg
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Reducer using reducer arg
     {a: 2}
 
 
-Reducer using reducer const
----------------------------
+## Reducer using reducer const
 
 ### Juttle
 
@@ -29,8 +26,7 @@ Reducer using reducer const
     {a: 2}
 
 
-Reducer using top-level const
------------------------------
+## Reducer using top-level const
 
 ### Juttle
 
@@ -43,8 +39,7 @@ Reducer using top-level const
     {a: 2}
 
 
-Reducer using sub arg
----------------------
+## Reducer using sub arg
 
 ### Juttle
 
@@ -59,8 +54,7 @@ Reducer using sub arg
     {a: 4}
 
 
-Reducer using sub arg (multiply-instantiated sub)
--------------------------------------------------
+## Reducer using sub arg (multiply-instantiated sub)
 
 ### Juttle
 
@@ -76,8 +70,7 @@ Reducer using sub arg (multiply-instantiated sub)
     {a: 4}
 
 
-Reducer using reducer arg (multiply-instantiated sub)
------------------------------------------------------
+## Reducer using reducer arg (multiply-instantiated sub)
 
 ### Juttle
 
@@ -92,8 +85,7 @@ Reducer using reducer arg (multiply-instantiated sub)
     {a: 3}
     {a: 4}
 
-Reducer using const from sub arg (multiply-instantiated sub)
-------------------------------------------------------------
+## Reducer using const from sub arg (multiply-instantiated sub)
 
 ### Juttle
 
@@ -110,8 +102,7 @@ Reducer using const from sub arg (multiply-instantiated sub)
     {a: 4}
 
 
-Reducer using stream value (multiply-instantiated sub)
-------------------------------------------------------
+## Reducer using stream value (multiply-instantiated sub)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/avg-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/avg-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "avg" reducer
-======================
+# Juttle "avg" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/count_unique-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/count_unique-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "count_unique" reducer
-======================
+# Juttle "count_unique" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer count_unique expects 1 argument but was called with 0
 
 
-counts unique days
-----------------------------------------
+## counts unique days
 ### Juttle
     emit -limit 100 -every :hour: -from Date.new(0)
     | put day = Date.startOf(time,"day")
@@ -24,8 +21,7 @@ counts unique days
 ### Output
     { days: 5 }
 
-supports nested points
----------------------------------------
+## supports nested points
 ### Juttle
     emit -points [ {"task":{"day":"Monday"}}, {"task":{"day":"Friday"}}, {"task":{"day":"Monday"}} ]
     | reduce days = count_unique(task)

--- a/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
@@ -1,24 +1,20 @@
-Juttle "delta" reducer
-======================
+# Juttle "delta" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 ### Juttle
     emit -limit 1 | put losing = delta() | view result
 
 ### Errors
    * reducer delta expects 1 to 3 arguments but was called with 0
 
-complains if reduce delta
------------------------------
+## complains if reduce delta
 ### Juttle
     emit -limit 1 | reduce delta(foo) | view result
 
 ### Errors
    * CompileError: delta cannot be used with reduce (use reduce last | put delta=delta())
 
-outputs "empty" on missing field
---------------------------------------------------
+## outputs "empty" on missing field
 ### Juttle
     emit -limit 2 -every :0.1s: -from Date.new(0)
     | put delta = delta(foo, "empty")
@@ -28,8 +24,7 @@ outputs "empty" on missing field
     {delta: "empty", time: "1970-01-01T00:00:00.000Z"}
     {delta: "empty", time: "1970-01-01T00:00:00.100Z"}
 
-reduce + put delta pattern works like reduce delta sorta-aughta
-------------------------------------------------------
+## reduce + put delta pattern works like reduce delta sorta-aughta
 
 ### Juttle
 
@@ -53,8 +48,7 @@ reduce + put delta pattern works like reduce delta sorta-aughta
     { time: "1970-01-01T00:00:00.700Z", delta: 1 }
     { time: "1970-01-01T00:00:00.800Z", delta: 1 }
 
-put computes point-to-point differences
---------------------------------------------------
+## put computes point-to-point differences
 ### Juttle
     emit -points [
     { time: "1970-01-01T00:00:00.000Z", x: 1},
@@ -71,8 +65,7 @@ put computes point-to-point differences
     { dx: 0 }
     { x: 20, dx: 10 }
 
-put works with durations and time
---------------------------------------------------
+## put works with durations and time
 compute a rate in units per second by dividing delta(foo) by delta(time).
 empty results give us NaN (one reason you want derivative()).
 also compute running change in a duration.
@@ -89,8 +82,7 @@ also compute running change in a duration.
     { time: "1970-01-01T00:00:01.000Z",       dfoo: 3,       dfoos: "00:00:03.000" }
     { time: "1970-01-01T00:00:02.000Z",       dfoo: 5,       dfoos: "00:00:05.000" }
 
-put computes point-to-point differences by name
---------------------------------------------------
+## put computes point-to-point differences by name
 ### Juttle
     emit -points [
     { time: "1970-01-01T00:00:00.000Z", name:"x", value:1},
@@ -111,8 +103,7 @@ put computes point-to-point differences by name
     { name: "x", value: 100, d: 90 }
     { name: "y", value: -100, d: -90 }
 
-put computes point-to-point differences with a wrapping counter, wrap > 0
---------------------------------------------------
+## put computes point-to-point differences with a wrapping counter, wrap > 0
 ### Juttle
     emit -points [
     { time: "1970-01-01T00:00:00.000Z", x: 1},
@@ -129,8 +120,7 @@ put computes point-to-point differences with a wrapping counter, wrap > 0
     { x:  5, dx: 15 }
     { x: 15, dx: 10 }
 
-put computes point-to-point differences with a wrapping counter, wrap = 0
---------------------------------------------------
+## put computes point-to-point differences with a wrapping counter, wrap = 0
 ### Juttle
     emit -points [
     { time: "1970-01-01T00:00:00.000Z", x: 1},
@@ -147,8 +137,7 @@ put computes point-to-point differences with a wrapping counter, wrap = 0
     { x:  5, dx: 5 }
     { x: 15, dx: 10 }
 
-put computes point-to-point differences with a wrapping counter, wrap = true
---------------------------------------------------
+## put computes point-to-point differences with a wrapping counter, wrap = true
 ### Juttle
     emit -points [
     { time: "1970-01-01T00:00:00.000Z", x: 1},

--- a/test/runtime/specs/juttle-spec/reducers/first-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/first-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "first" reducer
-======================
+# Juttle "first" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer first expects 1 argument but was called with 0
 
 
-outputs null on empty stream
-----------------------------
+## outputs null on empty stream
 
 ### Juttle
 
@@ -24,8 +21,7 @@ outputs null on empty stream
     {first: null}
 
 
-(skip) outputs null on empty batched stream (explicit batch)
------------------------------------------------------
+## (skip) outputs null on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -35,8 +31,7 @@ outputs null on empty stream
     {first: null}
 
 
-(skip) outputs null on empty batched stream  (reduce -every)
------------------------------------------------------
+## (skip) outputs null on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -46,8 +41,7 @@ outputs null on empty stream
     {first: null}
 
 
-outputs null on empty batch (explicit batches)
-----------------------------------------------
+## outputs null on empty batch (explicit batches)
 
 ### Juttle
 
@@ -57,8 +51,7 @@ outputs null on empty batch (explicit batches)
     {first: null, time: "1970-01-01T00:00:00.100Z"}
     {first: null, time: "1970-01-01T00:00:00.200Z"}
 
-outputs null on empty batch (reduce -every)
--------------------------------------------
+## outputs null on empty batch (reduce -every)
 
 ### Juttle
 
@@ -69,8 +62,7 @@ outputs null on empty batch (reduce -every)
     {first: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty window (reduce -every -over)
---------------------------------------------------
+## outputs null on empty window (reduce -every -over)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/last-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/last-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "last" reducer
-=====================
+# Juttle "last" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer last expects 1 argument but was called with 0
 
 
-outputs null on empty stream
-----------------------------
+## outputs null on empty stream
 
 ### Juttle
 
@@ -24,8 +21,7 @@ outputs null on empty stream
     {last: null}
 
 
-(skip) outputs null on empty batched stream (explicit batch)
------------------------------------------------------
+## (skip) outputs null on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -35,8 +31,7 @@ outputs null on empty stream
     {last: null}
 
 
-(skip) outputs null on empty batched stream  (reduce -every)
------------------------------------------------------
+## (skip) outputs null on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -46,8 +41,7 @@ outputs null on empty stream
     {last: null}
 
 
-outputs null on empty batch (explicit batches)
-----------------------------------------------
+## outputs null on empty batch (explicit batches)
 
 ### Juttle
 
@@ -58,8 +52,7 @@ outputs null on empty batch (explicit batches)
     {last: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty batch (reduce -every)
--------------------------------------------
+## outputs null on empty batch (reduce -every)
 
 ### Juttle
 
@@ -70,8 +63,7 @@ outputs null on empty batch (reduce -every)
     {last: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty window (reduce -every -over)
---------------------------------------------------
+## outputs null on empty window (reduce -every -over)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/mad-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/mad-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "mad" reducer
-=====================
+# Juttle "mad" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer mad expects 1 argument but was called with 0
 
 
-outputs null on empty stream
-----------------------------
+## outputs null on empty stream
 
 ### Juttle
 
@@ -24,8 +21,7 @@ outputs null on empty stream
     {mad: null}
 
 
-(skip) outputs null on empty batched stream (explicit batch)
------------------------------------------------------
+## (skip) outputs null on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -35,8 +31,7 @@ outputs null on empty stream
     {mad: null}
 
 
-(skip) outputs null on empty batched stream  (reduce -every)
------------------------------------------------------
+## (skip) outputs null on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -46,8 +41,7 @@ outputs null on empty stream
     {mad: null}
 
 
-outputs null on empty batch (explicit batches)
-----------------------------------------------
+## outputs null on empty batch (explicit batches)
 
 ### Juttle
 
@@ -58,8 +52,7 @@ outputs null on empty batch (explicit batches)
     {mad: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty batch (reduce -every)
--------------------------------------------
+## outputs null on empty batch (reduce -every)
 
 ### Juttle
 
@@ -70,8 +63,7 @@ outputs null on empty batch (reduce -every)
     {mad: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty window (reduce -every -over)
---------------------------------------------------
+## outputs null on empty window (reduce -every -over)
 
 ### Juttle
 
@@ -81,8 +73,7 @@ outputs null on empty window (reduce -every -over)
     {mad: null, time: "1970-01-01T00:00:00.100Z"}
 
 
-computes a proper mad
---------------------------------------------------
+## computes a proper mad
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/max-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/max-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "max" reducer
-======================
+# Juttle "max" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -12,8 +10,7 @@ complains if missing argument
 
    * reducer max expects 1 argument but was called with 0
 
-outputs -Infinity on empty stream
----------------------------------
+## outputs -Infinity on empty stream
 
 ### Juttle
 
@@ -23,8 +20,7 @@ outputs -Infinity on empty stream
     {max: -Infinity}
 
 
-(skip) outputs -Infinity on empty batched stream (explicit batch)
-----------------------------------------------------------
+## (skip) outputs -Infinity on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -34,8 +30,7 @@ outputs -Infinity on empty stream
     {max: -Infinity}
 
 
-(skip) outputs -Infinity on empty batched stream  (reduce -every)
-----------------------------------------------------------
+## (skip) outputs -Infinity on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -45,8 +40,7 @@ outputs -Infinity on empty stream
     {max: -Infinity}
 
 
-outputs -Infinity on empty batch (explicit batches)
----------------------------------------------------
+## outputs -Infinity on empty batch (explicit batches)
 
 ### Juttle
 
@@ -57,8 +51,7 @@ outputs -Infinity on empty batch (explicit batches)
     {max: -Infinity, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs -Infinity on empty batch (reduce -every)
-------------------------------------------------
+## outputs -Infinity on empty batch (reduce -every)
 
 ### Juttle
 
@@ -69,8 +62,7 @@ outputs -Infinity on empty batch (reduce -every)
     {max: -Infinity, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs -Infinity on empty window (reduce -every -over)
--------------------------------------------------------
+## outputs -Infinity on empty window (reduce -every -over)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/min-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/min-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "min" reducer
-======================
+# Juttle "min" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -12,8 +10,7 @@ complains if missing argument
 
    * reducer min expects 1 argument but was called with 0
 
-outputs Infinity on empty stream
---------------------------------
+## outputs Infinity on empty stream
 
 ### Juttle
 
@@ -23,8 +20,7 @@ outputs Infinity on empty stream
     {min: Infinity}
 
 
-(skip) outputs Infinity on empty batched stream (explicit batch)
----------------------------------------------------------
+## (skip) outputs Infinity on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -34,8 +30,7 @@ outputs Infinity on empty stream
     {min: Infinity}
 
 
-(skip) outputs Infinity on empty batched stream  (reduce -every)
----------------------------------------------------------
+## (skip) outputs Infinity on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -45,8 +40,7 @@ outputs Infinity on empty stream
     {min: Infinity}
 
 
-outputs Infinity on empty batch (explicit batches)
---------------------------------------------------
+## outputs Infinity on empty batch (explicit batches)
 
 ### Juttle
 
@@ -57,8 +51,7 @@ outputs Infinity on empty batch (explicit batches)
     {min: Infinity, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs Infinity on empty batch (reduce -every)
------------------------------------------------
+## outputs Infinity on empty batch (reduce -every)
 
 ### Juttle
 
@@ -69,8 +62,7 @@ outputs Infinity on empty batch (reduce -every)
     {min: Infinity, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs Infinity on empty window (reduce -every -over)
-------------------------------------------------------
+## outputs Infinity on empty window (reduce -every -over)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/percentile-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/percentile-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "percentile" reducer
-=====================
+# Juttle "percentile" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer percentile expects 1 to 2 arguments but was called with 0
 
 
-outputs null on empty stream
-----------------------------
+## outputs null on empty stream
 
 ### Juttle
 
@@ -24,8 +21,7 @@ outputs null on empty stream
     {percentile: null}
 
 
-(skip) outputs null on empty batched stream (explicit batch)
-------------------------------------------------------------
+## (skip) outputs null on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -35,8 +31,7 @@ outputs null on empty stream
     {percentile: null}
 
 
-(skip) outputs null on empty batched stream  (reduce -every)
-------------------------------------------------------------
+## (skip) outputs null on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -46,8 +41,7 @@ outputs null on empty stream
     {percentile: null}
 
 
-outputs null on empty batch (explicit batches)
-----------------------------------------------
+## outputs null on empty batch (explicit batches)
 
 ### Juttle
 
@@ -58,8 +52,7 @@ outputs null on empty batch (explicit batches)
     {percentile: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty batch (reduce -every)
--------------------------------------------
+## outputs null on empty batch (reduce -every)
 
 ### Juttle
 
@@ -70,8 +63,7 @@ outputs null on empty batch (reduce -every)
     {percentile: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty window (reduce -every -over)
---------------------------------------------------
+## outputs null on empty window (reduce -every -over)
 
 ### Juttle
 
@@ -81,8 +73,7 @@ outputs null on empty window (reduce -every -over)
     {percentile: null, time: "1970-01-01T00:00:00.100Z"}
 
 
-complains about nonnumeric input
--------------------------------------------------------
+## complains about nonnumeric input
 ### Juttle
 
     emit -limit 1 -from Date.new(0) | put foo="bar" | reduce percentile('foo') |  view result
@@ -92,8 +83,7 @@ complains about nonnumeric input
    * percentile expects numeric fields, but received: bar
 
 
-keeps discrete values and returns data values for percentiles
-------------------------------------------------------------------------
+## keeps discrete values and returns data values for percentiles
 ### Juttle
     emit -limit 1000 -every :.001s: -from Date.new(0)
         | put x = Math.floor(count()/100)
@@ -104,8 +94,7 @@ keeps discrete values and returns data values for percentiles
 ### Output
     { median: 5, medplus: 6 }
 
-discrete case: median of an even number of points
------------------------------------------------------------------------
+## discrete case: median of an even number of points
 ### Juttle
     emit -limit 10 -from Date.new(0)
     | put x = count()
@@ -115,8 +104,7 @@ discrete case: median of an even number of points
 ### Output
     { p: 5 }
 
-discrete case: median of an odd number of points
------------------------------------------------------------------------
+## discrete case: median of an odd number of points
 ### Juttle
     emit -limit 11 -from Date.new(0)
     | put x = count()
@@ -126,8 +114,7 @@ discrete case: median of an odd number of points
 ### Output
     { p: 6 }
 
-discrete case: median of a run of duplicates
------------------------------------------------------------------------
+## discrete case: median of a run of duplicates
 ### Juttle
     emit -limit 11 -from Date.new(0)
     | put x = (count() % 3 == 0) ? count() : 0
@@ -137,8 +124,7 @@ discrete case: median of a run of duplicates
 ### Output
     { p: 0 }
 
-switches to approximation for continuous values (interpolates percentiles)
-------------------------------------------------------------------------
+## switches to approximation for continuous values (interpolates percentiles)
 ### Juttle
     emit -limit 1000 -every :.001s: -from Date.new(0)
         | (put x=Math.random() ; put x=Math.random() + 10)

--- a/test/runtime/specs/juttle-spec/reducers/pluck-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/pluck-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "pluck" reducer
-======================
+# Juttle "pluck" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/reducers/sigma-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/sigma-reducer.spec.md
@@ -1,8 +1,6 @@
-Juttle "sigma" reducer
-=====================
+# Juttle "sigma" reducer
 
-complains if missing argument
------------------------------
+## complains if missing argument
 
 ### Juttle
 
@@ -13,8 +11,7 @@ complains if missing argument
    * reducer sigma expects 1 argument but was called with 0
 
 
-outputs null on empty stream
-----------------------------
+## outputs null on empty stream
 
 ### Juttle
 
@@ -24,8 +21,7 @@ outputs null on empty stream
     {sigma: null}
 
 
-(skip) outputs null on empty batched stream (explicit batch)
------------------------------------------------------
+## (skip) outputs null on empty batched stream (explicit batch)
 
 ### Juttle
 
@@ -35,8 +31,7 @@ outputs null on empty stream
     {sigma: null}
 
 
-(skip) outputs null on empty batched stream  (reduce -every)
------------------------------------------------------
+## (skip) outputs null on empty batched stream  (reduce -every)
 
 ### Juttle
 
@@ -46,8 +41,7 @@ outputs null on empty stream
     {sigma: null}
 
 
-outputs null on empty batch (explicit batches)
-----------------------------------------------
+## outputs null on empty batch (explicit batches)
 
 ### Juttle
 
@@ -58,8 +52,7 @@ outputs null on empty batch (explicit batches)
     {sigma: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty batch (reduce -every)
--------------------------------------------
+## outputs null on empty batch (reduce -every)
 
 ### Juttle
 
@@ -70,8 +63,7 @@ outputs null on empty batch (reduce -every)
     {sigma: null, time: "1970-01-01T00:00:00.200Z"}
 
 
-outputs null on empty window (reduce -every -over)
---------------------------------------------------
+## outputs null on empty window (reduce -every -over)
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/scoping.spec.md
+++ b/test/runtime/specs/juttle-spec/scoping.spec.md
@@ -1,8 +1,6 @@
-Scoping
-=======
+# Scoping
 
-Calls like `count()` in streaming expressions always refer to the built-in reducer
-----------------------------------------------------------------------------------
+## Calls like `count()` in streaming expressions always refer to the built-in reducer
 
 Regression test for PROD-9211.
 

--- a/test/runtime/specs/juttle-spec/statements.spec.md
+++ b/test/runtime/specs/juttle-spec/statements.spec.md
@@ -1,8 +1,6 @@
-Juttle statements
-=================
+# Juttle statements
 
-Empty statement
----------------
+## Empty statement
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/error-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/error-statement.spec.md
@@ -1,8 +1,6 @@
-The `error` statement
-=====================
+# The `error` statement
 
-Produces an error with passed message
--------------------------------------
+## Produces an error with passed message
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Produces an error with passed message
 
   * Boom!
 
-Produces an error when passed a message of invalid type
--------------------------------------------------------
+## Produces an error when passed a message of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/function-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/function-statement.spec.md
@@ -1,8 +1,6 @@
-The `function` statement
-========================
+# The `function` statement
 
-Optional parameters can be expressions
---------------------------------------
+## Optional parameters can be expressions
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Optional parameters can be expressions
 
     { time: "1970-01-01T00:00:00.000Z", result: 47 }
 
-Optional parameters can depend on previous parameters
------------------------------------------------------
+## Optional parameters can depend on previous parameters
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Optional parameters can depend on previous parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when a required parameter follows an optional parameter
--------------------------------------------------------------------------
+## Produces an error when a required parameter follows an optional parameter
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/if-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/if-statement.spec.md
@@ -1,8 +1,6 @@
-The `if` statement
-==================
+# The `if` statement
 
-With one branch: Executes the branch depending on the condition
----------------------------------------------------------------
+## With one branch: Executes the branch depending on the condition
 
 ### Juttle
 
@@ -23,8 +21,7 @@ With one branch: Executes the branch depending on the condition
 
     { "time": "1970-01-01T00:00:00.000Z", f: null, t: 1 }
 
-With two branches: Executes one of the branches depending on the condition
---------------------------------------------------------------------------
+## With two branches: Executes one of the branches depending on the condition
 
 ### Juttle
 
@@ -45,8 +42,7 @@ With two branches: Executes one of the branches depending on the condition
 
     { "time": "1970-01-01T00:00:00.000Z", f: 0, t: 1 }
 
-Produces an error when used with a condition of invalid type
-------------------------------------------------------------
+## Produces an error when used with a condition of invalid type
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/reducer-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/reducer-statement.spec.md
@@ -1,8 +1,6 @@
-The `reducer` statement
-=======================
+# The `reducer` statement
 
-Optional parameters can be expressions
---------------------------------------
+## Optional parameters can be expressions
 
 ### Juttle
 
@@ -21,8 +19,7 @@ Optional parameters can be expressions
 
     { time: "1970-01-01T00:00:00.000Z", result: 47 }
 
-Optional parameters can depend on previous parameters
------------------------------------------------------
+## Optional parameters can depend on previous parameters
 
 ### Juttle
 
@@ -41,8 +38,7 @@ Optional parameters can depend on previous parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when a required parameter follows an optional parameter
--------------------------------------------------------------------------
+## Produces an error when a required parameter follows an optional parameter
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/return-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/return-statement.spec.md
@@ -1,8 +1,6 @@
-The `return` statement
-======================
+# The `return` statement
 
-Without value: Makes enclosing function return `null`
------------------------------------------------------
+## Without value: Makes enclosing function return `null`
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Without value: Makes enclosing function return `null`
 
     { time: "1970-01-01T00:00:00.000Z", result: null }
 
-With value: Makes enclosing function return the value
------------------------------------------------------
+## With value: Makes enclosing function return the value
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/sub-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/sub-statement.spec.md
@@ -1,8 +1,6 @@
-The `sub` statement
-===================
+# The `sub` statement
 
-Optional parameters can be expressions
---------------------------------------
+## Optional parameters can be expressions
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Optional parameters can be expressions
 
     { time: "1970-01-01T00:00:00.000Z", result: 47 }
 
-Optional parameters can depend on previous parameters
------------------------------------------------------
+## Optional parameters can depend on previous parameters
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Optional parameters can depend on previous parameters
 
     { time: "1970-01-01T00:00:00.000Z", result: [1, 2] }
 
-Produces an error when a required parameter follows an optional parameter
--------------------------------------------------------------------------
+## Produces an error when a required parameter follows an optional parameter
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/statements/var-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/var-statement.spec.md
@@ -1,8 +1,6 @@
-The `var` statement
-===================
+# The `var` statement
 
-Initializes a variable to specified value
------------------------------------------
+## Initializes a variable to specified value
 
 ### Juttle
 
@@ -18,8 +16,7 @@ Initializes a variable to specified value
 
     { "time": "1970-01-01T00:00:00.000Z", result: 5 }
 
-Initializes a variable to `null` when no value is specified
------------------------------------------------------------
+## Initializes a variable to `null` when no value is specified
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/stdlib/predict.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/predict.spec.md
@@ -1,8 +1,6 @@
-juttle stdlib.predict module
-====================================================
+# juttle stdlib.predict module
 
-predict with features disabled returns previous value
-----------------------------------------------------------
+## predict with features disabled returns previous value
 ### Juttle
     import "predict.juttle" as predict;
     emit -limit 5 -from Date.new(0) -every :d:
@@ -18,8 +16,7 @@ predict with features disabled returns previous value
     { time: "1970-01-04T00:00:00.000Z", value: 4, P: 3, E: -1 }
     { time: "1970-01-05T00:00:00.000Z", value: 5, P: 4, E: -1 }
 
-predict can detrend a straight line
-----------------------------------------------------------
+## predict can detrend a straight line
 ### Juttle
     import "predict.juttle" as predict;
     emit -limit 14 -from Date.new(0) -every :d:
@@ -31,8 +28,7 @@ predict can detrend a straight line
 ### Output
     { value: 14, P: 14 }
 
-predict can deseasonalize a sinewave
-----------------------------------------------------------
+## predict can deseasonalize a sinewave
 ### Juttle
     import "predict.juttle" as predict;
     const every=:d:;
@@ -47,8 +43,7 @@ predict can deseasonalize a sinewave
 ### Output
     { value: -7.818314824680304, P: -7.818314824680301 }
 
-predict can detrend and deseasonalize
-----------------------------------------------------------
+## predict can detrend and deseasonalize
 ### Juttle
     import "predict.juttle" as predict;
     const every=:d:;

--- a/test/runtime/specs/juttle-spec/stdlib/random.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/random.spec.md
@@ -1,8 +1,6 @@
-juttle stdlib.random module
-====================================================
+# juttle stdlib.random module
 
-exponential produces numbers > 0 for positive scale
---------------------------------------
+## exponential produces numbers > 0 for positive scale
 ### Juttle
     import "random.juttle" as random;
     emit -limit 1000 -from Date.new(0)
@@ -14,8 +12,7 @@ exponential produces numbers > 0 for positive scale
 ### Output
     {count: 1000}
 
-normal produces some numbers
---------------------------------------
+## normal produces some numbers
 ### Juttle
     import "random.juttle" as random;
     emit -limit 1000 -from Date.new(0)
@@ -27,8 +24,7 @@ normal produces some numbers
 ### Output
     {count: 1000}
 
-poisson produces integers >= 0
---------------------------------------
+## poisson produces integers >= 0
 ### Juttle
     import "random.juttle" as random;
     emit -limit 1000 -from Date.new(0)
@@ -41,8 +37,7 @@ poisson produces integers >= 0
 ### Output
     {count: 1000}
 
-uniform produces numbers in (low...high)
---------------------------------------
+## uniform produces numbers in (low...high)
 ### Juttle
     import "random.juttle" as random;
     emit -limit 1000 -from Date.new(0)

--- a/test/runtime/specs/juttle-spec/stdlib/select.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/select.spec.md
@@ -1,8 +1,6 @@
-juttle stdlib.select module
-====================================================
+# juttle stdlib.select module
 
-min selects the minimum value
--------------------------------------
+## min selects the minimum value
 ### Juttle
     import "select.juttle" as select;
     emit -limit 5 -from Date.new(0)
@@ -14,8 +12,7 @@ min selects the minimum value
 ### Output
     {x: 1}
 
-max selects the maximum value
--------------------------------------
+## max selects the maximum value
 ### Juttle
     import "select.juttle" as select;
     emit -limit 5 -from Date.new(0)
@@ -27,8 +24,7 @@ max selects the maximum value
 ### Output
     {x: 5}
 
-median selects the median value (odd)
--------------------------------------
+## median selects the median value (odd)
 ### Juttle
     import "select.juttle" as select;
     emit -limit 5 -from Date.new(0)
@@ -40,8 +36,7 @@ median selects the median value (odd)
 ### Output
     {x: 3}
 
-median selects the median value (even)
--------------------------------------
+## median selects the median value (even)
 ### Juttle
     import "select.juttle" as select;
     emit -limit 6 -from Date.new(0)
@@ -53,8 +48,7 @@ median selects the median value (even)
 ### Output
     {x: 3}
 
-percentile selects the 75th percentile point
--------------------------------------
+## percentile selects the 75th percentile point
 ### Juttle
     import "select.juttle" as select;
     emit -limit 10 -from Date.new(0)
@@ -66,8 +60,7 @@ percentile selects the 75th percentile point
 ### Output
     {x: 8}
 
-min selects the minimum value by group
--------------------------------------
+## min selects the minimum value by group
 ### Juttle
     import "select.juttle" as select;
     emit -limit 10 -from Date.new(0)
@@ -80,8 +73,7 @@ min selects the minimum value by group
     {parity:0, x: 2}
     {parity:1, x: 1}
 
-max selects the maximum value by group
--------------------------------------
+## max selects the maximum value by group
 ### Juttle
     import "select.juttle" as select;
     emit -limit 10 -from Date.new(0)
@@ -94,8 +86,7 @@ max selects the maximum value by group
     {parity:0, x: 10}
     {parity:1, x: 9}
 
-median selects the median value by group
--------------------------------------
+## median selects the median value by group
 ### Juttle
     import "select.juttle" as select;
     emit -limit 10 -from Date.new(0)
@@ -108,8 +99,7 @@ median selects the median value by group
     {parity:0, x: 6}
     {parity:1, x: 5}
 
-percentile selects the 75th percentile point by group
--------------------------------------
+## percentile selects the 75th percentile point by group
 ### Juttle
     import "select.juttle" as select;
     emit -limit 20 -from Date.new(0)
@@ -122,8 +112,7 @@ percentile selects the 75th percentile point by group
     {parity:0, x: 16}
     {parity:1, x: 15}
 
-min selects the minimum value, batched
--------------------------------------
+## min selects the minimum value, batched
 ### Juttle
     import "select.juttle" as select;
     emit -limit 20 -from Date.new(0)
@@ -140,8 +129,7 @@ min selects the minimum value, batched
     {parity:0, x: 12}
     {parity:1, x: 11}
 
-max selects the maximum value, batched
--------------------------------------
+## max selects the maximum value, batched
 ### Juttle
     import "select.juttle" as select;
     emit -limit 20 -from Date.new(0)
@@ -158,8 +146,7 @@ max selects the maximum value, batched
     {parity:0, x: 20}
     {parity:1, x: 19}
 
-median selects the median value, batched
--------------------------------------
+## median selects the median value, batched
 ### Juttle
     import "select.juttle" as select;
     emit -limit 20 -from Date.new(0)
@@ -176,8 +163,7 @@ median selects the median value, batched
     {parity:0, x: 16}
     {parity:1, x: 15}
 
-percentile selects the 75th percentile point, batched
--------------------------------------
+## percentile selects the 75th percentile point, batched
 ### Juttle
     import "select.juttle" as select;
     emit -limit 40 -from Date.new(0)

--- a/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
@@ -1,8 +1,6 @@
-juttle stdlib.stats module
-====================================================
+# juttle stdlib.stats module
 
-reducer demean(fld) subtracts the mean
-------------------------------------------
+## reducer demean(fld) subtracts the mean
 ### Juttle
     import "stats.juttle" as stats;
     emit -limit 5 -from Date.new(0)
@@ -13,8 +11,7 @@ reducer demean(fld) subtracts the mean
 ### Output
     {x: 10, u:6, xmu: 4}
 
-reducer stddev(fld) computes the right thing
-------------------------------------------
+## reducer stddev(fld) computes the right thing
 ### Juttle
     import "stats.juttle" as stats;
     emit -limit 3 -from Date.new(0)
@@ -25,8 +22,7 @@ reducer stddev(fld) computes the right thing
 ### Output
     {s: 2}
 
-reducer z(fld) computes the right thing
-------------------------------------------
+## reducer z(fld) computes the right thing
 note the first output point is dropped because we
 tried to do Math.floor(null)
 ### Juttle
@@ -39,8 +35,7 @@ tried to do Math.floor(null)
 ### Output
     {z:1}
 
-reducer relMean(fld) divides by the mean
-------------------------------------------
+## reducer relMean(fld) divides by the mean
 ### Juttle
     import "stats.juttle" as stats;
     emit -limit 3 -from Date.new(0)
@@ -51,8 +46,7 @@ reducer relMean(fld) divides by the mean
 ### Output
     {x: 6, u:4, xdu: 1.5}
 
-reducer cv(fld) computes the coefficient of variation
-------------------------------------------------------
+## reducer cv(fld) computes the coefficient of variation
 ### Juttle
     import "stats.juttle" as stats;
     emit -limit 100 -from Date.new(0)

--- a/test/runtime/specs/juttle-spec/subgraph-options.spec.md
+++ b/test/runtime/specs/juttle-spec/subgraph-options.spec.md
@@ -1,8 +1,6 @@
-Tests for complex parameters to subgraphs
-=========================================
+# Tests for complex parameters to subgraphs
 
-subgraph with params passed by -
---------------------------------
+## subgraph with params passed by -
 
 ### Juttle
 
@@ -16,8 +14,7 @@ subgraph with params passed by -
     { time: "1970-01-01T00:00:00.000Z" }
     { time: "1970-01-01T00:00:00.001Z" }
 
-subgraph with missing parameters
---------------------------------
+## subgraph with missing parameters
 
 ### Juttle
 
@@ -30,8 +27,7 @@ subgraph with missing parameters
 
    * Subgraph fakemit called without argument hertz
 
-subgraph with optional parameter (passed)
------------------------------------------
+## subgraph with optional parameter (passed)
 
 ### Juttle
 
@@ -45,8 +41,7 @@ subgraph with optional parameter (passed)
     { time: "1970-01-01T00:00:00.000Z" }
     { time: "1970-01-01T00:00:00.001Z" }
 
-subgraph with optional parameter (not passed)
----------------------------------------------
+## subgraph with optional parameter (not passed)
 
 ### Juttle
 
@@ -63,8 +58,7 @@ subgraph with optional parameter (not passed)
     { time: "1970-01-01T00:00:00.003Z" }
     { time: "1970-01-01T00:00:00.004Z" }
 
-subgraph with -o (unsupported)
-------------------------------
+## subgraph with -o (unsupported)
 
 ### Juttle
     const p = {st: 1};
@@ -78,8 +72,7 @@ subgraph with -o (unsupported)
 
    * Subgraph fakemit called with invalid argument o
 
-subgraph with invalid parameters
---------------------------------
+## subgraph with invalid parameters
 
 ### Juttle
 
@@ -92,8 +85,7 @@ subgraph with invalid parameters
 
    * Subgraph fakemit called with invalid argument hz
 
-subgraph with params passed by - (module)
------------------------------------------
+## subgraph with params passed by - (module)
 
 ### Module `mitt`
 
@@ -111,8 +103,7 @@ subgraph with params passed by - (module)
     { time: "1970-01-01T00:00:00.000Z" }
     { time: "1970-01-01T00:00:00.001Z" }
 
-subgraph with optional params (passed, module)
-----------------------------------------------
+## subgraph with optional params (passed, module)
 
 ### Module `mitt`
 
@@ -130,8 +121,7 @@ subgraph with optional params (passed, module)
     { time: "1970-01-01T00:00:00.000Z" }
     { time: "1970-01-01T00:00:00.001Z" }
 
-subgraph with optional params (not passed, module)
---------------------------------------------------
+## subgraph with optional params (not passed, module)
 
 ### Module `mitt`
 
@@ -152,8 +142,7 @@ subgraph with optional params (not passed, module)
     { time: "1970-01-01T00:00:00.003Z" }
     { time: "1970-01-01T00:00:00.004Z" }
 
-subgraph with missing params (module)
--------------------------------------
+## subgraph with missing params (module)
 
 ### Module `mitt`
 

--- a/test/runtime/specs/juttle-spec/ticks.spec.md
+++ b/test/runtime/specs/juttle-spec/ticks.spec.md
@@ -1,8 +1,6 @@
-Juttle live tick tests
-============================================
+# Juttle live tick tests
 
-(skip)PROD-7471 merge forwards ticks
--------------------------
+## (skip)PROD-7471 merge forwards ticks
 ### Juttle
     (emit -every :2s: -limit 2
     | (put slow=true ; filter time < :now:)

--- a/test/runtime/specs/juttle-spec/topology-tests.spec.md
+++ b/test/runtime/specs/juttle-spec/topology-tests.spec.md
@@ -1,8 +1,6 @@
-Topology tests
-===============
+# Topology tests
 
-Proc after a sink
------------------
+## Proc after a sink
 
 ### Juttle
 
@@ -12,8 +10,7 @@ Proc after a sink
 
    * keep may not come after a sink
 
-Proc before a source
---------------------
+## Proc before a source
 
 ### Juttle
 
@@ -23,8 +20,7 @@ Proc before a source
 
    * keep may not come before a source
 
-Source inside a parellel graph in the middle of a flowgraph
------------------------------------------------------------
+## Source inside a parellel graph in the middle of a flowgraph
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/user-defined-reducers.spec.md
+++ b/test/runtime/specs/juttle-spec/user-defined-reducers.spec.md
@@ -1,8 +1,6 @@
-User-defined reducers
-=====================
+# User-defined reducers
 
-Can't contain statement blocks
-------------------------------
+## Can't contain statement blocks
 
 ### Juttle
 
@@ -16,8 +14,7 @@ Can't contain statement blocks
 
   * Cannot use a block at the top level of a reducer.
 
-Can't contain assignments
--------------------------
+## Can't contain assignments
 
 ### Juttle
 
@@ -31,8 +28,7 @@ Can't contain assignments
 
   * Cannot use an assignment at the top level of a reducer.
 
-Can't contain `if` statements
------------------------------
+## Can't contain `if` statements
 
 ### Juttle
 
@@ -47,8 +43,7 @@ Can't contain `if` statements
 
   * Cannot use an if statement at the top level of a reducer.
 
-Can't contain `return` statements
----------------------------------
+## Can't contain `return` statements
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/views/options.spec.md
+++ b/test/runtime/specs/juttle-spec/views/options.spec.md
@@ -1,8 +1,6 @@
-View options
-============
+# View options
 
-Identifiers in multi-value options are not coerced to strings
--------------------------------------------------------------
+## Identifiers in multi-value options are not coerced to strings
 
 Regression test for #444.
 


### PR DESCRIPTION
Maintaining long lines of `=`’s and `-`’s which marked level 1 and 2 headings in JuttleSpec tests was quite a burden. This commit converts the syntax to the `#`-based one.

The conversion was done by running the following commands inside `test/runtime/specs/juttle-spec`:

    ls **/*.spec.md | xargs -n 1 ruby -e 'File.write(ARGV[0], File.read(ARGV[1]).gsub(/^(.+)\n=+$/, "# \\1"))'
    ls **/*.spec.md | xargs -n 1 ruby -e 'File.write(ARGV[0], File.read(ARGV[0]).gsub(/^(.+)\n-+$/, "## \\1"))'