### PR TITLE
ast-visitor handle adapters

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -90,6 +90,7 @@ var NODE_CHILDREN = {
     ErrorStatement:           ['message'],
 
     /* Program Elements */
+    Identifier:               [],
     FunctionDef:              ['args', 'elements'],
     ReducerDef:               ['args', 'elements'],
     SubDef:                   ['args', 'elements'],

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -272,12 +272,11 @@ IdentifierName 'identifier'
           return start + parts.join('');
       }
 
-IdentifierNameWithPos
+Identifier
     = name:IdentifierName {
-          return {
+          return createNode('Identifier', location(), {
               name: name,
-              location: locationWithFilename(location())
-          };
+          });
       }
 
 IdentifierStart
@@ -780,7 +779,7 @@ Variable
       }
 
 FieldReferenceShortcut
-    = '#' name:IdentifierNameWithPos {
+    = '#' name:Identifier {
           return createNode('Field', location(), {
               name: name.name
           });
@@ -900,7 +899,7 @@ CoreExpression
                     location: locationWithFilename(location())
                 };
             }
-          / __ '.' __ property:IdentifierNameWithPos {
+          / __ '.' __ property:Identifier {
                 return {
                     property: createNode('StringLiteral', property.location, {
                         value: property.name
@@ -928,7 +927,7 @@ CallExpression
                     computed: true
                 });
             }
-          / __ '.' __ property:IdentifierNameWithPos {
+          / __ '.' __ property:Identifier {
                 return createNode('MemberExpressionProperty', location(), {
                     property: createNode('StringLiteral', property.location, {
                         value: property.name
@@ -955,7 +954,7 @@ FunctionCall
       }
 
 FunctionName
-    = object:(IdentifierNameWithPos __ '.' __)? id:IdentifierNameWithPos {
+    = object:(Identifier __ '.' __)? id:Identifier {
           var op =  createNode('Variable', id.location, {
               name: id.name
           });
@@ -996,7 +995,7 @@ RealLeftHandSideExpression
 
 // Coerce LHS to a Field Reference.
 RealCoercedLeftHandSideExpression
-    = name:IdentifierNameWithPos {
+    = name:Identifier {
           return createNode('Field', location(), {
               name: name.name
           });
@@ -1590,7 +1589,7 @@ PutProc
       }
 
 ReadProc
-    = ACProcStart ReadToken ACProcEnd __ adapter:IdentifierNameWithPos options:ProcOptions __ filter:FilterExpressionToplevel? {
+    = ACProcStart ReadToken ACProcEnd __ adapter:Identifier options:ProcOptions __ filter:FilterExpressionToplevel? {
           return createNode('ReadProc', location(), {
               name: 'read',
               adapter: adapter,
@@ -1653,7 +1652,7 @@ UniqProc
       }
 
 WriteProc
-  = ACProcStart WriteToken ACProcEnd __ adapter:IdentifierNameWithPos options:ProcOptions {
+  = ACProcStart WriteToken ACProcEnd __ adapter:Identifier options:ProcOptions {
         return createNode('WriteProc', location(), {
             name: 'write',
             adapter: adapter,

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -267,9 +267,6 @@ MultiLineCommentNoLineTerminator
 SingleLineComment
     = '//' (!LineTerminator SourceCharacter)*
 
-Identifier 'identifier'
-    = name:IdentifierName { return name; }
-
 IdentifierName 'identifier'
     = start:IdentifierStart parts:IdentifierPart* {
           return start + parts.join('');
@@ -776,7 +773,7 @@ PrimaryExpression
 
 Variable
     = FieldReferenceShortcut
-    / name:Identifier {
+    / name:IdentifierName {
           return createNode('Variable', location(), {
               name: name
           });
@@ -1096,7 +1093,7 @@ AdditiveExpression
 //
 AdditiveExpressionToplevel
     = head:MultiplicativeExpressionToplevel
-      tail:(!(___ '-' id:Identifier) __ op:AdditiveOperator __ expr:MultiplicativeExpressionToplevel)* {
+      tail:(!(___ '-' id:IdentifierName) __ op:AdditiveOperator __ expr:MultiplicativeExpressionToplevel)* {
           return buildBinaryExpression(head, tail.map(function(e) { return e.slice(1); }));
       }
 
@@ -1206,7 +1203,7 @@ BitwiseORExpression
 //
 BitwiseORExpressionToplevel
     = head:BitwiseXORExpressionToplevel
-      tail:(__ BitwiseOROperator __ !Identifier BitwiseXORExpressionToplevel)* {
+      tail:(__ BitwiseOROperator __ !IdentifierName BitwiseXORExpressionToplevel)* {
           return buildBinaryExpression(head, tail.map(function(e) { return e.slice(0, 3).concat(e.slice(4)); }));
       }
 
@@ -1752,7 +1749,7 @@ ProcOption
      }
 
 ProcOptionName 'option'
-    = ACOptionNameStart '-' id:Identifier ACOptionNameEnd { return id; }
+    = ACOptionNameStart '-' id:IdentifierName ACOptionNameEnd { return id; }
     // The following line ensures that a lone "-" gets marked up as an
     // autocomplete region even when it is syntactically not an option.
     / ACOptionNameStart '-' ACOptionNameEnd Fail
@@ -1792,7 +1789,7 @@ SortByList
       }
 
 SortFieldList
-    = head:(ConditionalExpressionToplevel (__ '-' Identifier)?) tail:( __ ',' __ ConditionalExpressionToplevel __ ('-' Identifier)?)* {
+    = head:(ConditionalExpressionToplevel (__ '-' IdentifierName)?) tail:( __ ',' __ ConditionalExpressionToplevel __ ('-' IdentifierName)?)* {
           var element = head[0];
           var direction = head[1] ? (head[1][2] || '') : '';
           var result = [
@@ -1832,7 +1829,7 @@ ReduceItem
       }
 
 View
-    = ACProcStart ViewToken ACProcEnd __ name:Identifier options:ViewOption* {
+    = ACProcStart ViewToken ACProcEnd __ name:IdentifierName options:ViewOption* {
           return createNode('View', location(), {
               name: name,
               options: options
@@ -1853,7 +1850,7 @@ ViewOption
     }
 
 ViewOptionName 'option'
-    = ACOptionNameStart '-' start:Identifier parts:('.' Identifier)* ACOptionNameEnd {
+    = ACOptionNameStart '-' start:IdentifierName parts:('.' IdentifierName)* ACOptionNameEnd {
           var result = start;
           for (var i=0; i<parts.length; i++) {
               result += parts[i][0];
@@ -1873,7 +1870,7 @@ InputOption
         });
     }
 
-InputOptionName = start:Identifier parts:('.' Identifier)* {
+InputOptionName = start:IdentifierName parts:('.' IdentifierName)* {
     var result = start;
     for (var i=0; i<parts.length; i++) {
         result += parts[i][0];
@@ -1964,7 +1961,7 @@ ConstDecls
       }
 
 ConstDecl
-    = name:Identifier value:(__ Initialiser)? {
+    = name:IdentifierName value:(__ Initialiser)? {
           return createNode('ConstDecl', location(), {
               name:  name,
               expr: extractOptional(value, 1)
@@ -1984,7 +1981,7 @@ VarDecls
       }
 
 VarDecl
-    = name:Identifier value:(__ Initialiser)? {
+    = name:IdentifierName value:(__ Initialiser)? {
           return createNode('VarDecl', location(), {
               name:  name,
               expr: extractOptional(value, 1)
@@ -1992,7 +1989,7 @@ VarDecl
       }
 
 InputStatement
-    = exp:(ExportToken __)? InputToken __ name:Identifier __ ':' __ input_name:Identifier options:InputOption* __ ';' {
+    = exp:(ExportToken __)? InputToken __ name:IdentifierName __ ':' __ input_name:IdentifierName options:InputOption* __ ';' {
           return createNode('InputStatement', location(), {
               export: exp ? true : false,
               name: name,
@@ -2005,7 +2002,7 @@ Initialiser
     = '=' !('=' / '~') __ expression:AssignmentExpression { return expression; }
 
 ImportStatement
-    = ImportToken __ modulename:StringLiteral __ AsToken __ localname:Identifier __ ';' {
+    = ImportToken __ modulename:StringLiteral __ AsToken __ localname:IdentifierName __ ';' {
           return createNode('ImportStatement', location(), {
               modulename: modulename,
               localname: localname,
@@ -2044,7 +2041,7 @@ ErrorStatement
 // ----- Program Elements -----
 
 FunctionDef
-    = exp:(ExportToken __)? FunctionToken __ name:Identifier __ '(' __ args:(FormalArgs __)? __ ')' __
+    = exp:(ExportToken __)? FunctionToken __ name:IdentifierName __ '(' __ args:(FormalArgs __)? __ ')' __
       '{' __ elements:(FunctionStatements __)? '}' {
           return createNode('FunctionDef', location(), {
               name:name,
@@ -2055,7 +2052,7 @@ FunctionDef
       }
 
 ReducerDef
-    = exp:(ExportToken __)? ReducerToken __ name:Identifier __
+    = exp:(ExportToken __)? ReducerToken __ name:IdentifierName __
       '('__ args:(FormalArgs __)? ')' __
       '{' __ elements:(FunctionStatements __)? '}' {
           return createNode('ReducerDef', location(), {
@@ -2067,7 +2064,7 @@ ReducerDef
       }
 
 SubDef
-    = exp:(ExportToken __)? SubToken __ id:Identifier __ '('__ formals:(FormalArgs __)? ')'
+    = exp:(ExportToken __)? SubToken __ id:IdentifierName __ '('__ formals:(FormalArgs __)? ')'
           __ '{' __ program:Program __ '}' {
 
           var args;
@@ -2091,7 +2088,7 @@ FormalArgs
       }
 
 FormalArg
-    = name:Identifier default_:(__ Initialiser)? {
+    = name:IdentifierName default_:(__ Initialiser)? {
           return createNode('FormalArg', location(), {
               name: name,
               default: extractOptional(default_, 1)


### PR DESCRIPTION
Update the grammar so that it generates AST nodes with `type: 'Identifier'` wherever we generate identifiers that contain locations.

This involved replacing instances of the `Identifier` rule with the functionally equivalent `IdentifierName`, and changing `IdentifierNameWithPos` to be the new `Identifier` which creates the appropriate AST nodes.

Fixes #507