### PR TITLE
Move variable checks from Build and GraphCompiler to SemanticPass

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -2,7 +2,6 @@
 
 var _ = require('underscore');
 var CodeGenerator = require('./code-generator');
-var errors = require('../errors');
 
 var UNARY_OPS_TO_FUNCTIONS = {
     '+':   'pos',
@@ -35,13 +34,6 @@ var BINARY_OPS_TO_FUNCTIONS = {
     'AND': 'land',
     'OR':  'lor',
     '??':  'coal'
-};
-
-var SYMBOL_TYPE_NAMES = {
-    'function': 'function',
-    'reducer': 'reducer',
-    'sub': 'subgraph',
-    'import': 'module'
 };
 
 //
@@ -781,16 +773,10 @@ class Build extends CodeGenerator {
         switch (node.symbol.type) {
             case 'const':
                 return 'builder.get_const("' + node.symbol.uname + '")';
-            case 'import':
-            case 'function':
-            case 'reducer':
-            case 'sub':
-                throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
-                    thing: SYMBOL_TYPE_NAMES[node.symbol.type],
-                    location: node.location
-                });
-            default:
+            case 'var':
                 return node.symbol.uname;
+            default:
+                throw new Error('Invalid symbol type: ' + node.symbol.type + '.');
         }
     }
     gen_Field(node) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -42,13 +42,6 @@ var BINARY_OPS_TO_FUNCTIONS = {
     '??':  'coal'
 };
 
-var SYMBOL_TYPE_NAMES = {
-    'function': 'function',
-    'reducer': 'reducer',
-    'sub': 'subgraph',
-    'import': 'module'
-};
-
 //
 // take a dataflow graph representation and generate a javascript program
 // that runs against the Juttle javascript runtime
@@ -705,18 +698,7 @@ class GraphCompiler extends CodeGenerator {
             + this.gen_expr(node.consequent) + '))';
     }
     gen_Variable(node) {
-        switch (node.symbol.type) {
-            case 'import':
-            case 'function':
-            case 'reducer':
-            case 'sub':
-                throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
-                    thing: SYMBOL_TYPE_NAMES[node.symbol.type],
-                    location: node.location
-                });
-            default:
-                return node.symbol.uname;
-        }
+        return node.symbol.uname;
     }
     gen_Field(node, opts) {
         var name = JSON.stringify(node.name);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -42,6 +42,13 @@ const BUILTIN_PROCS = {
     'write': {}
 };
 
+const SYMBOL_TYPE_NAMES = {
+    'function': 'function',
+    'reducer': 'reducer',
+    'sub': 'subgraph',
+    'import': 'module'
+};
+
 class SemanticPass {
     constructor(options) {
         reset_scope();
@@ -1384,6 +1391,31 @@ class SemanticPass {
         var symbol = this.scope.get(node.name);
 
         if (symbol) {
+            // We can be in one of 2 situations:
+            //
+            //   1. We are processing a "bare" variable (one that has no ".",
+            //      "[...]" or "(...)" operator applied to it). In that case, we
+            //      need to check variable's symbol type (there is nobody else
+            //      who can do that).
+            //
+            //   2. We are processing a variable inside a member expression
+            //      (e.g. "foo" in "foo.bar" or "foo['bar']"). In that case, we
+            //      don't check anything because all the checks will be
+            //      performed by sa_MemberExpression (which has necessary
+            //      context).
+            //
+            // We don't need to process variables inside call expressions (e.g.
+            // "foo" in "foo()") because they are handled by sa_CallExpression
+            // (for now).
+            if (!this.in_member_expression) {
+                if (symbol.type !== 'const' && symbol.type !== 'var') {
+                    throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
+                        thing: SYMBOL_TYPE_NAMES[symbol.type],
+                        location: node.location
+                    });
+                }
+            }
+
             node.symbol = symbol;
             node.d = symbol.d;
         } else {
@@ -1423,7 +1455,9 @@ class SemanticPass {
     sa_MemberExpression(node) {
         var symbol;
 
-        this.sa_expr(node.object);
+        this.with_in_member_expression(true, () => {
+            this.sa_expr(node.object);
+        });
         this.sa_expr(node.property);
 
         if (this.lhs) {
@@ -1441,7 +1475,16 @@ class SemanticPass {
                 node.symbol = this.scope.get(node.object.name).exports[node.property.value];
             }
         } else {
-            if (!node.computed) {
+            if (node.computed) {
+                if (node.object.symbol) {
+                    if (node.object.symbol.type !== 'const' && node.object.symbol.type !== 'var') {
+                        throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
+                            thing: SYMBOL_TYPE_NAMES[node.object.symbol.type],
+                            location: node.object.location
+                        });
+                    }
+                }
+            } else {
                 // We are processing an expression like "foo.bar". If "foo" is a
                 // module, the expression is *static* and in later stage, it
                 // will be compiled as a reference to exported module entity
@@ -1449,18 +1492,27 @@ class SemanticPass {
                 // expression is *dynamic* and it will be compiled in the same
                 // way as "foo['bar']". The compiler distinguishes these cases
                 // by presence of node.symbol.
-                if (node.object.symbol && node.object.symbol.type === 'import') {
-                    symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
-                    if (symbol === undefined) {
-                        throw errors.compileError('NOT-EXPORTED', {
-                            thing: 'variable',
-                            name: node.property.value,
-                            module: node.object.name,
-                            location: node.location
+                if (node.object.symbol) {
+                    if (node.object.symbol.type !== 'const' && node.object.symbol.type !== 'var' && node.object.symbol.type !== 'import') {
+                        throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
+                            thing: SYMBOL_TYPE_NAMES[node.object.symbol.type],
+                            location: node.object.location
                         });
                     }
 
-                    node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                    if (node.object.symbol.type === 'import') {
+                        symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                        if (symbol === undefined) {
+                            throw errors.compileError('NOT-EXPORTED', {
+                                thing: 'variable',
+                                name: node.property.value,
+                                module: node.object.name,
+                                location: node.location
+                            });
+                        }
+
+                        node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                    }
                 }
             }
         }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -51,6 +51,7 @@ class SemanticPass {
         this.context = 'build';
         this.coercion_mode = 'none';
         this.lhs = false;
+        this.in_member_expression = false;
         this.reducers = null;
         this.index = null;
 
@@ -336,6 +337,15 @@ class SemanticPass {
             fn();
         } finally {
             this.lhs = saved_lhs;
+        }
+    }
+    with_in_member_expression(in_member_expression, fn) {
+        var saved_in_member_expression = this.in_member_expression;
+        this.in_member_expression = in_member_expression;
+        try {
+            fn();
+        } finally {
+            this.in_member_expression = saved_in_member_expression;
         }
     }
 


### PR DESCRIPTION
`Build` and `GraphCompiler` checked that entities such as module references or functions were not used as variables. This check was semantic in nature so this PR moves it to the semantic pass. See the commit messages for more details.

Part of work on #419.