### PR TITLE
Make toString functions in Juttle modules use values.toString

### DIFF
--- a/lib/runtime/modules/boolean.js
+++ b/lib/runtime/modules/boolean.js
@@ -11,7 +11,7 @@ var boolean = {
             throw errors.typeErrorFunction('Boolean.toString', 'boolean', value);
         }
 
-        return String(value);
+        return values.toString(value);
     }
 };
 

--- a/lib/runtime/modules/date.js
+++ b/lib/runtime/modules/date.js
@@ -125,7 +125,7 @@ var date = {
             throw errors.typeErrorFunction('Date.toString', 'date', value);
         }
 
-        return value.valueOf();
+        return values.toString(value);
     },
 
     unix: function(date) {

--- a/lib/runtime/modules/duration.js
+++ b/lib/runtime/modules/duration.js
@@ -66,7 +66,7 @@ var duration = {
             throw errors.typeErrorFunction('Duration.toString', 'duration', value);
         }
 
-        return value.valueOf();
+        return values.toString(value);
     }
 };
 

--- a/lib/runtime/modules/null.js
+++ b/lib/runtime/modules/null.js
@@ -11,7 +11,7 @@ var null_ = {
             throw errors.typeErrorFunction('Null.toString', 'null', value);
         }
 
-        return 'null';
+        return values.toString(value);
     }
 };
 

--- a/lib/runtime/modules/number.js
+++ b/lib/runtime/modules/number.js
@@ -18,7 +18,7 @@ var number = {
             throw errors.typeErrorFunction('Number.toString', 'number', value);
         }
 
-        return String(value);
+        return values.toString(value);
     }
 };
 

--- a/lib/runtime/modules/regexp.js
+++ b/lib/runtime/modules/regexp.js
@@ -11,7 +11,7 @@ var regexp = {
             throw errors.typeErrorFunction('RegExp.toString', 'regular expression', value);
         }
 
-        return String(value);
+        return values.toString(value);
     }
 };
 

--- a/lib/runtime/modules/string.js
+++ b/lib/runtime/modules/string.js
@@ -167,7 +167,7 @@ var string = {
             throw errors.typeErrorFunction('String.toString', 'string', value);
         }
 
-        return value;
+        return values.toString(value);
     },
 
     toUpperCase: function(string) {


### PR DESCRIPTION
Various `toString` functions in Juttle modules implemented their own string representation of Juttle values. Let’s replace that with `values.toString`, which is the canonical way.

(The reason why `toString` functions did their own thing is that there was no `values.toString` when they were written.)