### PR TITLE
Make the “.” operator work properly in rvalues (part 2)

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1436,11 +1436,12 @@ class SemanticPass {
     }
     sa_MemberExpression(node) {
         var symbol;
+
+        this.sa_expr(node.object);
+        this.sa_expr(node.property);
+
         if (this.lhs) {
             if (!node.computed) {
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
-
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
@@ -1452,15 +1453,9 @@ class SemanticPass {
                 }
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-            } else {
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
             }
         } else {
             if (!node.computed) {
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
-
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
@@ -1472,9 +1467,6 @@ class SemanticPass {
                 }
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-            } else {
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
             }
         }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1449,6 +1449,7 @@ class SemanticPass {
                 }
 
                 this.sa_expr(node.object);
+                this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
                 node.d = true;
@@ -1470,6 +1471,7 @@ class SemanticPass {
                 }
 
                 this.sa_expr(node.object);
+                this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
                 node.d = true;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1452,11 +1452,9 @@ class SemanticPass {
                 this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-                node.d = true;
             } else {
                 this.sa_expr(node.object);
                 this.sa_expr(node.property);
-                node.d = node.object.d && node.property.d;
             }
         } else {
             if (!node.computed) {
@@ -1474,13 +1472,13 @@ class SemanticPass {
                 this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-                node.d = true;
             } else {
                 this.sa_expr(node.object);
                 this.sa_expr(node.property);
-                node.d = node.object.d && node.property.d;
             }
         }
+
+        node.d = node.object.d && node.property.d;
     }
 }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1438,6 +1438,9 @@ class SemanticPass {
         var symbol;
         if (this.lhs) {
             if (!node.computed) {
+                this.sa_expr(node.object);
+                this.sa_expr(node.property);
+
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
@@ -1447,9 +1450,6 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             } else {
@@ -1458,6 +1458,9 @@ class SemanticPass {
             }
         } else {
             if (!node.computed) {
+                this.sa_expr(node.object);
+                this.sa_expr(node.property);
+
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
@@ -1467,9 +1470,6 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-
-                this.sa_expr(node.object);
-                this.sa_expr(node.property);
 
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             } else {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -118,7 +118,8 @@ class SemanticPass {
                 seed:   { type: 'function', exported: true, uname: 'juttle.modules.math.seed',   arg_count: 1             },
                 sqrt:   { type: 'function', exported: true, uname: 'juttle.modules.math.sqrt',   arg_count: 1             },
                 tan:    { type: 'function', exported: true, uname: 'juttle.modules.math.tan',    arg_count: 1             },
-            }
+            },
+            d: true
         });
     }
     import_null_module() {
@@ -128,7 +129,8 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.null.toString', arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_array_module() {
@@ -151,7 +153,8 @@ class SemanticPass {
                 splice: { type: 'function', exported: true, uname: 'juttle.modules.array.splice', arg_count: [1, Infinity]},
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.array.toString', arg_count: 1},
                 unshift:  { type: 'function', exported: true, uname: 'juttle.modules.array.unshift',   arg_count: [1, Infinity] },
-            }
+            },
+            d: true
         });
     }
     import_boolean_module() {
@@ -161,7 +164,8 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.boolean.toString', arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_number_module() {
@@ -179,7 +183,8 @@ class SemanticPass {
                 /* Functions (sorted alphabetically) */
                 fromString: { type: 'function', exported: true, uname: 'juttle.modules.number.fromString', arg_count: 1 },
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.number.toString', arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_string_module() {
@@ -206,7 +211,8 @@ class SemanticPass {
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.string.toString', arg_count: 1   },
                 toUpperCase: { type: 'function', exported: true, uname: 'juttle.modules.string.toUpperCase', arg_count: 1   },
                 trim: { type: 'function', exported: true, uname: 'juttle.modules.string.trim', arg_count: 1                 },
-            }
+            },
+            d: true
         });
     }
     import_object_module() {
@@ -218,7 +224,8 @@ class SemanticPass {
                 keys: { type: 'function', exported: true, uname: 'juttle.modules.object.keys', arg_count: 1 },
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.object.toString', arg_count: 1},
                 values: { type: 'function', exported: true, uname: 'juttle.modules.object.values', arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_regexp_module() {
@@ -228,7 +235,8 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.regexp.toString', arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_date_module() {
@@ -250,7 +258,8 @@ class SemanticPass {
                 toString:    { type: 'function', exported: true, uname: 'juttle.modules.date.toString',    arg_count: 1      },
                 unix:        { type: 'function', exported: true, uname: 'juttle.modules.date.unix',        arg_count: 1      },
                 unixms:      { type: 'function', exported: true, uname: 'juttle.modules.date.unixms',      arg_count: 1      },
-            }
+            },
+            d: true
         });
     }
     import_duration_module() {
@@ -266,7 +275,8 @@ class SemanticPass {
                 new:          { type: 'function', exported: true, uname: 'juttle.modules.duration.new',          arg_count: 1 },
                 seconds:      { type: 'function', exported: true, uname: 'juttle.modules.duration.seconds',      arg_count: 1 },
                 toString:     { type: 'function', exported: true, uname: 'juttle.modules.duration.toString',     arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_json_module() {
@@ -276,7 +286,8 @@ class SemanticPass {
             exports: {
                 parse:       { type: 'function', exported: true, uname: 'juttle.modules.json.parse',       arg_count: 1 },
                 stringify:   { type: 'function', exported: true, uname: 'juttle.modules.json.stringify',   arg_count: 1 },
-            }
+            },
+            d: true
         });
     }
     import_juttle_module() {
@@ -286,7 +297,8 @@ class SemanticPass {
             exports: {
                 version: { type: 'const', exported: true, uname: 'juttle.modules.juttle.version' },
                 adapters: { type: 'function', exported: true, uname: 'juttle.modules.juttle.adapters' }
-            }
+            },
+            d: true
         });
     }
     analyze(ast) {
@@ -812,7 +824,8 @@ class SemanticPass {
         this.scope.put(node.localname, {
             type: 'import',
             exported: false,
-            exports: module.exports
+            exports: module.exports,
+            d: true
         });
 
         this.import_path.pop();

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -425,10 +425,10 @@ class SemanticPass {
             }
         }
     }
