### PR TITLE
fix JavaScript capitalization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Be sure to update documentation when you make user-facing changes. Small reposit
 
 ### Style
 
-When developing you may run into failures during linting where eslint complains about your Javascript coding style. An easy way to fix those files is to simply run `eslint --fix test` or `eslint --fix lib` from the root directory of the project. After eslint fixes things you should proceed to check that those changes are reasonable, as auto-fixing may not produce the nicest looking code.
+When developing you may run into failures during linting where eslint complains about your JavaScript coding style. An easy way to fix those files is to simply run `eslint --fix test` or `eslint --fix lib` from the root directory of the project. After eslint fixes things you should proceed to check that those changes are reasonable, as auto-fixing may not produce the nicest looking code.
 
 When adding Juttle code, follow the [Juttle Style Guide](docs/references/style_guide.md). If you add *.juttle programs under docs/examples, or embedded anywhere in the docs markdown articles as a code block with `juttle` language marker, they will be automatically syntax-checked when tests are run.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ and analyze live and historical data from many different backends, and then send
 output to files, data stores, alerting systems, or [streaming
 visualizations](http://github.com/juttle/juttle-viz).
 
-This repository contains the core Juttle compiler, the Javascript runtime, a set
+This repository contains the core Juttle compiler, the JavaScript runtime, a set
 of basic adapters to connect to files or http sources, and a command line
 interface with text-based and tabular views. As such it is most useful for
 learning the language, doing simple exploration of data, or powering periodic

--- a/docs/adapters/adapter_api.md
+++ b/docs/adapters/adapter_api.md
@@ -10,7 +10,7 @@ __TOC__
 
 An Adapter is the interface between the juttle runtime and a backend data source. The backend houses a data set, comprised of data points. Each data point contains a number of fields. In most cases, each data point also contains a timestamp.
 
-For reads, the adapter's job is to interpret the options included in the juttle `read` command into a a query that selects the matching set of points, fetch the points via the query, construct Javascript objects representing those data points, and pass them to the juttle runtime. For writes, the adapter's job is to take the output of programs, convert the data points to the native form used by the backend, and write the points to the backend.
+For reads, the adapter's job is to interpret the options included in the juttle `read` command into a a query that selects the matching set of points, fetch the points via the query, construct JavaScript objects representing those data points, and pass them to the juttle runtime. For writes, the adapter's job is to take the output of programs, convert the data points to the native form used by the backend, and write the points to the backend.
 
 More sophisticated adapters work together with the juttle optimizer to push aggregation operations directly into the backend. For example, to count the number of data points in a given time period you could simply fetch all the data points and have the juttle program perform the counting. However, if supported by the backend it would be more efficient to count the number of data points directly in the backend and return the count instead. And that's exactly what many adapters do.
 
@@ -18,13 +18,13 @@ More sophisticated adapters work together with the juttle optimizer to push aggr
 
 Here are the main steps involved in writing a new adapter:
 
-1. Create a Javascript module that can be `require()`d by the juttle runtime.
+1. Create a JavaScript module that can be `require()`d by the juttle runtime.
 2. From that module, export an initialization function to define the read/write capabilities of the adapter.
 3. Implement ES6 classes deriving from AdapterRead/AdapterWrite that perform the work of reading from/writing to the backend data source.
 
 We'll go through each of these steps in more detail below.
 
-## Javascript Modules, Classes and Methods
+## JavaScript Modules, Classes and Methods
 
 We've created the skeleton of an adapter in the [juttle-adapter-template](https://github.com/juttle/juttle-adapter-template) repository on github. That repository is a good reference for the layout of files, classes, functions, etc.
 
@@ -76,7 +76,7 @@ This object contains:
         ASTVisitor: <Utility for traversing Juttle ASTs>,
         ASTTransformer: <Utility for transforming Juttle ASTs>,
         StaticFilterCompiler: <Utility for parsing filter expressions>,
-        FilterJSCompiler: <Utility for converting filter expressions into Javascript>
+        FilterJSCompiler: <Utility for converting filter expressions into JavaScript>
     },
     parsers: <Module containing parsers for csv / json / jsonl>,
     serializers: <Module containing serializers for csv / json / jsonl>,
