### PR TITLE
Make the “.” operator work properly in rvalues (part 3)

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1456,17 +1456,26 @@ class SemanticPass {
             }
         } else {
             if (!node.computed) {
-                symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
-                if (symbol === undefined) {
-                    throw errors.compileError('NOT-EXPORTED', {
-                        thing: 'variable',
-                        name: node.property.value,
-                        module: node.object.name,
-                        location: node.location
-                    });
-                }
+                // We are processing an expression like "foo.bar". If "foo" is a
+                // module, the expression is *static* and in later stage, it
+                // will be compiled as a reference to exported module entity
+                // "bar" (which has to exist). If "foo" is not a module, the
+                // expression is *dynamic* and it will be compiled in the same
+                // way as "foo['bar']". The compiler distinguishes these cases
+                // by presence of node.symbol.
+                if (node.object.symbol && node.object.symbol.type === 'import') {
+                    symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                    if (symbol === undefined) {
+                        throw errors.compileError('NOT-EXPORTED', {
+                            thing: 'variable',
+                            name: node.property.value,
+                            module: node.object.name,
+                            location: node.location
+                        });
+                    }
 
-                node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                    node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                }
             }
         }
 

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-entities.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-entities.spec.md
@@ -1,0 +1,97 @@
+# The `.` operator (in rvalue, on entities)
+
+## Returns correct result when used on a constant
+
+### Juttle
+
+    const c = { a: 1, b: 2, c: 3 };
+
+    emit -from :0: -limit 1 | put result = c.b | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 2 }
+
+## Returns correct result when used on a variable
+
+### Juttle
+
+    function f() {
+      var v = { a: 1, b: 2, c: 3 };
+
+      return v.b;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 2 }
+
+## Returns correct result when used on a point field
+
+### Juttle
+
+    emit -from :0: -limit 1 | put f = { a: 1, b: 2, c: 3 } | put result = f.b | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", f: { a: 1, b: 2, c: 3 }, result: 2 }
+
+## Returns a correct result when used on a module
+
+### Module `m`
+
+    export const c = 5;
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from :0: -limit 1 | put result = m.c | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 5 }
+
+## Produces an error when used on a function
+
+### Juttle
+
+    function f() {
+    }
+
+    emit -from :0: -limit 1 | put result = f.b | view result
+
+### Errors
+
+  * CompileError: Cannot use a function as a variable
+
+## Produces an error when used on a reducer
+
+### Juttle
+
+    reducer r() {
+      function update() { }
+      function result() { }
+    }
+
+    emit -from :0: -limit 1 | put result = r.b | view result
+
+### Errors
+
+  * CompileError: Cannot use a reducer as a variable
+
+## Produces an error when used on a subgraph
+
+### Juttle
+
+    sub s() {
+      pass
+    }
+
+    emit -from :0: -limit 1 | put result = s.b | view result
+
+### Errors
+
+  * CompileError: Cannot use a subgraph as a variable

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
@@ -1,0 +1,71 @@
+# The `.` operator (in rvalue, on modules)
+
+## Returns correct result when used on a module, accessing a constant
+
+### Module `m`
+
+    export const c = 5;
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from :0: -limit 1 | put result = m.c | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 5 }
+
+## Produces an error when used on a module, accessing a function
+
+### Module `m`
+
+    export function f() {
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from :0: -limit 1 | put result = m.f | view result
+
+### Errors
+
+  * CompileError: variable 'f' is not exported by module m
+
+## Produces an error when used on a module, accessing a reducer
+
+### Module `m`
+
+    export reducer r() {
+      function update() { }
+      function result() { }
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from :0: -limit 1 | put result = m.r | view result
+
+### Errors
+
+  * CompileError: variable 'r' is not exported by module m
+
+## Produces an error when used on a module, accessing a subgraph
+
+### Module `m`
+
+    export sub s() {
+      pass
+    }
+
+### Juttle
+
+    import 'm' as m;
+
+    emit -from :0: -limit 1 | put result = m.s | view result
+
+### Errors
+
+  * CompileError: variable 's' is not exported by module m

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-values.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-values.spec.md
@@ -1,0 +1,28 @@
+# The `.` operator (in rvalue, on values)
+
+## Returns correct result when used on an `Object`
+
+### Juttle
+
+    emit -from :0: -limit 1
+    | put in1 = { a: 1, b: 2, c: 3 }.a
+    | put in2 = { a: 1, b: 2, c: 3 }.b
+    | put in3 = { a: 1, b: 2, c: 3 }.c
+    | put out = { a: 1, b: 2, c: 3 }.d
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", in1: 1, in2: 2, in3: 3, out: null }
+
+## Produces an error when used on a value of invalid type
+
+### Juttle
+
+    emit -from :0: -limit 1
+    | put result = null.b
+    | view result
+
+### Errors
+
+  * RuntimeError: Invalid operand types for "[]": null and string (b).


### PR DESCRIPTION
This commit adds tests that specify behavior of the `.` operator in rvalues and adjusts the implementation to match. Specifically, it allows using the `.` operator not only to access entities exported from
modules, but also properties of objects.

Part of work on #419.