### PR TITLE
More improvements to field based paging.

### DIFF
--- a/docs/adapters/http.md
+++ b/docs/adapters/http.md
@@ -40,9 +40,9 @@ Parameter         |             Description          | Required?
 `-format`         | HTTP data format, supports: `csv`, `json` and `jsonl` | No; defaults to HTTP response header `Content-Type`
 `-followLinkHeader` |  When set to true the [Web Linking](https://tools.ietf.org/html/rfc5988) feature is enabled which allows for automatic handling of paging as specified by the [RFC5988](https://tools.ietf.org/html/rfc5988). | No; default `false`
 `-pageParam`      | The name of the query parameter used to enable paging with multiple HTTP requests sent to the URL provided until response contains 0 records | No; defaults to paging behavior disabled
-`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request. This is ignored when `-pageField` is set. | No; default: `0`
-`-pageUnit <request|record>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. Only of one `pageUnit` and `pageField` can be specified. | No; default: `request`
-`-pageField`      | If set, then each successive HTTP paging request sets the paging query parameter to the last value of the field with name `pageField`. Only of one `pageUnit` and `pageField` can be specified. | No
+`-pageStart`      | Initial value of the paging offset to set the `pageParam` to in the URL used to make the HTTP request. | No; default: `0`
+`-pageUnit <request|record>` | If set to `request`, then each successive HTTP paging request increments the paging query parameter by one. If set to `record`, then each successive request increments the paging query parameter by the number of records returned in the previous request. | No; default: `request`
+`-pageField`      | If set, then each successive HTTP paging request sets the paging query parameter to the last value of the field with name `pageField`. Cannot be used with `pageStart` or `pageUnit`. | No
 
 Currently the `read http` adapter will automatically parse incoming data based off of the `content-type` header. Here are the currently supported content-types:
 

--- a/lib/adapters/http/read.js
+++ b/lib/adapters/http/read.js
@@ -141,13 +141,15 @@ class ReadHTTP extends AdapterRead {
             });
         }
 
-        if (_.has(options, 'pageUnit') &&
-            _.has(options, 'pageField')) {
-            throw new errors.compileError('INCOMPATIBLE-OPTION', {
-                option: 'pageField',
-                other: 'pageUnit'
-            });
-        }
+        _.each(['pageUnit', 'pageStart'], (option) => {
+            if (_.has(options, option) &&
+                _.has(options, 'pageField')) {
+                throw new errors.compileError('INCOMPATIBLE-OPTION', {
+                    option: 'pageField',
+                    other: option
+                });
+            }
+        });
 
         this.url = options.url;
         this.method = options.method ? options.method : 'GET';

--- a/test/adapters/http/read.spec.js
+++ b/test/adapters/http/read.spec.js
@@ -120,6 +120,16 @@ describe('HTTP read tests', function() {
         });
     });
 
+    it(`fails when both -pageField and -pageStart are specified`, () => {
+        return check_juttle({
+            program: `read http -pageField "after" -pageStart 1 -url "${server.url}/status/200"`
+        })
+        .then((result) => {
+            throw Error('pageField combined with pageStart succeeded when it should have failed');
+        }).catch(function(err) {
+            expect(err.toString()).to.contain('-pageField option should not be combined with -pageStart');
+        });
+    });
 
     it('fails when unknown content-type received', function() {
         return check_juttle({


### PR DESCRIPTION
Address feedback from Mike on https://github.com/juttle/juttle/pull/524 after I merged:

 - Make pageField and pageStart exclusive, adding a new unit test to check.
 - Change the docs to only mention the exclusivity for pageField.

There's still a bad interaction with
https://github.com/juttle/juttle/commit/167935e3f5e66cc3862e890fc707efd4ab076a8e. Test
programs are calling deactivate immediately and relying on active
reads to signal that the program should be torn down. That doesn't
work for any of these paging based methods that could involve multiple
calls to read.