### PR TITLE
Star operator ambiguity tests use test adapter

### DIFF
--- a/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
+++ b/test/runtime/specs/juttle-spec/parser/field-dereference-operator-ambiguity.spec.md
@@ -7,7 +7,7 @@ multiplication operator or a field dereference operator.
 
 ### Juttle
 
-    read stochastic -source 'cdn' -last :minute:*'name' == 'cpu'
+    read test -last :minute:*'name' == 'cpu'
 
 ### Errors
 
@@ -17,7 +17,7 @@ multiplication operator or a field dereference operator.
 
 ### Juttle
 
-    read stochastic -source 'cdn' -last :minute:* 'name' == 'cpu'
+    read test -last :minute:* 'name' == 'cpu'
 
 ### Errors
 
@@ -27,19 +27,21 @@ multiplication operator or a field dereference operator.
 
 ### Juttle
 
-    read stochastic -source 'cdn' -last :minute: *'name' == 'cpu'
-    | reduce count()
+    (
+        read test -key "test" -last :minute: *'name' == 'cpu';
+        emit -limit 1 -from Date.new(0);
+    )
     | view result
 
 ### Output
 
-    { count: 62 }
+    { time: "1970-01-01T00:00:00.000Z" }
 
 ## Parses toplevel `*` as multiplication with whitespace before and whitespace after
 
 ### Juttle
 
-    read stochastic -source 'cdn' -last :minute: * 'name' == 'cpu'
+    read test -last :minute: * 'name' == 'cpu'
 
 ### Errors
 


### PR DESCRIPTION
One of the tests was relying on stochastic adapter emitting a certain
number of points and was failing non-deterministically.

Either the bug is in reduce, or in stochastic adapter (which is known to
sometimes emit ooo points that are automatically dropped).

From the syntax POV, an adapter is an easy place to trigger the
ambiguity which we want to test, i.e. to get a number/duration literal
nearby a field dereference.

Change the adapter from stochastic to test and modify the irrelevant
test condition that was counting points to be stable.

Fixes: #525