@@ -148,7 +148,7 @@ read <adapter> [-from <moment>] [-to <moment>] [-timeField <field>] [-raw <expre
 * `-every`: A JuttleMoment. When performing live reads, poll for new data points at this interval.
 * `-raw`: A backend-specific search parameter that is passed opaquely to the adapter. For the Gmail Adapter, the `-raw` expression is passed directly through as a Gmail advanced search string.
 
-The implementation of `read` should be a Javascript class that should inherit from the `AdapterRead` base class.
+The implementation of `read` should be a JavaScript class that should inherit from the `AdapterRead` base class.
 
 It can implement / override the following methods:
 
@@ -232,7 +232,7 @@ This should return a promise that resolves when all output, including any output
 
 Unlike `read`, there are no conventions for a standard set of options supported by all adapters. In general, options related to configuration (hostnames, API keys, etc) should be specified in the adapter's configuration rather than provided as arguments to the `write` proc.
 
-The implementation of `write` should be a Javascript class that should inherit from the `AdapterWrite` base class.
+The implementation of `write` should be a JavaScript class that should inherit from the `AdapterWrite` base class.
 
 It can implement / override the following methods:
 
@@ -270,7 +270,7 @@ Called when the flow of points has ended. Returns a promise that should resolve 
 
 To log messages, use the logger instance variable, for example:
 
-```Javascript
+```javascript
 this.logger.debug(`Got ${response.messages.length} potential messages`);
 ```
 
@@ -280,7 +280,7 @@ Log messages are passed through the Juttle runtime and eventually logged to file
 
 To throw errors, use the methods `compileError` or `runtimeError` in the `AdapterRead` base class to construct an error and throw() it. Here's an example:
 
-```Javascript
+```javascript
 var unknown = _.difference(_.keys(options), this.allowed_options);
 if (unknown.length > 0) {
     throw this.compile_error('UNKNOWN-OPTION-ERROR', {

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -44,7 +44,7 @@ emit -limit 10
       points_cubed=Math.pow(num_points, 3)
 ```
 
-Users can define their own Juttle functions, using the `function` keyword. The syntax is similar to Javascript functions, although parameters can be given default values.
+Users can define their own Juttle functions, using the `function` keyword. The syntax is similar to JavaScript functions, although parameters can be given default values.
 
 ```
 function functionName(parameter1[=default_value1], parameter2[=default_value2]...) {

--- a/docs/doc_templates/template.md
+++ b/docs/doc_templates/template.md
@@ -49,7 +49,7 @@ Syntax of a juttle proc/etc is presented below in a code block, with no section 
 function makeFencedCodeBlock() {
   // here is a code sample in a fenced code block
   // don't use four-space-indenting approach, we prefer fencing with triple backticks
-  // this uses javascript syntax highlighting
+  // this uses JavaScript syntax highlighting
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ If a particular backend is not yet supported, an adapter for it can be
 added in a relatively straightforward manner using
 Juttle's backend adapter API.
 
-Under the hood, the Juttle compiler generates javascript
+Under the hood, the Juttle compiler generates JavaScript
 output that implements the Juttle dataflow computation by
 executing alongside the Juttle runtime, either in node or the
 browser.  The Juttle optimizer figures out the pattern of queries
@@ -84,7 +84,7 @@ the output of Spark can feed the input of Juttle (the Juttle Spark adapter
 is currently under development).
 An interesting future extension for Juttle would be to adapt
 the Juttle compiler and runtime to generate scala in addition to
-javascript as a target output langauge and leverage the Spark infrastructure
+JavaScript as a target output langauge and leverage the Spark infrastructure
 for Juttle programs.
 
 ## How To Navigate

--- a/docs/juttle_ecosystem.md
+++ b/docs/juttle_ecosystem.md
@@ -4,7 +4,7 @@
 
 The Juttle Ecosystem consists of the following projects:
 
-* [juttle](https://github.com/juttle/juttle) contains the core Juttle compiler, the Javascript runtime, a set of basic adapters to connect to files or http sources, and a command line interface with text-based and tabular views.
+* [juttle](https://github.com/juttle/juttle) contains the core Juttle compiler, the JavaScript runtime, a set of basic adapters to connect to files or http sources, and a command line interface with text-based and tabular views.
 
 * [juttle-engine](https://github.com/juttle/juttle-engine) is an execution environment for Juttle, which packages together the following components into a complete development and visualization environment.
 
@@ -12,7 +12,7 @@ The Juttle Ecosystem consists of the following projects:
 
 * [juttle-viz](https://github.com/juttle/juttle-viz) is a visualization library based on D3 that can render the results of Juttle programs as streaming charts.
 
-* [juttle-client-library](https://github.com/juttle/juttle-client-library) is a client-side Javascript application that interacts with juttle-service to execute juttle programs and render the results in the browser, including support for programmable input controls.
+* [juttle-client-library](https://github.com/juttle/juttle-client-library) is a client-side JavaScript application that interacts with juttle-service to execute juttle programs and render the results in the browser, including support for programmable input controls.
 
 * [juttle-viewer](https://github.com/juttle/juttle-client-viewer) is a development and presentation application for juttle programs that packages juttle-client-library, juttle-viz, and application logic to select and run juttle programs using a remote juttle engine (either packaged within juttle-engine or standalone).
 

--- a/docs/reference/data_types.md
+++ b/docs/reference/data_types.md
@@ -13,7 +13,7 @@ Null       | Non-existing or unknown value
 Boolean    | A logical truth value, either "true" or "false"
 Number     | A number in IEEE 754 64-bit double-precision format
 String     | Zero or more Unicode characters
-RegExp     | A regular expression, [as implemented in Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+RegExp     | A regular expression, [as implemented in JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 Date       | An exact moment in time, represented by a number
 Duration   | An interval between to moments in time, represented by a numerical length
 Array      | An ordered sequence of zero or more values

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -37,11 +37,11 @@ var BINARY_OPS_TO_FUNCTIONS = {
 };
 
 //
-// generate a javascript program that when run returns a flowgraph
+// generate a JavaScript program that when run returns a flowgraph
 // datastructure representing the juttle program fully evaluated
 // in build context.  this intermediate form can then be optimized,
 // before a final pass traverses it and spits out the target implementation
-// (which is currently limited to javascript running against the
+// (which is currently limited to JavaScript running against the
 // juttle js runtime)
 //
 class Build extends CodeGenerator {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -43,8 +43,8 @@ var BINARY_OPS_TO_FUNCTIONS = {
 };
 
 //
-// take a dataflow graph representation and generate a javascript program
-// that runs against the Juttle javascript runtime
+// take a dataflow graph representation and generate a JavaScript program
+// that runs against the Juttle JavaScript runtime
 //
 class GraphCompiler extends CodeGenerator {
     constructor() {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1017,7 +1017,7 @@ class SemanticPass {
     // previously parsed. this gets added to the tree for later use.
     // XXX would be helpful to include all the functions referenced so we can
     // make sure those that are needed are compiled into the final output
-    // in the target language (as of 2014, just javascript) and available
+    // in the target language (as of 2014, just JavaScript) and available
     // in the juttle runtime
     //
     sa_reducers(reducers) {

--- a/lib/config/read-config.js
+++ b/lib/config/read-config.js
@@ -15,7 +15,7 @@
 //   $HOME/.juttle/config.json
 //
 // The files are loaded using require(path) so they can be either JSON or
-// javascript.
+// JavaScript.
 //
 /* eslint-env node */
 var path = require('path');

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -308,7 +308,7 @@ describe('Juttle basic language tests', function() {
     });
 
 
-    it('fails if an expression has a syntax error (javascript section)', function() {
+    it('fails if an expression has a syntax error (JavaScript section)', function() {
         return check_juttle({
             program: 'const foo = 5+; read file -file "input/simple-non-monotonic-time.json" | put snarks=#grumpkins+foo | view sink1',
         })
@@ -501,7 +501,7 @@ describe('Juttle basic language tests', function() {
         });
     });
 
-    it('fails if a Javascript variable is undefined', function() {
+    it('fails if a JavaScript variable is undefined', function() {
         return check_juttle({
             program:
                 'const foo=bar;' +
@@ -522,7 +522,7 @@ describe('Juttle basic language tests', function() {
         });
     });
 
-    it('fails if a variable is redefined in the javascript section', function() {
+    it('fails if a variable is redefined in the JavaScript section', function() {
         return check_juttle({
             program:
                 'const foo=1.2;' +

--- a/test/runtime/specs/juttle-spec/modules/math.spec.md
+++ b/test/runtime/specs/juttle-spec/modules/math.spec.md
@@ -23,7 +23,7 @@
     }
 
 ## All the functions are here
-Since these are currently implemented as direct javascript
+Since these are currently implemented as direct JavaScript
 Math.* invocations, we merely test for existence,
 to catch any accidental language removals.
 


### PR DESCRIPTION
Change from Javascript to JavaScript. As far as I can tell, this is _the_ accepted way to spell/capitalize it.

@mstemm @dmajda 