### PR TITLE
Add support for new paging method using after query params.

### DIFF
--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -40,9 +40,9 @@ Parameter         |             Description          | Required?
 `-format`         | HTTP data format, supports: `csv`, `json` and `jsonl` | No; defaults to HTTP response header `Content-Type`
 `-followLinkHeader` |  When set to true the [Web Linking](https://tools.ietf.org/html/rfc5988) feature is enabled which allows for automatic handling of paging as specified by the [RFC5988](https://tools.ietf.org/html/rfc5988). | No; default `false`
 `-pageParam`      | The name of the query parameter used to enable paging with multiple HTTP requests sent to the URL provided until response contains 0 records | No; defaults to paging behavior disabled
-`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request. This is ignored when `-pageUnit=field` | No; default: `0`
-`-pageUnit <request|record|field>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. If set to `field`, then each successive request sets the paging query parameter to the last value of the field with name `pageField`| No; default: `request`
-`-pageField`      | When performing pagination with `-pageUnit=field`, the field to use to obtain values that go into each successive reqeust's paging query parameter. | Yes, when `-pageUnit=field`, no otherwise
+`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request. This is ignored when `-pageField` is set. | No; default: `0`
+`-pageUnit <request|record>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. Only of one `pageUnit` and `pageField` can be specified. | No; default: `request`
+`-pageField`      | If set, then each successive HTTP paging request sets the paging query parameter to the last value of the field with name `pageField`. Only of one `pageUnit` and `pageField` can be specified. | No
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 

--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -29,7 +29,7 @@ read http -url url
 
 Parameter         |             Description          | Required?
 ----------------- | -------------------------------- | ---------:
-`-url`            | URL to issue the HTTP request at | Yes 
+`-url`            | URL to issue the HTTP request at | Yes
 `-method`         | HTTP method to use               | No; default: `GET`
 `-headers`        | headers to attach to the HTTP request in the form `{ key1: "value1", ..., keyN: "valueN" }` | No; default: `{}`
 `-body`           | body to send with the HTTP requests | No; default: `{}`
@@ -40,14 +40,15 @@ Parameter         |             Description          | Required?
 `-format`         | HTTP data format, supports: `csv`, `json` and `jsonl` | No; defaults to HTTP response header `Content-Type`
 `-followLinkHeader` |  When set to true the [Web Linking](https://tools.ietf.org/html/rfc5988) feature is enabled which allows for automatic handling of paging as specified by the [RFC5988](https://tools.ietf.org/html/rfc5988). | No; default `false`
 `-pageParam`      | The name of the query parameter used to enable paging with multiple HTTP requests sent to the URL provided until response contains 0 records | No; defaults to paging behavior disabled
-`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request | No; default: `0`
-`-pageUnit <request|record>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. | No; default: `request`
+`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request. This is ignored when `-pageUnit=field` | No; default: `0`
+`-pageUnit <request|record|field>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. If set to `field`, then each successive request sets the paging query parameter to the last value of the field with name `pageField`| No; default: `request`
+`-pageField`      | When performing pagination with `-pageUnit=field`, the field to use to obtain values that go into each successive reqeust's paging query parameter. | Yes, when `-pageUnit=field`, no otherwise
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 
     * `text/csv`: for [CSV](https://tools.ietf.org/html/rfc4180) data
     * `application/json` for [JSON](https://tools.ietf.org/html/rfc7159) data
-    * `application/json` for [JSON lines](http://jsonlines.org/) data 
+    * `application/json` for [JSON lines](http://jsonlines.org/) data
 
 _Example_
 
@@ -67,6 +68,16 @@ counts for a given package. This uses the rootPath and timeField options:
 {!docs/examples/adapters/http_github_open_issues.juttle!}
 ```
 
+_Example_
+
+Example of how to access the Travis CI builds api and retrieve daily
+build counts for a given repository. This uses the -pageParam,
+-pageUnit=field, and -pageField options:
+
+```
+{!docs/examples/adapters/http_travisci_builds.juttle!}
+```
+
 ## write http
 
 Write points out of the Juttle flowgraph by making an HTTP request, with options:
@@ -80,7 +91,7 @@ write http -url url
 
 Parameter    |             Description          | Required?
 ------------ | -------------------------------- | ---------:
-`-url`       | URL to issue the HTTP request at | Yes 
+`-url`       | URL to issue the HTTP request at | Yes
 `-method`    | HTTP method to use               | No; default: `POST`
 `-headers`   | headers to attach to the HTTP request in the form `{ key1: "value1", ..., keyN: "valueN" }` | No; default: `{}`
 `-maxLength` | maximum payload length per HTTP request, as number of data points (not bytes) <br><br>If the number of data points out of the flowgraph exceeds `maxLength` then multiple HTTP requests will be sent. | No, default: 1 (each data point out of the flowgraph becomes one HTTP request)

--- a/docs/examples/adapters/http_travisci_builds.juttle
+++ b/docs/examples/adapters/http_travisci_builds.juttle
@@ -6,7 +6,6 @@ read http -url "https://api.travis-ci.org/repos/juttle/juttle/builds"
     }
     -rootPath "builds"
     -timeField 'finished_at'
-    -pageUnit "field"
     -pageField "number"
     -pageParam "after_number"
 | keep time, number, state

--- a/docs/examples/adapters/http_travisci_builds.juttle
+++ b/docs/examples/adapters/http_travisci_builds.juttle
@@ -1,0 +1,13 @@
+read http -url "https://api.travis-ci.org/repos/juttle/juttle/builds"
+    -headers {
+        'Authorization': 'token --TRAVIS-CI-AUTH-TOKEN-HERE--',
+        'Accept': 'application/vnd.travis-ci.2+json',
+        'User-Agent': 'Juttle TravisCI Testing'
+    }
+    -rootPath "builds"
+    -timeField 'finished_at'
+    -pageUnit "field"
+    -pageField "number"
+    -pageParam "after_number"
+| keep time, number, state
+| view text

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -134,19 +134,18 @@ class ReadHTTP extends AdapterRead {
         });
 
         if (options.pageUnit &&
-            !_.contains(['request', 'record', 'field'], options.pageUnit)) {
+            !_.contains(['request', 'record'], options.pageUnit)) {
             throw new errors.compileError('INVALID-OPTION-VALUE', {
                 option: 'pageUnit',
                 supported: 'request, record, field'
             });
         }
 
-        if (options.pageUnit &&
-            options.pageUnit === 'field' &&
-            !_.has(options, 'pageField')) {
-            throw new errors.compileError('REQUIRED-OPTION-COMBINATION', {
-                dep_option: 'pageUnit=field',
-                option: 'pageField'
+        if (_.has(options, 'pageUnit') &&
+            _.has(options, 'pageField')) {
+            throw new errors.compileError('INCOMPATIBLE-OPTION', {
+                option: 'pageField',
+                other: 'pageUnit'
             });
         }
 
@@ -166,9 +165,9 @@ class ReadHTTP extends AdapterRead {
         this.followLinkHeader = options.followLinkHeader;
         this.pageParam = options.pageParam;
         this.pageStart = options.pageStart || 0;
-        this.pageCount = (options.pageUnit === 'field' ? undefined : this.pageStart);
-        this.pageUnit = options.pageUnit || 'request';
         this.pageField = options.pageField;
+        this.pageCount = (this.pageField === undefined ? this.pageStart : undefined);
+        this.pageUnit = options.pageUnit || 'request';
         this.optimization_info = params && params.optimization_info || {};
     }
 
@@ -214,22 +213,31 @@ class ReadHTTP extends AdapterRead {
             if (this.pageParam && result.readEnd) {
                 if (result.state.total === 0) {
                     this.logger.debug('no results for page', this.pageCount, ' -- paging completed');
+                } else if (this.pageField && ! _.has(result.state.last_point, this.pageField)) {
+                    this.logger.debug(`-pageField set but no ${this.pageField} field found. -- paging completed`);
+                    // This shoudn't really happen, so emit a warning.
+                    var runtime_error = new errors.runtimeError('INTERNAL-ERROR', {
+                        error: `Last point in results did not contain a "${this.pageField}" field -- ending pagination`
+                    });
+                    this.trigger('warning', runtime_error);
                 } else {
                     this.logger.debug('got', result.state.total, 'results for page', this.nextPage);
 
-                    switch(this.pageUnit) {
-                        case 'request':
-                            this.pageCount++;
-                            break;
+                    if (this.pageField) {
+                        this.pageCount = result.state.last_point[this.pageField];
+                        // Clear last_point so it's not used again
+                        result.state.last_point = undefined;
+                    } else {
+                        switch(this.pageUnit) {
+                            case 'request':
+                                this.pageCount++;
+                                break;
 
-                        case 'record':
-                            this.pageCount += result.state.total;
-                            break;
+                            case 'record':
+                                this.pageCount += result.state.total;
+                                break;
 
-                        case 'field':
-                            this.pageCount = (result.state.last_point ? result.state.last_point[this.pageField] : undefined);
-                            // Clear last_point so it's not used again
-                            result.state.last_point = undefined;
+                        }
                     }
 
                     result.readEnd = undefined;
@@ -259,7 +267,7 @@ class ReadHTTP extends AdapterRead {
 
                 // Only add pageCount to the query string if it is
                 // defined.  It will be undefined for the initial
-                // query when using -pageUnit=field.
+                // query when using -pageField.
                 if (this.pageCount !== undefined) {
                     parsedQueryString[this.pageParam] = this.pageCount;
                 }

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -44,6 +44,10 @@ class Iterator {
             points = this.process(res, points, from, to);
             this.total += points.length;
 
+            if (points.length > 0) {
+                this.last_point = points[points.length-1];
+            }
+
             // The current parser API doesn't offer any kind of backpressure,
             // so all we can do is manage our own buffer of points and return
             // them to read as fast as possible.
@@ -120,7 +124,7 @@ class ReadHTTP extends AdapterRead {
             });
         }
 
-        _.each(['pageParam', 'pageUnit', 'pageStart'], (option) => {
+        _.each(['pageParam', 'pageUnit', 'pageStart', 'pageField'], (option) => {
             if (options.followLinkHeader && options[option] !== undefined) {
                 throw new errors.compileError('INCOMPATIBLE-OPTION', {
                     option: 'followLinkHeader',
@@ -130,10 +134,19 @@ class ReadHTTP extends AdapterRead {
         });
 
         if (options.pageUnit &&
-            !_.contains(['request', 'record'], options.pageUnit)) {
+            !_.contains(['request', 'record', 'field'], options.pageUnit)) {
             throw new errors.compileError('INVALID-OPTION-VALUE', {
                 option: 'pageUnit',
-                supported: 'request, record'
+                supported: 'request, record, field'
+            });
+        }
+
+        if (options.pageUnit &&
+            options.pageUnit === 'field' &&
+            !_.has(options, 'pageField')) {
+            throw new errors.compileError('REQUIRED-OPTION-COMBINATION', {
+                dep_option: 'pageUnit=field',
+                option: 'pageField'
             });
         }
 
@@ -153,8 +166,9 @@ class ReadHTTP extends AdapterRead {
         this.followLinkHeader = options.followLinkHeader;
         this.pageParam = options.pageParam;
         this.pageStart = options.pageStart || 0;
-        this.pageCount = this.pageStart;
+        this.pageCount = (options.pageUnit === 'field' ? undefined : this.pageStart);
         this.pageUnit = options.pageUnit || 'request';
+        this.pageField = options.pageField;
         this.optimization_info = params && params.optimization_info || {};
     }
 
@@ -162,7 +176,7 @@ class ReadHTTP extends AdapterRead {
         var httpOptions = ['url', 'method', 'headers', 'body', 'timeField',
                            'includeHeaders', 'rootPath', 'format',
                            'followLinkHeader', 'pageParam', 'pageStart',
-                           'pageUnit'];
+                           'pageUnit', 'pageField'];
 
         return AdapterRead.commonOptions().concat(httpOptions);
     }
@@ -210,6 +224,12 @@ class ReadHTTP extends AdapterRead {
 
                         case 'record':
                             this.pageCount += result.state.total;
+                            break;
+
+                        case 'field':
+                            this.pageCount = (result.state.last_point ? result.state.last_point[this.pageField] : undefined);
+                            // Clear last_point so it's not used again
+                            result.state.last_point = undefined;
                     }
 
                     result.readEnd = undefined;
@@ -233,10 +253,16 @@ class ReadHTTP extends AdapterRead {
         return new Promise((resolve, reject) => {
             if (this.pageParam) {
                 // when pageParam is set we manage the URL construction and use
-                // the options pageParam, pageStart and pageUnit
+                // the options pageParam, pageStart, pageUnit, and pageField.
                 var parsedURL = urlParse(this.url);
                 var parsedQueryString = querystring.parse(parsedURL.query);
-                parsedQueryString[this.pageParam] = this.pageCount;
+
+                // Only add pageCount to the query string if it is
+                // defined.  It will be undefined for the initial
+                // query when using -pageUnit=field.
+                if (this.pageCount !== undefined) {
+                    parsedQueryString[this.pageParam] = this.pageCount;
+                }
 
                 url = urlFormat({
                     protocol: parsedURL.protocol,

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -124,7 +124,6 @@
   "OPTION-SHOULD-BE-POSITIVE-INTEGER": "option {option} should be a positive integer",
   "OPTION-VALUE-EXCEEDED": "option {option} exceeded limit of {value}{extra}",
   "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
-  "REQUIRED-OPTION-COMBINATION": "if option {dep_option} is specified, {option} is required",
   "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context.",
   "HTTP-ERROR": "HTTP request failed with {status}: {message}"
 }

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -124,6 +124,7 @@
   "OPTION-SHOULD-BE-POSITIVE-INTEGER": "option {option} should be a positive integer",
   "OPTION-VALUE-EXCEEDED": "option {option} exceeded limit of {value}{extra}",
   "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
+  "REQUIRED-OPTION-COMBINATION": "if option {dep_option} is specified, {option} is required",
   "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context.",
   "HTTP-ERROR": "HTTP request failed with {status}: {message}"
 }

--- a/test/adapters/http/test-server.js
+++ b/test/adapters/http/test-server.js
@@ -364,20 +364,50 @@ class TestHTTPServer {
                 // returns 5 records based on the record count and limit parameter
                 var offset = parseInt(req.query['offset']);
                 var limit = parseInt(req.query['limit']);
-                
+
                 var left = 5 - offset;
                 res.set('Content-Type', 'application/json');
                 res.status(200);
 
-                if (left < 0) { 
+                if (left < 0) {
                     res.end('[]');
-                } else { 
+                } else {
                     var data = [];
-                
-                    if (left < limit) { 
+
+                    if (left < limit) {
                         limit = left;
                     }
-                   
+
+                    for (var index = 0; index < limit; index++) {
+                        data.push({ index: offset + index});
+                    }
+
+                    res.end(JSON.stringify(data));
+                }
+            });
+
+            this.app.get('/pageByField', (req, res) => {
+                // returns 5 records with index > after subject to the limit parameter
+                var offset = 0;
+                var limit = parseInt(req.query['limit']);
+
+                if (_.has(req.query, 'after')) {
+                    offset = parseInt(req.query['after']) + 1;
+                }
+
+                var left = 5 - offset;
+                res.set('Content-Type', 'application/json');
+                res.status(200);
+
+                if (left < 0) {
+                    res.end('[]');
+                } else {
+                    var data = [];
+
+                    if (left < limit) {
+                        limit = left;
+                    }
+
                     for (var index = 0; index < limit; index++) {
                         data.push({ index: offset + index});
                     }


### PR DESCRIPTION
While working on pulling TravisCI build statuses, I found I needed an
additional pagination method.

The pagination format TravisCI uses is:

https://api.travis-ci.org/repos/juttle/juttle/builds?after_number=<id>

after_number is related to a number field in the results:

{..., number: <id>, ...}

The idea is that you fetch the first page, find the last build number,
and then ask for another page with all builds after <id>.

To support that, add a new option for -pageUnit, "field". When
-pageUnit=field, an additional new option pageField is required, which
controls the field to use from the last returned point as the value to
put in the subsequent request's pageParam.

When pageUnit = field, the initial request does not contain a
pageParam query parameter.

Within the read adapter, the iterator keeps track of the last parsed
point. When it's time to move to a new page, the specified field from
that last point is used for the next page's pageParam.

Also require that when pageUnit "field", pageField is specified.

Add an example to the docs using TravisCI build status.

@rlgomes @VladVega 