### PR TITLE
Make the “.” operator work properly in rvalues (part 1)

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -797,7 +797,7 @@ class Build extends CodeGenerator {
         return 'juttle.ops.pget(pt,' + JSON.stringify(node.name) + ')';
     }
     gen_MemberExpression(node, opts) {
-        if (!node.computed) {
+        if (node.symbol) {
             return node.symbol.uname;
         } else {
             if (opts.lhs) {

--- a/lib/compiler/filters/filter-js-compiler.js
+++ b/lib/compiler/filters/filter-js-compiler.js
@@ -128,7 +128,7 @@ class FilterJSCompiler extends ASTVisitor {
     }
 
     visitMemberExpression(node) {
-        if (!node.computed) {
+        if (node.symbol) {
             return node.uname;
         } else {
             return 'juttle.ops.get('

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -727,7 +727,7 @@ class GraphCompiler extends CodeGenerator {
         }
     }
     gen_MemberExpression(node, opts) {
-        if (!node.computed) {
+        if (node.symbol) {
             return node.symbol.uname;
         } else {
             if (opts.lhs) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -50,6 +50,7 @@ class SemanticPass {
 
         this.context = 'build';
         this.coercion_mode = 'none';
+        this.lhs = false;
         this.reducers = null;
         this.index = null;
 
@@ -314,6 +315,15 @@ class SemanticPass {
             fn();
         } finally {
             this.coercion_mode = saved_coercion_mode;
+        }
+    }
+    with_lhs(lhs, fn) {
+        var saved_lhs = this.lhs;
+        this.lhs = lhs;
+        try {
+            fn();
+        } finally {
+            this.lhs = saved_lhs;
         }
     }
 
@@ -711,14 +721,18 @@ class SemanticPass {
     sa_AssignmentStatement(node) {
         this.check_reducer_toplevel(node, 'an assignment');
 
-        this.sa_assignment_lhs(node.left);
+        this.with_lhs(true, () => {
+            this.sa_assignment_lhs(node.left);
+        });
         //XXX need to handle op's other than "="
         this.sa_expr(node.expr);
     }
     // this type of assignment lives in places where there can be
     // points or reducers
     sa_AssignmentExpression(node) {
-        this.sa_assignment_lhs(node.left);
+        this.with_lhs(true, () => {
+            this.sa_assignment_lhs(node.left);
+        });
         this.sa_expr(node.right);
         node.d = node.left.d && node.right.d;
     }
@@ -1169,7 +1183,9 @@ class SemanticPass {
             case 'MemberExpression':
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
-                this.sa_expr(node.expression);
+                this.with_lhs(true, () => {
+                    this.sa_expr(node.expression);
+                });
                 if (!this.scope.is_mutable(name, this.scope.type)) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
                         operator: node.operator,
@@ -1275,7 +1291,14 @@ class SemanticPass {
         var op = node.operator;
         var name;
 
-        this.sa_expr(node.argument);
+        if (op === '++' || op === '--') {
+            this.with_lhs(true, () => {
+                this.sa_expr(node.argument);
+            });
+        } else {
+            this.sa_expr(node.argument);
+        }
+
         if (op === '*') {
             if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
                 throw errors.compileError('INVALID-FIELD-REFERENCE', {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1420,7 +1420,6 @@ class SemanticPass {
             this.sa_expr(node.object);
             this.sa_expr(node.property);
             node.d = node.object.d && node.property.d;
-            //XXX/TBD need to track d flag in arrays...
         }
     }
 }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1423,25 +1423,48 @@ class SemanticPass {
     }
     sa_MemberExpression(node) {
         var varInfo;
-        if (!node.computed) {
-            varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
-            if (varInfo === undefined) {
-                throw errors.compileError('NOT-EXPORTED', {
-                    thing: 'variable',
-                    name: node.property.value,
-                    module: node.object.name,
-                    location: node.location
-                });
+        if (this.lhs) {
+            if (!node.computed) {
+                varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                if (varInfo === undefined) {
+                    throw errors.compileError('NOT-EXPORTED', {
+                        thing: 'variable',
+                        name: node.property.value,
+                        module: node.object.name,
+                        location: node.location
+                    });
+                }
+
+                this.sa_expr(node.object);
+
+                node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                node.d = true;
+            } else {
+                this.sa_expr(node.object);
+                this.sa_expr(node.property);
+                node.d = node.object.d && node.property.d;
             }
-
-            this.sa_expr(node.object);
-
-            node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-            node.d = true;
         } else {
-            this.sa_expr(node.object);
-            this.sa_expr(node.property);
-            node.d = node.object.d && node.property.d;
+            if (!node.computed) {
+                varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                if (varInfo === undefined) {
+                    throw errors.compileError('NOT-EXPORTED', {
+                        thing: 'variable',
+                        name: node.property.value,
+                        module: node.object.name,
+                        location: node.location
+                    });
+                }
+
+                this.sa_expr(node.object);
+
+                node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                node.d = true;
+            } else {
+                this.sa_expr(node.object);
+                this.sa_expr(node.property);
+                node.d = node.object.d && node.property.d;
+            }
         }
     }
 }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1415,8 +1415,7 @@ class SemanticPass {
 
             node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             node.d = true;
-        }
-        else {
+        } else {
             this.sa_expr(node.object);
             this.sa_expr(node.property);
             node.d = node.object.d && node.property.d;


### PR DESCRIPTION
Various preparations for making the `.` operator work properly in rvalues. Core changes are splitting lvalue and rvalue processing in the semantic pass (so they can be refactored independently) and preparing the compiler for the existence of dynamic non-computed member expressions (that is, expressions like `foo.bar` where `foo` is not a module).

Part of work on #419.