### PR TITLE
Allow *"field" syntax in static filter expressions

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1022,10 +1022,22 @@ PostfixOperator
 
 UnaryExpression
     = operator:UnaryOperator __ argument:UnaryExpression {
-          return createNode('UnaryExpression', location(), {
-              operator: operator,
-              argument: argument
-          });
+          // Handle expressions like *"field" as if they were simple field
+          // references. This is mainly to permit their use in filters (where
+          // the "*" operator generally isn't allowed), which provides a way to
+          // escape field names containing special characters.
+          //
+          // See #483 for details.
+          if (argument.type === 'StringLiteral') {
+              return createNode('Field', location(), {
+                  name: argument.value
+              });
+          } else {
+              return createNode('UnaryExpression', location(), {
+                  operator: operator,
+                  argument: argument
+              });
+          }
       }
     / PostfixExpression
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/expression-filter-terms.spec.md
@@ -12,6 +12,18 @@ Regression test for PROD-6797.
 
     { time: "1970-01-01T00:00:00.000Z", a: 5 }
 
+## Allows using the `*"field"` syntax in static filter expressions
+
+### Juttle
+
+    read stochastic -source 'cdn' -nhosts 3 -from :0: -to :60: *'host' = 'sea.0'
+    | reduce count() by host
+    | view result
+
+### Output
+
+    { host: "sea.0", count: 1388 }
+
 ## Allows using the `*compile-expression` syntax
 
 ### Juttle

--- a/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
+++ b/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
@@ -31,9 +31,9 @@ multiplication operator or a field dereference operator.
     | reduce count()
     | view result
 
-### Errors
+### Output
 
-  * Invalid filter term. Valid forms are: "field == value", "value == field".
+    { count: 62 }
 
 ## Parses toplevel `*` as multiplication with whitespace before and whitespace after
 


### PR DESCRIPTION
Without this syntax, there was no way to enter field names containing special characters.

The implementation is done directly in parser and it converts the `*"field"` syntax directly to `Field` nodes (instead of `UnaryExpression` nodes). This makes the syntax transparent for any filter processing code and ensures only string literal arguments of `*` are allowed.

Fixes #483.