### PR TITLE
read.js - emit initial tick immediately if from is specified

### DIFF
--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -72,7 +72,14 @@ class Read extends source {
     // Set the initial time parameters for read from the adapter and
     // schedule the initial run.
     start() {
-        // First tell the adapter to kick off the process of reading.
+        // Emit the initial tick if we know the beginning of the time range.
+        // This allows fanins down the flowraph to emit all points before
+        // `from` of this read.
+        if (this.from) {
+            this.emit_tick(this.from);
+        }
+
+        // Tell the adapter to kick off the process of reading.
         this.adapter.start();
 
         // Then check if the adapter wants pseudo-live behavior for reading.

--- a/test/runtime/adapter-read-timeseries.spec.js
+++ b/test/runtime/adapter-read-timeseries.spec.js
@@ -98,6 +98,7 @@ describe('read testTimeseries', function () {
         }, 4000)
         .then(function(result) {
             var expected = [
+                { tick: true, dt: '00:00:00.000'},
                 { count: 0, dtProg: 0, dtReal: 2 },
                 { tick: true, dt: '00:00:01.000'},
                 { count: 1, dtProg: 2, dtReal: 2 },


### PR DESCRIPTION
If there are parallel streams fed into fanin, the initial tick allows
fanin to start emitting points from a faster source earlier - it doesn't
have to wait until first points arrive.