### PR TITLE
file: add missing tests for corrupt files and fix json parser

### DIFF
--- a/lib/adapters/parsers/json.js
+++ b/lib/adapters/parsers/json.js
@@ -62,7 +62,7 @@ class JSONParser extends base {
             })
             .on('fail', function(err) {
                 reject(errors.runtimeError('INVALID-JSON',{
-                    detail: err.toString()
+                    detail: err.thrown.toString()
                 }));
             });
 

--- a/test/adapters/file/read.spec.js
+++ b/test/adapters/file/read.spec.js
@@ -69,6 +69,29 @@ describe('read file adapter tests', function () {
                     });
             });
 
+            it('throws an error on a corrupt file', function() {
+                var file_name = corrupt + '.' + format;
+                return run_read_file_juttle(file_name, {format: format, timeField: 'mytime'})
+                    .then(function(result) {
+                        var expected;
+                        switch(format) {
+                            case 'csv':
+                                expected = 'Invalid CSV data: Error: Row length does not match headers';
+                                break;
+                            case 'json':
+                                expected = 'Invalid JSON data: Error: Malformed object key should start with \" \nLn: 4\nCol: 3\nChr: X';
+                                break;
+                            case 'jsonl':
+                                expected = 'Invalid JSONL data: Error: Invalid JSON (Unexpected \"X\" at position 102 in state STOP)';
+                                break;
+                            default:
+                                throw new Error('implement test for ' + format);
+                        }
+                        expect(result.errors).deep.equals([expected]);
+                        expect(result.sinks.table).deep.equal([]);
+                    });
+            });
+
             it('emits a warning if specified timeField does not exist', function() {
                 var options = {timeField: 'foo', format: format};
                 return run_read_file_juttle(file_name, options)


### PR DESCRIPTION
I noticed that when reading a corrupt JSON file, the error message
contains [Object object]. Fix the parser to reject with err.thrown
and add a test to verify that we get expected error messages when
reading from corrupt files.