### PR TITLE
throw an error when redefining a module import

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -95,6 +95,21 @@ class Scope {
         }
         return varName;
     }
+    check_not_redefined(name, type, location) {
+        if (this.symbols.hasOwnProperty(name)) {
+            throw errors.compileError('REDEFINED', {
+                type: type,
+                name: name,
+                location: location
+            });
+        }
+    }
+    define_import(name, exports, location) {
+        this.check_not_redefined(name, 'import', location);
+        var symbol = { type: 'import', exported: false, exports: exports, d: true };
+        this.put(name, symbol);
+        return symbol;
+    }
     define_var(name, exported) {
         var runtimeVar = this.alloc_var(name);
         var symbol = { type: 'var', exported: exported, uname: runtimeVar };
@@ -126,12 +141,8 @@ class Scope {
         return symbol;
     }
     define_variable(name, type, exported, can_redefine, d, location) {
-        if (!can_redefine && this.symbols.hasOwnProperty(name)) {
-            throw errors.compileError('REDEFINED', {
-                type: type,
-                name: name,
-                location: location
-            });
+        if (!can_redefine) {
+            this.check_not_redefined(name, type, location);
         }
         switch (type) {
             case 'var':

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -858,13 +858,7 @@ class SemanticPass {
         }
         // localname is the juttle "as" name of the module
         var module = this.modules[modulename];
-        this.scope.put(node.localname, {
-            type: 'import',
-            exported: false,
-            exports: module.exports,
-            d: true
-        });
-
+        this.scope.define_import(node.localname, module.exports, node.location);
         this.import_path.pop();
         this.stats.imports++;
     }

--- a/test/runtime/modules.spec.js
+++ b/test/runtime/modules.spec.js
@@ -230,6 +230,22 @@ describe('Juttle modules ', function() {
             });
         });
 
+        it('Throws an error when importing modules under the same identifier', function() {
+            var resolver = moduleResolver({
+                mod1: 'const foo="bar";',
+                mod2: 'const foo="bar";'
+            });
+            return check_juttle({
+                moduleResolver: resolver,
+                program: 'import "mod1" as m; import "mod2" as m;'
+            })
+            .then(function() {
+                throw new Error('Should have thrown an error');
+            })
+            .catch(function(err) {
+                expect(err.message).to.match(/redefined import: m/);
+            });
+        });
     });
 
     describe('Modules: running', function() {


### PR DESCRIPTION
fixes #520

quick fix and test to verify that we throw an error when the user
accidentally imports a module with the same locally scoped identifier.