### PR TITLE
Allow ctrl-c to stop programs (politely)

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -18,6 +18,14 @@ process.stdout.on('error', function( err ) {
     }
 });
 
+var current_program = undefined;
+process.on('SIGINT', function() {
+    if (current_program) {
+        logger.debug('ctrl-c received, stopping current program');
+        current_program.deactivate();
+    }
+});
+
 var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
@@ -193,6 +201,13 @@ function perform_run(options) {
             console.warn('Warning: ' + msg);
         });
 
+        current_program = program;
+
+        // Change stdin to non-raw mode
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(false);
+        }
+
         // Start the program.
         program.activate();
 
@@ -205,6 +220,11 @@ function perform_run(options) {
         })
         .then(function() {
             program.deactivate();
+        }).finally(function() {
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(true);
+            }
+            current_program = undefined;
         });
     });
 }

--- a/bin/juttle
+++ b/bin/juttle
@@ -203,11 +203,6 @@ function perform_run(options) {
 
         current_program = program;
 
-        // Change stdin to non-raw mode
-        if (process.stdin.isTTY) {
-            process.stdin.setRawMode(false);
-        }
-
         // Start the program.
         program.activate();
 
@@ -221,9 +216,6 @@ function perform_run(options) {
         .then(function() {
             program.deactivate();
         }).finally(function() {
-            if (process.stdin.isTTY) {
-                process.stdin.setRawMode(true);
-            }
             current_program = undefined;
         });
     });
@@ -364,9 +356,20 @@ function setupCline() {
         if (in_multi_line) {
             multi_line_src += input + '\n';
         } else {
+
+            // Change stdin to non-raw mode so the program can be
+            // interrupted.
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(false);
+            }
+
             perform_mode({
                 action: mode,
                 juttle_src: input
+            }).finally(function() {
+                if (process.stdin.isTTY) {
+                    process.stdin.setRawMode(true);
+                }
             });
         }
     });

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -25,7 +25,7 @@ class emit extends source {
         var allowedOptions = _.union(_.keys(INFO.options), _.keys(INFO._options));
         this.validate_options(allowedOptions);
 
-        this.teardown_rcvd = false;
+        this.teardown_received = false;
 
         this.handleTimeOptions(options);
 
@@ -175,7 +175,7 @@ class emit extends source {
     run(ts) {
         // If we received a teardown, just emit an eof and don't
         // schedule any more work.
-        if (this.teardown_rcvd) {
+        if (this.teardown_received) {
             this.emit_eof();
             return;
         }
@@ -198,7 +198,7 @@ class emit extends source {
 
     teardown() {
         this.logger.debug('Got teardown, scheduling eof');
-        this.teardown_rcvd = true;
+        this.teardown_received = true;
     }
 
 

--- a/lib/runtime/procs/emit.js
+++ b/lib/runtime/procs/emit.js
@@ -25,6 +25,8 @@ class emit extends source {
         var allowedOptions = _.union(_.keys(INFO.options), _.keys(INFO._options));
         this.validate_options(allowedOptions);
 
+        this.teardown_rcvd = false;
+
         this.handleTimeOptions(options);
 
         if (_.has(options, 'every') && !options.every.duration) {
@@ -171,6 +173,13 @@ class emit extends source {
         function() { self.run(ts); });
     }
     run(ts) {
+        // If we received a teardown, just emit an eof and don't
+        // schedule any more work.
+        if (this.teardown_rcvd) {
+            this.emit_eof();
+            return;
+        }
+
         // Check if it's time to send the next point or emit ticks
         var pt = this.next_point(false);
         if (!pt.time || pt.time.lte(ts)) {
@@ -186,6 +195,12 @@ class emit extends source {
             this.emit_eof();
         }
     }
+
+    teardown() {
+        this.logger.debug('Got teardown, scheduling eof');
+        this.teardown_rcvd = true;
+    }
+
 
     static get info() {
         return INFO;

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -486,4 +486,42 @@ describe('Juttle CLI Tests', function() {
             });
         });
     });
+
+    describe('interrupts', function() {
+
+        it('can be interrupted by ctrl-c for a program using emit', function() {
+            return runJuttle(
+                ['-e', 'emit -every :1s: -limit 60| view text -format "jsonl"'],
+                {
+                    env: {DEBUG: '*'},
+                    signalAfter: {
+                        signal: 'SIGINT',
+                        delay: 1000
+                    }
+                }
+            )
+            .then(function(result) {
+                expect(result.stdout).to.match(/ctrl-c received, stopping current program/);
+            });
+        });
+
+        it('can be interrupted by ctrl-c for a program using read', function() {
+            return runJuttle(
+                ['-e', 'read stochastic -source "logs" -from :now: -to :end: | view text -format "jsonl"'],
+                {
+                    env: {DEBUG: '*'},
+                    signalAfter: {
+                        signal: 'SIGINT',
+                        delay: 1000
+                    }
+                }
+            )
+            .then(function(result) {
+                expect(result.stdout).to.match(/ctrl-c received, stopping current program/);
+            });
+        });
+
+    });
+
+
 });

--- a/test/cli/util.js
+++ b/test/cli/util.js
@@ -39,6 +39,12 @@ module.exports.runJuttle = function(args, options) {
                     proc.stdin.write(options.stdin);
                 }
 
+                if (options.signalAfter) {
+                    setTimeout(function() {
+                        proc.kill(options.signalAfter.signal);
+                    }, options.signalAfter.delay);
+                }
+
                 proc.stdout.on('data', function (data) {
                     stdout += data;
                 });


### PR DESCRIPTION
Allow ctrl-c to stop programs by adding a signal handler for SIGINT
that calls program.deactivate(). bin/juttle must also set standard
input to non-raw mode while the program is running so ctrl-c isn't
read by the cli directly.

Read already handles teardown properly in a limited way--after any
pending read has completed, the adapter is torn down and emits an
eof. An in-progress read is not stopped, though.

Emit required changes, though--add a teardown method that sets
a flag. The next time run() is called, it checks the flag and emits
eof() if set.

With these changes, a program won't be stopped until the next emit
happens or a read in progress has completed. If we want immediate
program cancellation, we'd have to make some additional changes:

 - Modify the scheduler to return ids from all calls to schedule so
   any pending callbacks could be cancelled, or do a wholesale
   teardown itself.

 - Start cancelling the read promise in read's teardown.

I think the current polite teardown is fairly nice as it results in a
relatively clean set of data and stil mostly meets the goal of
allowing program teardown, so I think we should try it first.

This fixes #31.

@demmer @bkutil @dmajda 