-    sa_function_call(node, funcInfo) {
+    sa_function_call(node, symbol) {
         var k, args = node.arguments;
-        node.fname = {type: 'function_uname', uname: funcInfo.uname};
-        this.check_arg_count(this.function_name(node), 'function', args.length, funcInfo.arg_count, node.location);
+        node.fname = {type: 'function_uname', uname: symbol.uname};
+        this.check_arg_count(this.function_name(node), 'function', args.length, symbol.arg_count, node.location);
         var d = true;
         if (args) {
             for (k = 0; k < args.length; ++k) {
@@ -958,7 +958,7 @@ class SemanticPass {
     // in the juttle runtime
     //
     sa_reducers(reducers) {
-        var k, op, args, reducerInfo, index;
+        var k, op, args, symbol, index;
         var out = [];
         for (k = 0; k < reducers.length; ++k) {
             //XXX need a uniform way to pass in args... we will do
@@ -968,9 +968,9 @@ class SemanticPass {
             index = reducers[k].index;
 
             if (reducers[k].module) {
-                reducerInfo = this.scope.lookup_module_reducer(reducers[k].module, op);
+                symbol = this.scope.lookup_module_reducer(reducers[k].module, op);
             } else {
-                reducerInfo = is_builtin_reducer(op)
+                symbol = is_builtin_reducer(op)
                     ? this.scope.fake_builtin_reducer_symbol(op)
                     : this.scope.get(op);
             }
@@ -978,7 +978,7 @@ class SemanticPass {
             out.push({
                 index: index,
                 name: op,
-                uname: {type: 'function_uname', uname: reducerInfo.uname},
+                uname: {type: 'function_uname', uname: symbol.uname},
                 arguments: args });
         }
         return out;
@@ -1202,12 +1202,12 @@ class SemanticPass {
         }
     }
     sa_CallExpression(node) {
-        var fname, args, funcInfo, i;
+        var fname, args, symbol, i;
         if (node.callee.type === 'MemberExpression') {
             args = node.arguments;
 
-            funcInfo = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
-            if (funcInfo) {
+            symbol = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
+            if (symbol) {
                 if (this.context !== 'put' && this.context !== 'reduce') {
                     throw errors.compileError('INVALID-REDUCER-CALL', {
                         name: node.callee.object.name + '.' + node.callee.property.value,
@@ -1221,17 +1221,17 @@ class SemanticPass {
                     index: this.index
                 });
                 node.reducer_call_index = this.reducers.length - 1;
-                node.callee.symbol = funcInfo;
+                node.callee.symbol = symbol;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
+                this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
                 node.context = this.context; // needed because reducer calls are different in put vs reduce
                 for (i = 0; i < args.length; ++i) {
                     this.sa_reducer_arg(args[i]);
                 }
                 return;
             } else {
-                funcInfo = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
-                if (funcInfo === undefined) {
+                symbol = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
+                if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
                         thing: 'function',
                         name: node.callee.property.value,
@@ -1239,9 +1239,9 @@ class SemanticPass {
                         location: node.location
                     });
                 }
-                node.callee.symbol = funcInfo;
+                node.callee.symbol = symbol;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.sa_function_call(node, funcInfo);
+                this.sa_function_call(node, symbol);
                 return;
             }
         } else {
@@ -1260,31 +1260,31 @@ class SemanticPass {
             this.reducers.push({name:fname, args:args, index: this.index});
             node.reducer_call_index = this.reducers.length - 1;
             // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
-            funcInfo = is_builtin_reducer(fname)
+            symbol = is_builtin_reducer(fname)
                 ? this.scope.fake_builtin_reducer_symbol(fname)
                 : this.scope.get(fname);
-            this.check_arg_count(this.function_name(node), 'reducer', args.length, funcInfo.arg_count, node.location);
-            node.callee.symbol = funcInfo;
+            this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
+            node.callee.symbol = symbol;
             node.context = this.context; // needed because reducer calls are different in put vs reduce
             for (i = 0; i < args.length; ++i) {
                 this.sa_reducer_arg(args[i]);
             }
         } else {
-            funcInfo = this.scope.get(fname);
-            if (!funcInfo) {
+            symbol = this.scope.get(fname);
+            if (!symbol) {
                 throw errors.compileError('NO-SUCH-FUNCTION', {
                     name: fname,
                     location: node.location
                 });
             }
-            if (funcInfo.type !== 'function') {
+            if (symbol.type !== 'function') {
                 throw errors.compileError('NOT-A-FUNCTION', {
                     name: fname,
                     location: node.location
                 });
             }
-            node.callee.symbol = funcInfo;
-            this.sa_function_call(node, funcInfo);
+            node.callee.symbol = symbol;
+            this.sa_function_call(node, symbol);
         }
     }
     sa_UnaryExpression(node) {
@@ -1382,11 +1382,11 @@ class SemanticPass {
         node.d = d;
     }
     sa_Variable(node) {
-        var varInfo = this.scope.get(node.name);
+        var symbol = this.scope.get(node.name);
 
-        if (varInfo) {
-            node.symbol = varInfo;
-            node.d = varInfo.d;
+        if (symbol) {
+            node.symbol = symbol;
+            node.d = symbol.d;
         } else {
             switch (this.coercion_mode) {
                 case 'string':
@@ -1422,11 +1422,11 @@ class SemanticPass {
         node.d = node.expression.d;
     }
     sa_MemberExpression(node) {
-        var varInfo;
+        var symbol;
         if (this.lhs) {
             if (!node.computed) {
-                varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
-                if (varInfo === undefined) {
+                symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
                         thing: 'variable',
                         name: node.property.value,
@@ -1446,8 +1446,8 @@ class SemanticPass {
             }
         } else {
             if (!node.computed) {
-                varInfo = this.scope.lookup_module_variable(node.object.name, node.property.value);
-                if (varInfo === undefined) {
+                symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
                         thing: 'variable',
                         name: node.property.value,

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -270,7 +270,7 @@ describe('Juttle basic language tests', function() {
         })
         .catch(function(err) {
             expect(err.name).to.equal('CompileError');
-            expect(err.message).to.match(/variable .* not exported by/);
+            expect(err.message).to.match(/.* is not defined/);
         });
     });
 


### PR DESCRIPTION
In this part, `sa_MemberExpression` is cleaned up so that future change to support dynamic non-computed member expressions could be done easily. As a nice side effect, error messages in case of invalid module entity references (e.g. `m.c` when there is no module `m` imported) are improved.

Note that both lvalue and rvalue branches are affected by the changes (they are still kept identical). Splitting them in #488 was apparently slightly premature, but I realized that too late and didn’t want to go back and do a big rebase at the time.

Part of work on #419.