### PR TITLE
Program cleanups

### DIFF
--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -77,8 +77,7 @@ class GraphCompiler extends CodeGenerator {
         code = '(function(juttle, program) {\n';
         code += 'var views=[];\n';
         code += body;
-        code += 'return { program: program, now: program.now, views: views,';
-        code += 'graph: ' + entry + ' };\n';
+        code += 'return { views: views, graph: ' + entry + ' };\n';
         code += '})';
         return code;
     }

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -63,7 +63,6 @@ class GraphCompiler extends CodeGenerator {
     }
     gen(graph) {
         var code, body, entry;
-        this.gen_now(graph.now);
         this.gen_functionDefs(graph.functions);
         this.gen_reducerDefs(graph.reducers);
         entry = this.gen_procs(graph.nodes);
@@ -85,9 +84,6 @@ class GraphCompiler extends CodeGenerator {
     }
     emit(s) {
         this.code += s;
-    }
-    gen_now(now) {
-        this.emit('program.now = ' + 'new juttle.types.JuttleMoment("' + now + '");');
     }
     gen_functionDefs(fns) {
         var k;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -63,7 +63,6 @@ class GraphCompiler extends CodeGenerator {
     }
     gen(graph) {
         var code, body, entry;
-        this.now = graph.now;
         this.gen_now(graph.now);
         this.gen_functionDefs(graph.functions);
         this.gen_reducerDefs(graph.reducers);

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -88,7 +88,6 @@ class GraphCompiler extends CodeGenerator {
     }
     gen_now(now) {
         this.emit('program.now = ' + 'new juttle.types.JuttleMoment("' + now + '");');
-        this.emit('program.channels = 0;');
     }
     gen_functionDefs(fns) {
         var k;

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -75,9 +75,8 @@ class GraphCompiler extends CodeGenerator {
         // this should be the only object reference into the entire
         // compiled world and associated runtime.
         //
-        code = '(function(juttle) {\n';
+        code = '(function(juttle, program) {\n';
         code += 'var views=[];\n';
-        code += 'var program = {};\n';
         code += body;
         code += 'return { program: program, now: program.now, views: views,';
         code += 'graph: ' + entry + ' };\n';

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -45,10 +45,9 @@ var stages = {
     },
 
     eval: function(code, options) {
-        var program = new Program();
+        var program = new Program(code);
         program.scheduler = options.scheduler;
         program.events = new EventEmitter();
-        program.code = code;
 
         program._eval();
         program.validate();

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var EventEmitter = require('eventemitter3');
 var Scheduler = require('../runtime/scheduler').Scheduler;
 var Graph = require('../graph');
 var Program = require('../program');
@@ -47,7 +46,6 @@ var stages = {
     eval: function(code, options) {
         var program = new Program(code);
         program.scheduler = options.scheduler;
-        program.events = new EventEmitter();
 
         program._eval();
         program.validate();

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -51,8 +51,7 @@ var stages = {
         program.code = code;
 
         program._eval();
-        program._validate_sinks();
-        program._validate_sources();
+        program.validate();
 
         return program;
     }

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -46,7 +46,7 @@ var stages = {
     eval: function(code, options) {
         var program = new Program(code, options);
 
-        program._eval();
+        program.eval();
         program.validate();
 
         return program;

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -44,8 +44,7 @@ var stages = {
     },
 
     eval: function(code, options) {
-        var program = new Program(code);
-        program.scheduler = options.scheduler;
+        var program = new Program(code, options);
 
         program._eval();
         program.validate();

--- a/lib/program.js
+++ b/lib/program.js
@@ -21,9 +21,7 @@ class Program {
         this.scheduler = options.scheduler;
         this.code = code;
         this.now = options.now;
-    }
-    set_env(env) {
-        this.env = _.extend(this.env, env);
+        this.env.now = options.now;
     }
     deactivate() {
         var k;
@@ -39,7 +37,6 @@ class Program {
     }
     eval() {
         var o = eval(this.code)(juttle, this);
-        this.set_env({now: o.now});
         this.graph = o.graph;
         o.program.scheduler = this.scheduler;
     }
@@ -51,10 +48,9 @@ class Program {
         }));
     }
     activate() {
-        var env = this.env;
         var events = this.events;
         _.each(this.get_nodes(), function(node) {
-            _.extend(node.program, env, {events: events});
+            _.extend(node.program, {events: events});
         });
 
         _.each(this.get_nodes(), function(node) {

--- a/lib/program.js
+++ b/lib/program.js
@@ -3,6 +3,7 @@
 
 var _ = require('underscore');
 var Promise = require('bluebird');
+var EventEmitter = require('eventemitter3');
 
 var juttle = require('./runtime').runtime;
 
@@ -15,6 +16,7 @@ class Program {
     constructor(code) {
         this.env = {};
         this.visitGen = 0;
+        this.events = new EventEmitter();
         this.code = code;
     }
     set_env(env) {

--- a/lib/program.js
+++ b/lib/program.js
@@ -48,11 +48,6 @@ class Program {
         }));
     }
     activate() {
-        var events = this.events;
-        _.each(this.get_nodes(), function(node) {
-            _.extend(node.program, {events: events});
-        });
-
         _.each(this.get_nodes(), function(node) {
             node.start();
         });

--- a/lib/program.js
+++ b/lib/program.js
@@ -16,6 +16,7 @@ class Program {
     constructor(code, options) {
         this.env = {};
         this.visitGen = 0;
+        this.channels = 0;
         this.events = new EventEmitter();
         this.scheduler = options.scheduler;
         this.code = code;

--- a/lib/program.js
+++ b/lib/program.js
@@ -11,11 +11,11 @@ var sink = require('./runtime/procs/sink');
 var view = require('./runtime/procs/view');
 var errors = require('./errors');
 
-
 class Program {
-    constructor() {
+    constructor(code) {
         this.env = {};
         this.visitGen = 0;
+        this.code = code;
     }
     set_env(env) {
         this.env = _.extend(this.env, env);

--- a/lib/program.js
+++ b/lib/program.js
@@ -58,6 +58,12 @@ class Program {
 
         this.scheduler.start();
     }
+
+    validate() {
+        this._validate_sources();
+        this._validate_sinks();
+    }
+
     _validate_sources() {
         var sources = this.get_sources();
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -20,6 +20,7 @@ class Program {
         this.events = new EventEmitter();
         this.scheduler = options.scheduler;
         this.code = code;
+        this.now = options.now;
     }
     set_env(env) {
         this.env = _.extend(this.env, env);

--- a/lib/program.js
+++ b/lib/program.js
@@ -36,7 +36,7 @@ class Program {
         }
     }
     eval() {
-        var o = eval(this.code)(juttle);
+        var o = eval(this.code)(juttle, this);
         this.set_env({now: o.now});
         this.graph = o.graph;
         o.program.scheduler = this.scheduler;

--- a/lib/program.js
+++ b/lib/program.js
@@ -35,7 +35,7 @@ class Program {
             }
         }
     }
-    _eval() {
+    eval() {
         var o = eval(this.code)(juttle);
         this.set_env({now: o.now});
         this.graph = o.graph;

--- a/lib/program.js
+++ b/lib/program.js
@@ -13,10 +13,11 @@ var view = require('./runtime/procs/view');
 var errors = require('./errors');
 
 class Program {
-    constructor(code) {
+    constructor(code, options) {
         this.env = {};
         this.visitGen = 0;
         this.events = new EventEmitter();
+        this.scheduler = options.scheduler;
         this.code = code;
     }
     set_env(env) {

--- a/lib/program.js
+++ b/lib/program.js
@@ -36,9 +36,7 @@ class Program {
         }
     }
     eval() {
-        var o = eval(this.code)(juttle, this);
-        this.graph = o.graph;
-        o.program.scheduler = this.scheduler;
+        this.graph = eval(this.code)(juttle, this).graph;
     }
     // Returns a promise that is resolved when the program completes execution,
     // which is determined when all of the sinks have seen an eof.


### PR DESCRIPTION
The high level goal of this patch set is to make `scheduler` accessible during procs construction.

Currently, procs access a `program` object and its properties, some of which (e.g assignments for `channels` and `now`) are generated by the compiler.

After the code produced by the compiler is evaluated, additional properties (`scheduler`) are assigned to `program`.

And as a part of `activate` step, the `program` object is further extended with `env` and `events` properties.

Instead of generating `program` in the compiler, then extending it in various ways, pass instance of `Program` class to the compiler and ensure that all properties required by procs are added during `Program`'s `constructor` call. This also makes them accessible during compilation phase.