### PR TITLE
Deactivate program after running it

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -202,6 +202,9 @@ function perform_run(options) {
         })
         .then(function() {
             program.events.off();
+        })
+        .then(function() {
+            program.deactivate();
         });
     });
 }

--- a/test/adapters/http/read.spec.js
+++ b/test/adapters/http/read.spec.js
@@ -304,8 +304,9 @@ describe('HTTP read tests', function() {
 
     it('can follow the link header when told to', function() {
         return check_juttle({
-            program: `read http -url "${server.url}/linked" -followLinkHeader true`
-        }, 250)
+            program: `read http -url "${server.url}/linked" -followLinkHeader true`,
+            deactivateAfter: 250
+        })
         .then((result) => {
             expect(result.errors).to.deep.equal([]);
             expect(result.warnings).to.deep.equal([]);
@@ -324,8 +325,9 @@ describe('HTTP read tests', function() {
             program: `read http -url "${server.url}/pageByRecord?limit=2" ` +
                                 '-pageParam "offset" ' +
                                 '-pageUnit "record" ' +
-                                '-pageStart 0'
-        }, 250)
+                                '-pageStart 0',
+            deactivateAfter: 250
+        })
         .then((result) => {
             expect(result.errors).to.deep.equal([]);
             expect(result.warnings).to.deep.equal([]);
@@ -344,8 +346,9 @@ describe('HTTP read tests', function() {
             program: `read http -url "${server.url}/pageByRequest" ` +
                                 '-pageParam "page" ' +
                                 '-pageUnit "request" ' +
-                                '-pageStart 1'
-        }, 250)
+                                '-pageStart 1',
+            deactivateAfter: 250
+        })
         .then((result) => {
             expect(result.errors).to.deep.equal([]);
             expect(result.warnings).to.deep.equal([]);

--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -20,7 +20,7 @@ describe('read http_server', function() {
     });
 
     it('ingests simple json array', function() {
-        var programFinish, program;
+        var programFinish;
         var body = [
             { 'name': 'ted', 'age': 53, 'weight': 100},
             { 'name': 'ted', 'age': 53, 'weight': 100}
@@ -30,7 +30,6 @@ describe('read http_server', function() {
             program: 'read http_server -port ' + port
         })
         .then(function(prog) {
-            program = prog;
             programFinish = run_juttle(prog);
 
             return request({
@@ -41,7 +40,6 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
-            program.deactivate();
             return programFinish;
         })
         .then(function(result) {
@@ -72,8 +70,6 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
-
-            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -87,10 +83,10 @@ describe('read http_server', function() {
 
         return compile_juttle({
             program: 'read http_server -every :100ms: -port ' + port
-        }, 500)
+        })
         .then(function(prog) {
             program = prog;
-            programFinish = run_juttle(program);
+            programFinish = run_juttle(program, { deactivateAfter: 1000 });
         })
         // Wait a while before posting the data
         .delay(500)
@@ -107,8 +103,6 @@ describe('read http_server', function() {
         .delay(50)
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
-
-            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -137,8 +131,6 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
-
-            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -167,7 +159,6 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
-            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -196,7 +187,6 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
-            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -239,8 +229,6 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(415);
-
-            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -259,7 +247,7 @@ describe('read http_server', function() {
         })
         .then(function(prog) {
             program = prog;
-            finish = run_juttle(program);
+            finish = run_juttle(program, { deactivateAfter: 50 });
 
             return request({
                 uri: 'http://localhost:' + port,
@@ -274,8 +262,6 @@ describe('read http_server', function() {
         .delay(50)
         .then(function(res) {
             expect(res.statusCode).to.equal(400);
-
-            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -312,7 +298,6 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
-            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -340,8 +325,6 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(404);
-
-            program.deactivate();
             return finish;
         });
     });

--- a/test/adapters/stochastic.spec.js
+++ b/test/adapters/stochastic.spec.js
@@ -379,8 +379,8 @@ describe('stochastic -source "logs"', function() {
             program: 'read stochastic -to :end: -source "cdn" -every :1s: ' +
                 '| reduce -every :1s: count()' +
                 '| view result',
-
-        }, 2000).then(function(res) {
+            deactivateAfter: 2000
+        }).then(function(res) {
             expect(res.errors).to.have.length(0);
             expect(res.warnings).to.have.length(0);
             _.each(res.sinks.result, function(point) {

--- a/test/compiler/flowgraph/check_runaway.spec.js
+++ b/test/compiler/flowgraph/check_runaway.spec.js
@@ -8,8 +8,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read', () => {
         return check_juttle({
-            program: 'read stochastic -to :end:'
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end:',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -19,7 +20,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program from a live read to a tail 1', () => {
         return check_juttle({
             program: 'read stochastic -to :end: | tail 1 '
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -31,7 +32,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program from a superquery read to a tail 1', () => {
         return check_juttle({
             program: 'read stochastic -from :0: -to :end: | tail 1 '
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -42,8 +43,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read with batch to a tail 1', () => {
         return check_juttle({
-            program: 'read stochastic -to :end: | batch -every :1s: | tail 1 '
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end: | batch -every :1s: | tail 1 ',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -53,7 +55,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program from a live read to sort', () => {
         return check_juttle({
             program: 'read stochastic -to :end: | sort field'
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -65,7 +67,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program from a superquery read to sort', () => {
         return check_juttle({
             program: 'read stochastic -from :0: -to :end: | sort field'
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -76,8 +78,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read with batch to sort', () => {
         return check_juttle({
-            program: 'read stochastic -to :end: | put field=count() | batch -every :1s: | sort field '
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end: | put field=count() | batch -every :1s: | sort field ',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -86,8 +89,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read with reduce -every', () => {
         return check_juttle({
-            program: 'read stochastic -to :end: | reduce -every :1s: count()'
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end: | reduce -every :1s: count()',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -96,8 +100,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read with batch to reduce', () => {
         return check_juttle({
-            program: 'read stochastic -to :end: | batch :1s: | reduce count() '
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end: | batch :1s: | reduce count() ',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -106,8 +111,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a historical read to reduce', () => {
         return check_juttle({
-            program: 'read stochastic -to :now: | reduce count() '
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :now: | reduce count() ',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);
@@ -117,7 +123,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program when there are multiple read sources', () => {
         return check_juttle({
             program: 'read stochastic -to :end: | reduce count() | view results1; read stochastic -last :1m: | reduce count() | view results2'
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -129,7 +135,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program when there are multiple levels of procs used', () => {
         return check_juttle({
             program: 'read stochastic -to :end: | put a = count() | filter foo="bar" | reduce count() | put a = count()'
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -141,7 +147,7 @@ describe('Runaway program detection', function() {
     it('detects a runaway program when there are multiple reducers and one without -every', () => {
         return check_juttle({
             program: 'read stochastic -to :end: | reduce -every :1s: count() | reduce max(m)'
-        }) // stop the live program after 100ms
+        })
         .then((results) => {
             throw Error('runaway detector failed to catch');
         })
@@ -152,8 +158,9 @@ describe('Runaway program detection', function() {
 
     it('does not detect a runaway program from a live read to head', () => {
         return check_juttle({
-            program: 'read stochastic -to :end: | head 1'
-        }, 50) // stop the live program after 100ms
+            program: 'read stochastic -to :end: | head 1',
+            deactivateAfter: 50 // stop the live program after 50ms
+        })
         .then((results) => {
             expect(results.errors).to.deep.equal([]);
             expect(results.warnings).to.deep.equal([]);

--- a/test/runtime/adapter-read-timeseries.spec.js
+++ b/test/runtime/adapter-read-timeseries.spec.js
@@ -52,8 +52,9 @@ describe('read testTimeseries', function () {
                 '| put dtProg = Math.floor(Duration.seconds(time - :now:)) ' +
                 '| put dtReal = Math.floor(Duration.seconds(Date.time() - time)) ' +
                 '| keep count, dtProg, dtReal',
-            realtime: true
-        }, 3000)
+            realtime: true,
+            deactivateAfter: 3000
+        })
         .then(function(result) {
             expect(result.graph.readEvery.milliseconds()).equal(500);
             expect(result.graph.lag.milliseconds()).equal(1000);
@@ -74,8 +75,9 @@ describe('read testTimeseries', function () {
                 '| put dtProg = Math.floor(Duration.seconds(time - :now:)) ' +
                 '| put dtReal = Math.floor(Duration.seconds(Date.time() - time)) ' +
                 '| keep count, dtProg, dtReal',
-            realtime: true
-        }, 5000)
+            realtime: true,
+            deactivateAfter: 5000
+        })
         .then(function(result) {
             var expected = [
                 { count: 0, dtProg: 0, dtReal: 3 },
@@ -94,8 +96,9 @@ describe('read testTimeseries', function () {
                 '| put dtReal = Math.floor(Duration.seconds(Date.time() - time)) ' +
                 '| keep count, dtProg, dtReal' +
                 '| view result -ticks true -dt true',
-            realtime: true
-        }, 4000)
+            realtime: true,
+            deactivateAfter: 4000
+        })
         .then(function(result) {
             var expected = [
                 { count: 0, dtProg: 0, dtReal: 2 },
@@ -114,8 +117,9 @@ describe('read testTimeseries', function () {
                 '| put dtProg = Math.floor(Duration.seconds(time - :now:)) ' +
                 '| put dtReal = Math.floor(Duration.seconds(Date.time() - time)) ' +
                 '| keep count, dtProg, dtReal',
-            realtime: true
-        }, 3000)
+            realtime: true,
+            deactivateAfter: 3000
+        })
         .then(function(result) {
             var expected = [
                 { count: 0, dtProg: -2, dtReal: 2 },

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -183,26 +183,10 @@ function compile_juttle(options) {
 }
 
 
-function check_juttle(options, deactivateAfter) {
-    /*
-     * deactivateAfter: number of milliseconds to wait before deactivating the
-     *                  program allowing for live/long running program testing
-     */
+function check_juttle(options) {
     return compile_juttle(options)
     .then(function(prog) {
-        var done = run_juttle(prog, options);
-
-        if (deactivateAfter) {
-            return Promise
-            .delay(null, deactivateAfter)
-            .then(function() {
-                prog.deactivate();
-                return done;
-            });
-        } else {
-            prog.deactivate();
-            return done;
-        }
+        return run_juttle(prog, options);
     });
 }
 
@@ -227,7 +211,7 @@ function run_juttle(prog, options) {
         expect_data = JSON.parse(raw_data);
     }
 
-    return Promise.try(function() {
+    var done = Promise.try(function() {
         var views = {};
 
         var promises = _.map(prog.get_sinks(), function(sink) {
@@ -299,6 +283,22 @@ function run_juttle(prog, options) {
             return {sinks: all_sinks, prog:prog, graph: graph, errors: errors, warnings: warnings};
         });
     });
+
+    /*
+     * deactivateAfter: number of milliseconds to wait before deactivating the
+     *                  program allowing for live/long running program testing
+     */
+    if (options.deactivateAfter) {
+        return Promise
+        .delay(null, options.deactivateAfter)
+        .then(function() {
+            prog.deactivate();
+            return done;
+        });
+    } else {
+        prog.deactivate();
+        return done;
+    }
 }
 
 

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -162,11 +162,6 @@ class SpecRenderer {
             }
         }
 
-        // we have to deactivate the program in order to avoid leaving things
-        // like the setInterval objects in the source proc which only get
-        // cleaned up when the program is correctly deactivated
-        parts.push('        res.prog.deactivate();');
-
         if (test.errors.length > 0) {
             parts.push([
                 '        }, function(err) {',


### PR DESCRIPTION
Procs and scheduler depend on the program deactivation after juttle runs
and not doing that can lead to leaking timers.

Fix calls to `run_juttle` or `program.activate` that were missing a
corresponding `program.deactivate` call.