### PR TITLE
adapters: add the module name and builtin flag to the adapter list

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -115,7 +115,7 @@ adapters.configure(config.adapters);
 
 if (opts.adapters) {
     adapters.list().forEach(function(info) {
-        console.log(info.adapter, info.version, info.path);
+        console.log(info.adapter, info.version, (info.builtin ? '(builtin)' : info.path));
     });
     process.exit(0);
 }

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -142,22 +142,27 @@ function list() {
     var adapters = [];
     _.each(adapterConfig, function(config, adapter) {
         var modulePath = adapterModulePath(adapter, config);
-        var version, installPath;
+        var version, installPath, moduleName;
 
-        if (BUILTIN_ADAPTERS.indexOf(adapter) !== -1) {
+        var isBuiltin = BUILTIN_ADAPTERS.indexOf(adapter) !== -1;
+        if (isBuiltin) {
             version = juttleVersion;
             installPath = Module._resolveFilename(modulePath, module);
+            moduleName = '(builtin)';
         } else {
             try {
-                var pkg = require(path.join(modulePath, 'package'));
-                installPath = Module._resolveFilename(modulePath, module);
+                var packagePath = path.join(modulePath, 'package');
+                var pkg = require(packagePath);
+                installPath = path.dirname(Module._resolveFilename(packagePath, module));
                 version = pkg.version || '(unknown)';
+                moduleName = pkg.name;
             } catch (err) {
                 installPath = '(unable to load adapter)';
                 version = '(unknown)';
+                moduleName = '(unknown)';
             }
         }
-        adapters.push({adapter: adapter, version: version, path: installPath});
+        adapters.push({adapter: adapter, builtin: isBuiltin, module: moduleName, version: version, path: installPath});
     });
     return adapters;
 }

--- a/test/runtime/juttle-module.spec.js
+++ b/test/runtime/juttle-module.spec.js
@@ -27,8 +27,30 @@ describe('Juttle Module Tests', function() {
         })
         .then(function(result) {
             var adapterList = adapters.list();
-            expect(adapterList).to.contain({adapter: 'file', version: version, path: path.resolve(__dirname, '../../lib/adapters/file/index.js')});
-            expect(adapterList).to.contain({adapter: 'invalid', version: '(unknown)', path: '(unable to load adapter)'});
+            expect(adapterList).to.contain({
+                adapter: 'file',
+                builtin: true,
+                module: '(builtin)',
+                version: version,
+                path: path.resolve(__dirname, '../../lib/adapters/file/index.js')
+            });
+
+            expect(adapterList).to.contain({
+                adapter: 'invalid',
+                builtin: false,
+                version: '(unknown)',
+                module: '(unknown)',
+                path: '(unable to load adapter)'
+            });
+
+            expect(adapterList).to.contain({
+                adapter: 'test',
+                builtin: false,
+                module: 'test-adapter',
+                version: '0.1.0',
+                path: path.resolve(__dirname, './test-adapter')
+            });
+
             expect(result.sinks.result).to.deep.equal(adapterList);
         });
     });


### PR DESCRIPTION
In order to improve the ability of embedders like juttle-service
to list the version of all adapters, add the module name and a flag
to indicate which ones are builtins to the adapter list.