### PR TITLE
default processors for compiler

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -35,9 +35,6 @@ var URLResolver = require('../lib/module-resolvers/url-resolver');
 var FileResolver = require('../lib/module-resolvers/file-resolver');
 var resolver_utils = require('../lib/module-resolvers/resolver-utils');
 var compiler = require('../lib/compiler');
-var optimize = require('../lib/compiler/optimize');
-var implicit_views = require('../lib/compiler/flowgraph/implicit_views');
-var check_runaway = require('../lib/compiler/flowgraph/check_runaway.js');
 
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
 function usage() {
@@ -152,9 +149,9 @@ function perform_compile(options) {
     var compile_options = {
         stage: options.stage,
         moduleResolver: options.resolver,
-        fg_processors: [check_runaway, implicit_views(config.implicit_view), optimize],
         inputs: options.inputs,
-        stripLocations: options.stripLocations
+        stripLocations: options.stripLocations,
+        implicit_view: config.implicit_view
     };
 
     return compiler.compile(options.juttle_src, compile_options);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ gulp.task('examples-check', ['peg'], function() {
                 return compiler.compile(juttle_src, {
                     stage: 'compile',
                     moduleResolver: file_resolver.resolve,
-                    fg_processors: [implicit_views('table'), optimize]
+                    fg_processors: [implicit_views, optimize]
                 });
             })
             .then(function() {

--- a/lib/compiler/flowgraph/implicit_views.js
+++ b/lib/compiler/flowgraph/implicit_views.js
@@ -5,19 +5,17 @@ var is_sink = require('../graph-builder').is_sink;
 
 // Generate a graph builder that adds an implicit sink of the given type
 // to any branches of the graph that don't already end in a sink.
-function implicit_views(default_view) {
-    default_view = default_view || 'table';
+function implicit_views(g, options) {
+    var default_view = options.default_view || 'table';
 
-    return function implicit_views(g) {
-        var leaves = g.get_leaves();
-        var table;
-        _.each(leaves, function(node) {
-            if (!is_sink(node)) {
-                table = g.append_node('View', default_view);
-                g.add_edge(node, table);
-            }
-        });
-    };
+    var leaves = g.get_leaves();
+    var table;
+    _.each(leaves, function(node) {
+        if (!is_sink(node)) {
+            table = g.append_node('View', default_view);
+            g.add_edge(node, table);
+        }
+    });
 }
 
 module.exports = implicit_views;

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -15,6 +15,13 @@ var _ = require('underscore');
 var JuttleMoment = require('../runtime/types/juttle-moment');
 var juttle = require('../runtime').runtime;
 
+var optimize = require('./optimize');
+var implicit_views = require('./flowgraph/implicit_views');
+var check_runaway = require('./flowgraph/check_runaway');
+var views_sourceinfo = require('./flowgraph/views_sourceinfo');
+
+var DEFAULT_PROCESSORS = [implicit_views, check_runaway, views_sourceinfo, optimize];
+
 var stages = {
     semantic: function(ast, options) {
         var s = new SemanticPass(options);
@@ -34,7 +41,7 @@ var stages = {
         var program = new Graph();
         program.built_graph = graph;
         _.each(options.fg_processors, function(processor) {
-            processor(program);
+            processor(program, options);
         });
         return program;
     },
@@ -74,12 +81,16 @@ function compile(juttle, options) {
     var parserOptions = _.pick(options, 'filename', 'modules', 'moduleResolver');
     parserOptions.now = now;
 
+    var fg_processors = _.isEmpty(options.fg_processors) ?
+                        DEFAULT_PROCESSORS : options.fg_processors;
+
     var compilerOptions = _.defaults(_.clone(options), {
         stage: 'eval',
         now: now,
         inputs: {},
         input_defaults: {},
-        fg_processors: [],
+        implicit_view: 'table',
+        fg_processors: fg_processors,
         stripLocations: false,
         scheduler: new Scheduler()
     });
@@ -109,12 +120,16 @@ function compileSync(juttle, options) {
     var parserOptions = _.pick(options, 'filename', 'modules', 'moduleResolver');
     parserOptions.now = now;
 
+    var fg_processors = _.isEmpty(options.fg_processors) ?
+                        DEFAULT_PROCESSORS : options.fg_processors;
+
     var compilerOptions = _.defaults(_.clone(options), {
         stage: 'eval',
         now: now,
         inputs: {},
         input_defaults: {},
-        fg_processors: [],
+        implicit_view: 'table',
+        fg_processors: fg_processors,
         stripLocations: false,
         scheduler: new Scheduler()
     });

--- a/test/runtime/graph-api.spec.js
+++ b/test/runtime/graph-api.spec.js
@@ -5,12 +5,15 @@ var juttle_test_utils = require('./specs/juttle-test-utils');
 var run_juttle = juttle_test_utils.run_juttle;
 var _ = require('underscore');
 var compiler = require('../../lib/compiler');
+var optimize = require('../../lib/compiler/optimize');
 
 
 describe('Graph API', function() {
 
     function make_graph(juttle) {
-        return compiler.compileSync(juttle, { stage: 'flowgraph' });
+        // we want to compile with just optimization and verify the resulting
+        // graph in the tests below
+        return compiler.compileSync(juttle, { stage: 'flowgraph', fg_processors: [optimize] });
     }
 
     function compile(juttle, processor) {

--- a/test/runtime/object-literals.spec.js
+++ b/test/runtime/object-literals.spec.js
@@ -12,7 +12,10 @@ describe('Juttle Object Literal Tests', function() {
     }
 
     it('passes object literal to sink', function() {
-        var optionObject = { something: 3 };
+        var optionObject = {
+            _jut_time_bounds: [],
+            something: 3
+        };
 
         return check_juttle({
             program: 'emit -limit 1 | view result -o '+ JSON.stringify(optionObject)
@@ -24,8 +27,14 @@ describe('Juttle Object Literal Tests', function() {
     });
 
     it('correctly deals with option precendence', function() {
-        var optionObject = { foo: 'bar', something: 3 };
-        var optionObject2 = { something: 17 };
+        var optionObject = {
+            _jut_time_bounds: [],
+            foo: 'bar',
+            something: 3
+        };
+        var optionObject2 = {
+            something: 17
+        };
 
         return check_juttle({
             program: 'emit -limit 1 | view result -o '+ JSON.stringify(optionObject)
@@ -38,8 +47,13 @@ describe('Juttle Object Literal Tests', function() {
     });
 
     it('overrides option from object', function() {
-        var optionObject = { something: 3 };
-        var expectedObject = { something: 4 };
+        var optionObject = {
+            something: 3
+        };
+        var expectedObject = {
+            _jut_time_bounds: [],
+            something: 4
+        };
 
         return check_juttle({
             program: 'emit -limit 1 | view result -o '+ JSON.stringify(optionObject) +' -something 4'
@@ -51,7 +65,10 @@ describe('Juttle Object Literal Tests', function() {
     });
 
     it('overrides option with object', function() {
-        var optionObject = { something: 3 };
+        var optionObject = {
+            _jut_time_bounds: [],
+            something: 3
+        };
 
         return check_juttle({
             program: 'emit -limit 1 | view result -something 4 -o '+ JSON.stringify(optionObject)
@@ -63,7 +80,10 @@ describe('Juttle Object Literal Tests', function() {
     });
 
     it('passes object literal to sink from const', function() {
-        var optionObject = { something: 3 };
+        var optionObject = {
+            _jut_time_bounds: [],
+            something: 3
+        };
 
         return check_juttle({
             program: 'const foo = '+ JSON.stringify(optionObject) +'; emit -limit 1 | view result -o foo'
@@ -75,7 +95,10 @@ describe('Juttle Object Literal Tests', function() {
     });
 
     it('passes object literal to sink from function', function() {
-        var optionObject = { something: 3 };
+        var optionObject = {
+            _jut_time_bounds: [],
+            something: 3
+        };
 
         return check_juttle({
             program: 'function foo() { return '+ JSON.stringify(optionObject) +'; } emit -limit 1 | view result -o foo()'

--- a/test/runtime/sinks.spec.js
+++ b/test/runtime/sinks.spec.js
@@ -168,6 +168,7 @@ describe('Juttle sinks validation', function() {
     it('handles dots for nested sink arguments', function() {
         var program = 'emit -limit 1 | view result -foo.bar.baz 5';
         var nested = {
+            _jut_time_bounds: [],
             foo: {
                 bar: {
                     baz: 5

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -18,10 +18,7 @@ var JuttleMoment = require('../../../lib/runtime/types/juttle-moment');
 var compiler = require('../../../lib/compiler');
 var Scheduler = require('../../../lib/runtime/scheduler').Scheduler;
 var TestScheduler = require('../../../lib/runtime/scheduler').TestScheduler;
-var implicit_views = require('../../../lib/compiler/flowgraph/implicit_views')();
-var optimize = require('../../../lib/compiler/optimize');
 var View = require('../../../lib/views/view.js');
-var check_runaway = require('../../../lib/compiler/flowgraph/check_runaway');
 
 // Configure the test adapter
 adapters.configure({
@@ -156,7 +153,6 @@ function compile_juttle(options) {
     var compile_opts = {
         modules: options.modules,
         moduleResolver: options.moduleResolver,
-        fg_processors: [check_runaway, implicit_views, optimize],
         scheduler: options.realtime ? new Scheduler() : new TestScheduler()
     };
 


### PR DESCRIPTION
fixes #494

set the list of default processors while making sure to pass the
`options.implicit_view` which allows the underlying `implicit_view`
processor to change its default behavior at runtime.
