### PR TITLE
plugin runaway program detector

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -37,6 +37,7 @@ var resolver_utils = require('../lib/module-resolvers/resolver-utils');
 var compiler = require('../lib/compiler');
 var optimize = require('../lib/compiler/optimize');
 var implicit_views = require('../lib/compiler/flowgraph/implicit_views');
+var check_runaway = require('../lib/compiler/flowgraph/check_runaway.js');
 
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
 function usage() {
@@ -151,7 +152,7 @@ function perform_compile(options) {
     var compile_options = {
         stage: options.stage,
         moduleResolver: options.resolver,
-        fg_processors: [implicit_views(config.implicit_view || 'table'), optimize],
+        fg_processors: [check_runaway, implicit_views(config.implicit_view || 'table'), optimize],
         inputs: options.inputs,
         stripLocations: options.stripLocations
     };

--- a/lib/compiler/flowgraph/check_runaway.js
+++ b/lib/compiler/flowgraph/check_runaway.js
@@ -3,58 +3,66 @@
 var _ = require('underscore');
 var errors = require('../../errors');
 
+function isRunaway(readNode, graph) {
 
-
-function is_runaway(read_node, g) {
-
-    function node_type(node) {
+    function nodeType(node) {
         // temp while grammar refactor is in progress; once complete we should be
         // able to always look up .name
         return node.name || node.type;
     }
 
-    function multiple_inputs(node) {
-        return g.node_get_inputs(node).length > 1;
+    function multipleInputs(node) {
+        return graph.node_get_inputs(node).length > 1;
     }
     // historical read
-    if (g.node_get_option(read_node, 'to') || g.node_get_option(read_node, 'last')) {
+    if (graph.node_get_option(readNode, 'to') || graph.node_get_option(readNode, 'last')) {
         return;
     }
 
     var outs;
-    var next_node = read_node;
+    var nextNode = readNode;
     while (true) {
-        outs = g.node_get_outputs(next_node);
+        outs = graph.node_get_outputs(nextNode);
 
         // Keeping things simple for now and only considering linear topologies
         // (which means we won't flag all possible runaways)
-        if (outs.length !== 1 || _.any(outs, multiple_inputs)) {
+        if (outs.length !== 1 || _.any(outs, multipleInputs)) {
             return;
         }
 
-        next_node = outs[0];
+        nextNode = outs[0];
 
-        switch (node_type(next_node)) {
+        switch (nodeType(nextNode)) {
             case 'batch':
                 return;
             case 'tail':
-                throw errors.compileError('RUNAWAY-PROGRAM', {extra: 'Add a -to option to read?'});
+                throw errors.compileError('RUNAWAY-PROGRAM', {
+                    extra: 'Add a -to option to read?'
+                });
             case 'ReduceProc':
-                if (!g.node_has_option(next_node, 'every')) {
-                    throw errors.compileError('RUNAWAY-PROGRAM', {extra: 'Add a -to option to read or a -every option to reduce?'});
+                if (!graph.node_has_option(nextNode, 'every')) {
+                    throw errors.compileError('RUNAWAY-PROGRAM', {
+                        extra: 'Add a -to option to read or a -every option to reduce?'
+                    });
                 }
                 break;
             case 'SortProc':
-                throw errors.compileError('RUNAWAY-PROGRAM', {extra: 'Add a -to option to read?'});
+                throw errors.compileError('RUNAWAY-PROGRAM', {
+                    extra: 'Add a -to option to read?'
+                });
             default:
                 break;
         }
     }
 }
 
-function check_runaways(g) {
-    var reads = _.where(g.get_roots(), {type: 'ReadProc', name: 'read'});
-    _.each(reads, function(node) {is_runaway(node, g);});
+function checkRunaways(graph) {
+    var reads = _.where(graph.get_roots(), {
+        type: 'ReadProc',
+        name: 'read'
+    });
+
+    _.each(reads, function(node) {isRunaway(node, graph);});
 }
 
-module.exports = check_runaways;
+module.exports = checkRunaways;

--- a/lib/compiler/flowgraph/check_runaway.js
+++ b/lib/compiler/flowgraph/check_runaway.js
@@ -5,17 +5,15 @@ var errors = require('../../errors');
 
 function isRunaway(readNode, graph) {
 
-    function nodeType(node) {
-        // temp while grammar refactor is in progress; once complete we should be
-        // able to always look up .name
-        return node.name || node.type;
-    }
-
     function multipleInputs(node) {
         return graph.node_get_inputs(node).length > 1;
     }
-    // historical read
-    if (graph.node_get_option(readNode, 'to') || graph.node_get_option(readNode, 'last')) {
+
+    // historical read is any read that doesn't have the `to` set to :end:
+    var readNodeTo = graph.node_get_option(readNode, 'to');
+    if (!readNodeTo ||
+        // when the -to is set to something invalid then isEnd is not a function
+        (readNodeTo.isEnd && !readNodeTo.isEnd())) {
         return;
     }
 
@@ -32,21 +30,21 @@ function isRunaway(readNode, graph) {
 
         nextNode = outs[0];
 
-        switch (nodeType(nextNode)) {
+        switch (nextNode.name) {
             case 'batch':
                 return;
             case 'tail':
                 throw errors.compileError('RUNAWAY-PROGRAM', {
                     extra: 'Add a -to option to read?'
                 });
-            case 'ReduceProc':
+            case 'reduce':
                 if (!graph.node_has_option(nextNode, 'every')) {
                     throw errors.compileError('RUNAWAY-PROGRAM', {
                         extra: 'Add a -to option to read or a -every option to reduce?'
                     });
                 }
                 break;
-            case 'SortProc':
+            case 'sort':
                 throw errors.compileError('RUNAWAY-PROGRAM', {
                     extra: 'Add a -to option to read?'
                 });

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1615,6 +1615,7 @@ SortProc
     =
       ACProcStart SortToken ACProcEnd options:ProcOptions __ columns:SortByList __ by: ByClause? {
           return createNode('SortProc', location(), {
+              name: 'sort',
               columns:columns,
               options:options,
               groupby:by

--- a/test/compiler/flowgraph/check_runaway.spec.js
+++ b/test/compiler/flowgraph/check_runaway.spec.js
@@ -1,0 +1,162 @@
+'use strict';
+
+var expect = require('chai').expect;
+var juttle_test_utils = require('../../runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+
+describe('Runaway program detection', function() {
+
+    it('does not detect a runaway program from a live read', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end:'
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('detects a runaway program from a live read to a tail 1', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | tail 1 '
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('detects a runaway program from a superquery read to a tail 1', () => {
+        return check_juttle({
+            program: 'read stochastic -from :0: -to :end: | tail 1 '
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('does not detect a runaway program from a live read with batch to a tail 1', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | batch -every :1s: | tail 1 '
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('detects a runaway program from a live read to sort', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | sort field'
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('detects a runaway program from a superquery read to sort', () => {
+        return check_juttle({
+            program: 'read stochastic -from :0: -to :end: | sort field'
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('does not detect a runaway program from a live read with batch to sort', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | put field=count() | batch -every :1s: | sort field '
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('does not detect a runaway program from a live read with reduce -every', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | reduce -every :1s: count()'
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('does not detect a runaway program from a live read with batch to reduce', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | batch :1s: | reduce count() '
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('does not detect a runaway program from a historical read to reduce', () => {
+        return check_juttle({
+            program: 'read stochastic -to :now: | reduce count() '
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+
+    it('detects a runaway program when there are multiple read sources', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | reduce count() | view results1; read stochastic -last :1m: | reduce count() | view results2'
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('detects a runaway program when there are multiple levels of procs used', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | put a = count() | filter foo="bar" | reduce count() | put a = count()'
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('detects a runaway program when there are multiple reducers and one without -every', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | reduce -every :1s: count() | reduce max(m)'
+        }) // stop the live program after 100ms
+        .then((results) => {
+            throw Error('runaway detector failed to catch');
+        })
+        .catch((err) => {
+            expect(err.code).to.equal('RUNAWAY-PROGRAM');
+        });
+    });
+
+    it('does not detect a runaway program from a live read to head', () => {
+        return check_juttle({
+            program: 'read stochastic -to :end: | head 1'
+        }, 50) // stop the live program after 100ms
+        .then((results) => {
+            expect(results.errors).to.deep.equal([]);
+            expect(results.warnings).to.deep.equal([]);
+        });
+    });
+});

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -20,7 +20,8 @@ var Scheduler = require('../../../lib/runtime/scheduler').Scheduler;
 var TestScheduler = require('../../../lib/runtime/scheduler').TestScheduler;
 var implicit_views = require('../../../lib/compiler/flowgraph/implicit_views')();
 var optimize = require('../../../lib/compiler/optimize');
-var View = require('../../../lib/views/view');
+var View = require('../../../lib/views/view.js');
+var check_runaway = require('../../../lib/compiler/flowgraph/check_runaway');
 
 // Configure the test adapter
 adapters.configure({
@@ -155,7 +156,7 @@ function compile_juttle(options) {
     var compile_opts = {
         modules: options.modules,
         moduleResolver: options.moduleResolver,
-        fg_processors: [implicit_views, optimize],
+        fg_processors: [check_runaway, implicit_views, optimize],
         scheduler: options.realtime ? new Scheduler() : new TestScheduler()
     };
 


### PR DESCRIPTION
fixes #245

add in the runaway program detector and revive the unit tests along with
a small tweak to the pegjs grammar to correctly populate the sort proc
name