### PR TITLE
Fix moved variable checks

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -58,7 +58,7 @@ class SemanticPass {
         this.context = 'build';
         this.coercion_mode = 'none';
         this.lhs = false;
-        this.in_member_expression = false;
+        this.expr_mode = 'result';
         this.reducers = null;
         this.index = null;
 
@@ -346,13 +346,13 @@ class SemanticPass {
             this.lhs = saved_lhs;
         }
     }
-    with_in_member_expression(in_member_expression, fn) {
-        var saved_in_member_expression = this.in_member_expression;
-        this.in_member_expression = in_member_expression;
+    with_expr_mode(expr_mode, fn) {
+        var saved_expr_mode = this.expr_mode;
+        this.expr_mode = expr_mode;
         try {
             fn();
         } finally {
-            this.in_member_expression = saved_in_member_expression;
+            this.expr_mode = saved_expr_mode;
         }
     }
 
@@ -1407,7 +1407,7 @@ class SemanticPass {
             // We don't need to process variables inside call expressions (e.g.
             // "foo" in "foo()") because they are handled by sa_CallExpression
             // (for now).
-            if (!this.in_member_expression) {
+            if (this.expr_mode === 'result') {
                 if (symbol.type !== 'const' && symbol.type !== 'var') {
                     throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
                         thing: SYMBOL_TYPE_NAMES[symbol.type],
@@ -1455,7 +1455,7 @@ class SemanticPass {
     sa_MemberExpression(node) {
         var symbol;
 
-        this.with_in_member_expression(true, () => {
+        this.with_expr_mode('member', () => {
             this.sa_expr(node.object);
         });
         this.sa_expr(node.property);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -461,7 +461,9 @@ class SemanticPass {
         var d = true;
         if (args) {
             for (k = 0; k < args.length; ++k) {
-                this.sa_expr(args[k]);
+                this.with_expr_mode('result', () => {
+                    this.sa_expr(args[k]);
+                });
                 d = d && args[k].d;
             }
         }
@@ -775,10 +777,12 @@ class SemanticPass {
     // this type of assignment lives in places where there can be
     // points or reducers
     sa_AssignmentExpression(node) {
-        this.with_lhs(true, () => {
-            this.sa_assignment_lhs(node.left);
+        this.with_expr_mode('result', () => {
+            this.with_lhs(true, () => {
+                this.sa_assignment_lhs(node.left);
+            });
+            this.sa_expr(node.right);
         });
-        this.sa_expr(node.right);
         node.d = node.left.d && node.right.d;
     }
     sa_VarStatement(node) {
@@ -967,8 +971,10 @@ class SemanticPass {
         node.d = d;
     }
     sa_ObjectProperty(node) {
-        this.sa_expr(node.key);
-        this.sa_expr(node.value);
+        this.with_expr_mode('result', () => {
+            this.sa_expr(node.key);
+            this.sa_expr(node.value);
+        });
         node.d = node.key.d && node.value.d;
     }
     sa_RegExpLiteral(node) {
@@ -991,7 +997,9 @@ class SemanticPass {
         } else {
             // reducer *arguments* are evaluated at build time
             this.with_context('build', () => {
-                this.sa_expr(arg);
+                this.with_expr_mode('result', () => {
+                    this.sa_expr(arg);
+                });
             });
         }
     }
@@ -1223,7 +1231,9 @@ class SemanticPass {
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
                 this.with_lhs(true, () => {
-                    this.sa_expr(node.expression);
+                    this.with_expr_mode('result', () => {
+                        this.sa_expr(node.expression);
+                    });
                 });
                 if (!this.scope.is_mutable(name, this.scope.type)) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
@@ -1299,10 +1309,14 @@ class SemanticPass {
 
         if (op === '++' || op === '--') {
             this.with_lhs(true, () => {
-                this.sa_expr(node.argument);
+                this.with_expr_mode('result', () => {
+                    this.sa_expr(node.argument);
+                });
             });
         } else {
-            this.sa_expr(node.argument);
+            this.with_expr_mode('result', () => {
+                this.sa_expr(node.argument);
+            });
         }
 
         if (op === '*') {
@@ -1329,14 +1343,18 @@ class SemanticPass {
         }
     }
     sa_BinaryExpression(node) {
-        this.sa_expr(node.left);
-        this.sa_expr(node.right);
+        this.with_expr_mode('result', () => {
+            this.sa_expr(node.left);
+            this.sa_expr(node.right);
+        });
         node.d = node.left.d && node.right.d;
     }
     sa_ConditionalExpression(node) {
-        this.sa_expr(node.test);
-        this.sa_expr(node.alternate);
-        this.sa_expr(node.consequent);
+        this.with_expr_mode('result', () => {
+            this.sa_expr(node.test);
+            this.sa_expr(node.alternate);
+            this.sa_expr(node.consequent);
+        });
         //XXX can be smarter than this
         node.d = node.test.d && node.alternate.d && node.consequent.d;
     }
@@ -1344,7 +1362,9 @@ class SemanticPass {
         var k;
         var d = true;
         for (k = 0; k < node.parts.length; k++) {
-            this.sa_expr(node.parts[k]);
+            this.with_expr_mode('result', () => {
+                this.sa_expr(node.parts[k]);
+            });
             d = d && node.parts[k].d;
         }
         node.d = d;
@@ -1353,7 +1373,9 @@ class SemanticPass {
         var k;
         var d = true;
         for (k = 0; k < node.elements.length; k++) {
-            this.sa_expr(node.elements[k]);
+            this.with_expr_mode('result', () => {
+                this.sa_expr(node.elements[k]);
+            });
             d = d && node.elements[k].d;
         }
         node.d = d;
@@ -1458,7 +1480,9 @@ class SemanticPass {
         this.with_expr_mode('member', () => {
             this.sa_expr(node.object);
         });
-        this.sa_expr(node.property);
+        this.with_expr_mode('result', () => {
+            this.sa_expr(node.property);
+        });
 
         if (this.lhs) {
             if (!node.computed) {

--- a/test/runtime/specs/juttle-spec/expressions/variable.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/variable.spec.md
@@ -60,6 +60,18 @@
 
    * Cannot use a module as a variable
 
+## Throws an error when a built-in module name is used in a const declaration (inside a member expression object)
+
+Regression test for the issue fixed by #552.
+
+### Juttle
+
+    const d = (Date + 1)[0]; emit -limit 1
+
+### Errors
+
+   * Cannot use a module as a variable
+
 ## Throws an error when a built-in module name is used in a by list
 
 ### Juttle
@@ -85,6 +97,19 @@
 ### Juttle
 
     function f() {return 1;}; const d = f; emit -limit 1
+
+### Errors
+
+   * Cannot use a function as a variable
+
+
+## Throws an error when a function name is used in a const declaration (inside a member expression object)
+
+Regression test for the issue fixed by #552.
+
+### Juttle
+
+    function f() {return 1;}; const d = (f + 1)[0]; emit -limit 1
 
 ### Errors
 
@@ -123,6 +148,24 @@
     }
 
     const d = r; emit -limit 1
+
+### Errors
+
+   * Cannot use a reducer as a variable
+
+
+## Throws an error when a reducer name is used in a const declaration (inside a member expression object)
+
+Regression test for the issue fixed by #552.
+
+### Juttle
+
+    reducer r() {
+      function update() { }
+      function result() { }
+    }
+
+    const d = (r + 1)[0]; emit -limit 1
 
 ### Errors
 


### PR DESCRIPTION
Variable checks in the semantic were incomplete. For example, the compiler correctly reported that `f` can’t be used as a variable in cases like this:

    function f() {
    }

    const c = f[0];

but not in cases like this:

    function f() {
    }

    const c = (f + 1)[0];

This was because the `in_member_expression` flag wasn’t reset back to `false` when processing expressions deeper in `MemberExpression`’s object.

This PR fixes that and also generalizes the flag a bit in anticipation of upcoming refactorings.

Part of work on #419 (really a fix to #544).