### PR TITLE
Adapter API: add parsers/serializers

### DIFF
--- a/lib/adapters/api.js
+++ b/lib/adapters/api.js
@@ -10,7 +10,7 @@ let juttle_utils = require('../runtime/juttle-utils');
 // changes were made to the adapter API.
 //
 let AdapterAPI = {
-    version: '0.5.0',
+    version: '0.5.2',
     AdapterRead: require('./adapter-read'),
     AdapterWrite: require('./adapter-write'),
     compiler: {
@@ -19,6 +19,8 @@ let AdapterAPI = {
         StaticFilterCompiler: require('../compiler/filters/static-filter-compiler'),
         FilterJSCompiler: require('../compiler/filters/filter-js-compiler'),
     },
+    parsers: require('./parsers'),
+    serializers: require('./serializers'),
     errors: require('../errors'),
     getLogger: require('../logger').getLogger,
     runtime: {


### PR DESCRIPTION
https://github.com/juttle/juttle-s3-adapter/pull/8 `require`s these out of the Juttle lib, but the cool kids are pulling all their Juttle dependencies off the `JuttleAdapterAPI` these days.

@demmer @rlgomes 