### PR TITLE
Refactor sa_CallExpression

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1263,7 +1263,11 @@ class SemanticPass {
         }
 
         args = node.arguments;
-        if (is_builtin_reducer(fname) || (this.scope.get(fname) && this.scope.get(fname).type === 'reducer')) {
+        // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
+        symbol = is_builtin_reducer(fname)
+            ? this.scope.fake_builtin_reducer_symbol(fname)
+            : this.scope.get(fname);
+        if (symbol && symbol.type === 'reducer') {
             if (this.context !== 'put' && this.context !== 'reduce') {
                 throw errors.compileError('INVALID-REDUCER-CALL', {
                     name: fname,
@@ -1272,10 +1276,6 @@ class SemanticPass {
             }
             this.reducers.push({name:fname, args:args, index: this.index});
             node.reducer_call_index = this.reducers.length - 1;
-            // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
-            symbol = is_builtin_reducer(fname)
-                ? this.scope.fake_builtin_reducer_symbol(fname)
-                : this.scope.get(fname);
             this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
             node.callee.symbol = symbol;
             node.context = this.context; // needed because reducer calls are different in put vs reduce
@@ -1283,7 +1283,6 @@ class SemanticPass {
                 this.sa_reducer_arg(args[i]);
             }
         } else {
-            symbol = this.scope.get(fname);
             if (!symbol) {
                 throw errors.compileError('NO-SUCH-FUNCTION', {
                     name: fname,

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -457,6 +457,22 @@ class SemanticPass {
             node.d = false;
         }
     }
+    sa_reducer_call(node, symbol) {
+        var i, args = node.arguments;
+        if (this.context !== 'put' && this.context !== 'reduce') {
+            throw errors.compileError('INVALID-REDUCER-CALL', {
+                name: this.function_name(node),
+                location: node.location
+            });
+        }
+        this.reducers.push({name:this.function_name(node), symbol:symbol, args:args, index: this.index});
+        node.reducer_call_index = this.reducers.length - 1;
+        this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
+        node.context = this.context; // needed because reducer calls are different in put vs reduce
+        for (i = 0; i < args.length; ++i) {
+            this.sa_reducer_arg(args[i]);
+        }
+    }
     can_export() {
         return (this.scope.type === 'module' || this.scope.type === 'main');
     }
@@ -1208,32 +1224,13 @@ class SemanticPass {
         }
     }
     sa_CallExpression(node) {
-        var fname, args, symbol, i;
+        var fname, symbol;
         if (node.callee.type === 'MemberExpression') {
-            args = node.arguments;
-
             symbol = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
             if (symbol) {
-                if (this.context !== 'put' && this.context !== 'reduce') {
-                    throw errors.compileError('INVALID-REDUCER-CALL', {
-                        name: this.function_name(node),
-                        location: node.location
-                    });
-                }
-                this.reducers.push({
-                    name: this.function_name(node),
-                    symbol: symbol,
-                    args:args,
-                    index: this.index
-                });
-                node.reducer_call_index = this.reducers.length - 1;
                 node.callee.symbol = symbol;
                 node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
-                node.context = this.context; // needed because reducer calls are different in put vs reduce
-                for (i = 0; i < args.length; ++i) {
-                    this.sa_reducer_arg(args[i]);
-                }
+                this.sa_reducer_call(node, symbol);
                 return;
             } else {
                 symbol = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
@@ -1255,26 +1252,13 @@ class SemanticPass {
             fname = node.callee.name;
         }
 
-        args = node.arguments;
         // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
         symbol = is_builtin_reducer(fname)
             ? this.scope.fake_builtin_reducer_symbol(fname)
             : this.scope.get(fname);
         if (symbol && symbol.type === 'reducer') {
-            if (this.context !== 'put' && this.context !== 'reduce') {
-                throw errors.compileError('INVALID-REDUCER-CALL', {
-                    name: this.function_name(node),
-                    location: node.location
-                });
-            }
-            this.reducers.push({name:this.function_name(node), symbol:symbol, args:args, index: this.index});
-            node.reducer_call_index = this.reducers.length - 1;
-            this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
             node.callee.symbol = symbol;
-            node.context = this.context; // needed because reducer calls are different in put vs reduce
-            for (i = 0; i < args.length; ++i) {
-                this.sa_reducer_arg(args[i]);
-            }
+            this.sa_reducer_call(node, symbol);
         } else {
             if (!symbol) {
                 throw errors.compileError('NO-SUCH-FUNCTION', {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1216,7 +1216,7 @@ class SemanticPass {
             if (symbol) {
                 if (this.context !== 'put' && this.context !== 'reduce') {
                     throw errors.compileError('INVALID-REDUCER-CALL', {
-                        name: node.callee.object.name + '.' + node.callee.property.value,
+                        name: this.function_name(node),
                         location: node.location
                     });
                 }
@@ -1263,7 +1263,7 @@ class SemanticPass {
         if (symbol && symbol.type === 'reducer') {
             if (this.context !== 'put' && this.context !== 'reduce') {
                 throw errors.compileError('INVALID-REDUCER-CALL', {
-                    name: fname,
+                    name: this.function_name(node),
                     location: node.location
                 });
             }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -979,14 +979,7 @@ class SemanticPass {
             op = reducers[k].name;
             args = reducers[k].args || [];
             index = reducers[k].index;
-
-            if (reducers[k].module) {
-                symbol = this.scope.lookup_module_reducer(reducers[k].module, op);
-            } else {
-                symbol = is_builtin_reducer(op)
-                    ? this.scope.fake_builtin_reducer_symbol(op)
-                    : this.scope.get(op);
-            }
+            symbol = reducers[k].symbol;
 
             out.push({
                 index: index,
@@ -1228,8 +1221,8 @@ class SemanticPass {
                     });
                 }
                 this.reducers.push({
-                    module: node.callee.object.name,
-                    name:node.callee.property.value,
+                    name: this.function_name(node),
+                    symbol: symbol,
                     args:args,
                     index: this.index
                 });
@@ -1274,7 +1267,7 @@ class SemanticPass {
                     location: node.location
                 });
             }
-            this.reducers.push({name:fname, args:args, index: this.index});
+            this.reducers.push({name:this.function_name(node), symbol:symbol, args:args, index: this.index});
             node.reducer_call_index = this.reducers.length - 1;
             this.check_arg_count(this.function_name(node), 'reducer', args.length, symbol.arg_count, node.location);
             node.callee.symbol = symbol;


### PR DESCRIPTION
Refactor `sa_CallExpression` in order to eliminate duplication and to prepare for moving bulk of the symbol-manipulating an checking code to `sa_Variable` and `sa_MemberExpression`.

Part of work on #419.