### PR TITLE
juttle-test-utils: by default deactivate after the program is done

### DIFF
--- a/test/adapters/http_server.spec.js
+++ b/test/adapters/http_server.spec.js
@@ -20,7 +20,7 @@ describe('read http_server', function() {
     });
 
     it('ingests simple json array', function() {
-        var programFinish;
+        var programFinish, program;
         var body = [
             { 'name': 'ted', 'age': 53, 'weight': 100},
             { 'name': 'ted', 'age': 53, 'weight': 100}
@@ -30,16 +30,20 @@ describe('read http_server', function() {
             program: 'read http_server -port ' + port
         })
         .then(function(prog) {
+            program = prog;
             programFinish = run_juttle(prog);
 
             return request({
                 uri: 'http://localhost:' + port,
                 method: 'POST',
                 body: body,
-                json: true
+                json: true,
+                resolveWithFullResponse: true
             });
         })
-        .then(function() {
+        .then(function(res) {
+            expect(res.statusCode).to.equal(200);
+            program.deactivate();
             return programFinish;
         })
         .then(function(result) {
@@ -70,6 +74,7 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
+            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -86,7 +91,7 @@ describe('read http_server', function() {
         })
         .then(function(prog) {
             program = prog;
-            programFinish = run_juttle(program, { deactivateAfter: 1000 });
+            programFinish = run_juttle(program);
         })
         // Wait a while before posting the data
         .delay(500)
@@ -103,6 +108,7 @@ describe('read http_server', function() {
         .delay(50)
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
+            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -131,6 +137,7 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(200);
+            program.deactivate();
             return programFinish;
         })
         .then(function(results) {
@@ -159,6 +166,7 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
+            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -187,6 +195,7 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
+            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -229,6 +238,7 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(415);
+            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -262,6 +272,7 @@ describe('read http_server', function() {
         .delay(50)
         .then(function(res) {
             expect(res.statusCode).to.equal(400);
+            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -298,6 +309,7 @@ describe('read http_server', function() {
             });
         })
         .then(function() {
+            program.deactivate();
             return finish;
         })
         .then(function(results) {
@@ -325,11 +337,12 @@ describe('read http_server', function() {
         })
         .then(function(res) {
             expect(res.statusCode).to.equal(404);
+            program.deactivate();
             return finish;
         });
     });
 
-    it('unsupport method throws error', function() {
+    it('unsupported method throws error', function() {
         return check_juttle({
             program: 'read http_server -port ' + port + ' -method \'HEAD\''
         })

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -290,14 +290,16 @@ function run_juttle(prog, options) {
      */
     if (options.deactivateAfter) {
         return Promise
-        .delay(null, options.deactivateAfter)
+        .delay(options.deactivateAfter)
         .then(function() {
             prog.deactivate();
             return done;
         });
     } else {
-        prog.deactivate();
-        return done;
+        return done.then(function(result) {
+            prog.deactivate();
+            return result;
+        });
     }
 }
 


### PR DESCRIPTION
The change in #522 called deactivate immediately after running the
program unless deactivateAfter was set, which is the wrong semantics
since it will cause the programs to terminate early.

Instead, when deactivateAfter isn't set, wait until the program is
done before calling deactivate.

Also fix the call to Promise.delay -- the delay time is supposed to
be the only argument in bluebird promises.