### PR TITLE
remove unnecessary setting of table default

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -152,7 +152,7 @@ function perform_compile(options) {
     var compile_options = {
         stage: options.stage,
         moduleResolver: options.resolver,
-        fg_processors: [check_runaway, implicit_views(config.implicit_view || 'table'), optimize],
+        fg_processors: [check_runaway, implicit_views(config.implicit_view), optimize],
         inputs: options.inputs,
         stripLocations: options.stripLocations
     };


### PR DESCRIPTION
Caught this through code inspection but we're already setting the default for an implicit view to be `table`  [here](https://github.com/juttle/juttle/blob/master/lib/compiler/flowgraph/implicit_views.js#L9) so no need for this code.