### PR TITLE
values.spec.js - fix incorrect bind in "invalid comparison" test

### DIFF
--- a/lib/runtime/errors.js
+++ b/lib/runtime/errors.js
@@ -63,16 +63,6 @@ var errors = {
 
         return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
     },
-
-    typeErrorIncomparable: function(left, right) {
-        var message = 'Types '
-            + values.typeDisplayName(values.typeOf(left)) + valueString(left)
-            + ' and '
-            + values.typeDisplayName(values.typeOf(right)) + valueString(right)
-            + ' cannot be compared.';
-
-        return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
-    }
 };
 
 module.exports = errors;

--- a/lib/runtime/values.js
+++ b/lib/runtime/values.js
@@ -8,6 +8,19 @@ var Filter = require('./types/filter');
 var JuttleMoment = require('../runtime/types/juttle-moment');
 var errors = require('../errors');
 
+function typeErrorIncomparable(left, right) {
+    var leftStr = values.isNull(left) ? '' : ' (' + values.toString(left) + ')';
+    var rightStr = values.isNull(right) ? '' : ' (' + values.toString(right) + ')';
+
+    var message = 'Types '
+        + values.typeDisplayName(values.typeOf(left)) + leftStr
+        + ' and '
+        + values.typeDisplayName(values.typeOf(right)) + rightStr
+        + ' cannot be compared.';
+
+    return errors.runtimeError('TYPE-ERROR', { message: message });
+}
+
 var TYPE_DISPLAY_NAMES = {
     Null:     'null',
     Boolean:  'boolean',
@@ -252,7 +265,7 @@ var values = {
         var typeB = this.typeOf(b);
 
         if (typeA !== typeB) {
-            throw errors.typeErrorIncomparable(a, b);
+            throw typeErrorIncomparable(a, b);
         }
 
         switch (typeA) {
@@ -268,7 +281,7 @@ var values = {
                 return compareArrays(a, b);
 
             default:
-                throw errors.typeErrorIncomparable(a, b);
+                throw typeErrorIncomparable(a, b);
         }
 
     },

--- a/test/runtime/values.spec.js
+++ b/test/runtime/values.spec.js
@@ -87,9 +87,8 @@ describe('Values tests', function () {
                     { left: 1, right: [] },
                     { left: [], right: true }
                 ];
-
                 _.each(tests, function(test) {
-                    expect(values.compare.bind(test.left, test.right)).to.throw.error;
+                    expect(values.compare.bind(values, test.left, test.right)).to.throw(/cannot be compared/);
                 });
             });
         });


### PR DESCRIPTION
The test verifying that typeErrorIncomparable was thrown for comparison
of two incomparable value types wasn't checking for an actual error
string.

This masked an incorrect bind and another problem with cyclical
dependenncy between `lib/runtime/errors.js` and `lib/runtime/values.js`.

Fix the bind and break the cycle by moving the error helper into
`values.js` - it is not used anywhere else.