### PR TITLE
semantic.js - disallow empty subs

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -509,13 +509,17 @@ class SemanticPass {
         }
         this.exit_scope();
 
-        if (this.scope.type === 'top') {
-            has_graph = _.any(node.elements, function(element) {
-                return element.type === 'SequentialGraph' || element.type === 'ParallelGraph';
-            });
+        has_graph = _.any(node.elements, function(element) {
+            return element.type === 'SequentialGraph' || element.type === 'ParallelGraph';
+        });
 
-            if (!has_graph) {
+        if (!has_graph) {
+            if (this.scope.type === 'top') {
                 throw errors.compileError('PROGRAM-WITHOUT-FLOWGRAPH', {
+                    location: node.location
+                });
+            } else {
+                throw errors.compileError('SUB-WITHOUT-FLOWGRAPH', {
                     location: node.location
                 });
             }

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -74,6 +74,7 @@
   "ON-NO-EVERY": "Cannot set -on without -every",
   "CUSTOM-ERROR": "{message}",
   "PROGRAM-WITHOUT-FLOWGRAPH": "Cannot run a program without a flowgraph.",
+  "SUB-WITHOUT-FLOWGRAPH": "A sub must contain a flowgraph.",
   "PROC-CANNOT-START-FLOWGRAPH": "{proc} cannot be used at the start of a flowgraph.",
   "PROC-MUST-START-FLOWGRAPH": "{proc} can only be used at the start of a flowgraph.",
   "PROC-CANNOT-END-FLOWGRAPH": "{proc} cannot be used at the end of a flowgraph.",

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -19,6 +19,18 @@ describe('Juttle basic language tests', function() {
         });
     });
 
+    it('fails cleanly with an empty sub', function() {
+        return check_juttle({
+            program: 'sub empty() {}; empty'
+        })
+        .then(function() {
+            throw new Error('this should fail');
+        })
+        .catch(function(err) {
+            expect(err.message).to.equal('A sub must contain a flowgraph.');
+        });
+    });
+
     it('succeeds with a source and single sink', function() {
         return check_juttle({
             program: 'read file -file "input/simple.json" | view sink1',


### PR DESCRIPTION
Previously, defining an empty sub resulted in the following error from
the compiler:

```
$ bin/juttle -e 'sub s() {}; s'
Error: Cannot read property 'head' of undefined
```

As the sub didn't contain any nodes, it didn't return any which the
compiler could attach into the surrounding flowgraph.

A simple fix is to regard empty subs as an error. This is consistent
with handling of an empty program / flowgraph.

Fixes: #433