### PR TITLE
Add new built-in adapters to top README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ configuration.
 
 * [file](./docs/adapters/file.md)
 * [http](./docs/adapters/http.md)
+* [http_server](./docs/adapters/http_server.md)
+* [stdio](./docs/adapters/stdio.md)
 * [stochastic](./docs/adapters/stochastic.md)
 
 #### External


### PR DESCRIPTION
Add "new" built-in adapters (stdio/http_server) to top level README.

@rlgomes @dmajda @mnibecker @go-oleg 