### PR TITLE
fix http error handling

### DIFF
--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -271,8 +271,10 @@ class ReadHTTP extends AdapterRead {
                     res.on('end', function() {
                         var message = 'StatusCodeError: ' + res.statusCode +
                                       ' - ' + body.join('');
-                        reject(new errors.runtimeError('INTERNAL-ERROR', {
-                            error: message
+                        reject(new errors.runtimeError('HTTP-ERROR', {
+                            status: res.statusCode,
+                            message: res.statusMessage,
+                            body: message
                         }));
                     });
                 } else {

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -124,5 +124,6 @@
   "OPTION-SHOULD-BE-POSITIVE-INTEGER": "option {option} should be a positive integer",
   "OPTION-VALUE-EXCEEDED": "option {option} exceeded limit of {value}{extra}",
   "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
-  "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context."
+  "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context.",
+  "HTTP-ERROR": "HTTP request failed with {status}: {message}"
 }

--- a/test/adapters/http/read.spec.js
+++ b/test/adapters/http/read.spec.js
@@ -185,15 +185,19 @@ describe('HTTP read tests', function() {
         });
     });
 
-    _.each([400, 500], function(status) {
-        it('fails when response has status code of ' + status, function() {
+    _.each([
+        { status: 400, message: 'Bad Request' },
+        { status: 500, message: 'Internal Server Error' },
+        { status: 404, message: 'Not Found' }
+    ], function(response) {
+        it('fails when response has status code of ' + response.status, function() {
             return check_juttle({
-                program: 'read http -url "' + server.url + '/status/' + status + '"'
+                program: 'read http -url "' + server.url + '/status/' + response.status + '"'
             })
             .then((result) => {
                 expect(result.errors.length).equal(1);
                 expect(result.warnings).deep.equals([]);
-                expect(result.errors[0]).to.contain('internal error StatusCodeError: ' + status);
+                expect(result.errors[0]).to.contain(`HTTP request failed with ${response.status}: ${response.message}`);
             });
         });
     });


### PR DESCRIPTION
fixes #465

move the response to a `.body` field and placing the HTTP status message
into the actual `error.message` will make the UI's that display this
error not have to deal with large or ugly looking response payloads.