### PR TITLE
reduce.js - reduce -every returns aggregates for empty set of points

### DIFF
--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -311,6 +311,7 @@ class reduce_every extends reduce_base {
             // if -from or -to are specified, align on them by default.
             this.on = options.from || options.to ;
         }
+        this.after_first_epoch = false;
         this.init_warnings();
     }
     procName() {
@@ -319,6 +320,7 @@ class reduce_every extends reduce_base {
     first_epoch(epoch) {
         // emit initial mark (before any points arrive)
         this.emit_mark(epoch);
+        this.after_first_epoch = true;
     }
     //
     // mark() and process() are from periodic. tick() from reduce_runner_funcs
@@ -327,6 +329,16 @@ class reduce_every extends reduce_base {
     other_epoch(epoch) {
         super.other_epoch(epoch);
         this.emit_mark(epoch);
+    }
+
+    eof(from) {
+        // Edge case - 0 points followed immediately by eof. To be consistent
+        // with `batch | reduce`, run aggregation once and emit the result.
+        if (!this.batch_size && !this.after_first_epoch) {
+            var out = this.advance_epoch(this.next_epoch);
+            this.emit(out);
+        }
+        super.eof(from);
     }
 
     //

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -177,7 +177,6 @@ default values of null for when no -every is specified.
 ### Juttle
 
     emit  -hz 1000 -from Date.new(0) -limit 6
-    | batch :.001s:
     | reduce -every :0.002s: a=count()
     | put c=count()
     | view result -marks true -times true

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -191,6 +191,51 @@ default values of null for when no -every is specified.
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.006Z"}
     {"mark": true, "time": "1970-01-01T00:00:00.006Z"}
 
+## batch | reduce emits marks at batch boundaries
+
+### Juttle
+
+    emit  -hz 1000 -from Date.new(0) -limit 6
+    | batch :0.002s:
+    | reduce a=count()
+    | put c=count()
+    | view result -marks true -times true
+
+### Output
+
+    {"mark": true, "time": "1970-01-01T00:00:00.000Z"}
+    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.002Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.002Z"}
+    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.004Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.004Z"}
+    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.006Z"}
+    {"mark": true, "time": "1970-01-01T00:00:00.006Z"}
+
+## reduce -every produces aggregate for empty flow
+
+### Juttle
+
+    emit -limit 0 -from Date.new(0)
+    | reduce -every :0.002s: count()
+    | view result -marks true -times true
+
+### Output
+
+    { "count": 0 }
+
+## batch | reduce produces aggregate for empty flow
+
+### Juttle
+
+    emit -limit 0 -from Date.new(0)
+    | batch :0.002s:
+    | reduce count()
+    | view result -marks true -times true
+
+### Output
+
+    { "count": 0 }
+
 ## cascade of every-driven reducers
 
 ### Juttle


### PR DESCRIPTION
`reduce_batch` advances on `eof`, thus emitting the aggregate on empty flow,
i.e. when there aren't any upstream points, only an `eof`.

Make `reduce -every` follow the same pattern.

Fixes: #516