### PR TITLE
reduce.js - emit initial mark on first batch start

### DIFF
--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -317,7 +317,8 @@ class reduce_every extends reduce_base {
         return 'reduce';
     }
     first_epoch(epoch) {
-        // don't run on the first epoch (called by advance)
+        // emit initial mark (before any points arrive)
+        this.emit_mark(epoch);
     }
     //
     // mark() and process() are from periodic. tick() from reduce_runner_funcs

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -184,6 +184,7 @@ default values of null for when no -every is specified.
 
 ### Output
 
+    {"mark": true, "time": "1970-01-01T00:00:00.000Z"}
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.002Z"}
     {"mark": true, "time": "1970-01-01T00:00:00.002Z"}
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.004Z"}
@@ -467,6 +468,7 @@ default values of null for when no -every is specified.
 
 ### Warnings
 
+   * out-of-order assignment of time 1969-12-31T23:59:58.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
    * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
    * out-of-order assignment of time 1969-12-31T23:59:56.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
    * out-of-order assignment of time 1969-12-31T23:59:55.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped


### PR DESCRIPTION
To be consistent with `batch | reduce`, `reduce -every` should emit an
initial mark at the start of first batch.

Fixes #537, #538