### PR TITLE
SemanticPass: Remove use of obsolete allow_field_comparisons option

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -867,13 +867,13 @@ class SemanticPass {
         this.sa_proc(node);
     }
     sa_FilterProc(node) {
-        this.sa_filter_proc(node, { allow_field_comparisons: true });
+        this.sa_filter_proc(node);
     }
     sa_SequenceProc(node) {
         this.sa_sequence_proc(node);
     }
     sa_ReadProc(node) {
-        this.sa_filter_proc(node, { allow_field_comparisons: false });
+        this.sa_filter_proc(node);
     }
     sa_option_proc(node, options) {
         // Some procs have syntactical sugar for parameters (e.g. the limit in


### PR DESCRIPTION
This should have been done in caf4cf8821712fa016aa8279d094bd88567eb3e0.