### PR TITLE
SemanticPass: Call sa_MemberExpression in sa_CallExpression

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -184,12 +184,6 @@ class Scope {
     lookup_module_sub(mod, name) {
         return this.lookup_module_any(mod, name, 'sub');
     }
-    lookup_module_func(mod, name) {
-        return this.lookup_module_any(mod, name, 'function');
-    }
-    lookup_module_reducer(mod, name) {
-        return this.lookup_module_any(mod, name, 'reducer');
-    }
 }
 
 module.exports = {

--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -106,7 +106,7 @@ class Scope {
     }
     define_import(name, exports, location) {
         this.check_not_redefined(name, 'import', location);
-        var symbol = { type: 'import', exported: false, exports: exports, d: true };
+        var symbol = { type: 'import', exported: false, exports: exports };
         this.put(name, symbol);
         return symbol;
     }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1259,30 +1259,6 @@ class SemanticPass {
         }
     }
     sa_CallExpression(node) {
-        var symbol;
-        if (node.callee.type === 'MemberExpression') {
-            symbol = this.scope.lookup_module_reducer(node.callee.object.name, node.callee.property.value);
-            if (symbol) {
-                node.callee.symbol = symbol;
-                node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.sa_reducer_call(node, symbol);
-                return;
-            } else {
-                symbol = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
-                if (symbol === undefined) {
-                    throw errors.compileError('NOT-EXPORTED', {
-                        name: node.callee.property.value,
-                        module: node.callee.object.name,
-                        location: node.location
-                    });
-                }
-                node.callee.symbol = symbol;
-                node.callee.object.symbol = this.scope.get(node.callee.object.name);
-                this.sa_function_call(node, symbol);
-                return;
-            }
-        }
-
         this.with_expr_mode('call', () => {
             this.sa_expr(node.callee);
         });

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1546,7 +1546,11 @@ class SemanticPass {
             }
         }
 
-        node.d = node.object.d && node.property.d;
+        if (node.symbol) {
+            node.d = symbol.d;
+        } else {
+            node.d = node.object.d && node.property.d;
+        }
     }
 }
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -511,6 +511,33 @@ class SemanticPass {
             });
         }
     }
+    check_symbol(node, symbol) {
+        // We can be in one of 3 situations:
+        //
+        //   1. We are processing a "bare" variable (one that has no ".",
+        //      "[...]" or "(...)" operator applied to it). In that case, we
+        //      need to check variable's symbol type (there is nobody else
+        //      who can do that).
+        //
+        //   2. We are processing a variable inside a member expression
+        //      (e.g. "foo" in "foo.bar" or "foo['bar']"). In that case, we
+        //      don't check anything because all the checks will be
+        //      performed by sa_MemberExpression (which has necessary
+        //      context).
+        //
+        //   3. We are processing a variable inside a call expressions (e.g.
+        //      "foo" in "foo()"). In that case, we also don't check
+        //      anything because all the checks will be performed by
+        //      sa_CallExpression (which has necessary context).
+        if (this.expr_mode === 'result') {
+            if (symbol.type !== 'const' && symbol.type !== 'var') {
+                throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
+                    thing: SYMBOL_TYPE_NAMES[symbol.type],
+                    location: node.location
+                });
+            }
+        }
+    }
 
     // statements that can appear inside subs or at the top level
     sa_statement(node) {
@@ -1414,31 +1441,7 @@ class SemanticPass {
         }
 
         if (symbol) {
-            // We can be in one of 3 situations:
-            //
-            //   1. We are processing a "bare" variable (one that has no ".",
-            //      "[...]" or "(...)" operator applied to it). In that case, we
-            //      need to check variable's symbol type (there is nobody else
-            //      who can do that).
-            //
-            //   2. We are processing a variable inside a member expression
-            //      (e.g. "foo" in "foo.bar" or "foo['bar']"). In that case, we
-            //      don't check anything because all the checks will be
-            //      performed by sa_MemberExpression (which has necessary
-            //      context).
-            //
-            //   3. We are processing a variable inside a call expressions (e.g.
-            //      "foo" in "foo()"). In that case, we also don't check
-            //      anything because all the checks will be performed by
-            //      sa_CallExpression (which has necessary context).
-            if (this.expr_mode === 'result') {
-                if (symbol.type !== 'const' && symbol.type !== 'var') {
-                    throw errors.compileError('CANNOT-USE-AS-VARIABLE', {
-                        thing: SYMBOL_TYPE_NAMES[symbol.type],
-                        location: node.location
-                    });
-                }
-            }
+            this.check_symbol(node, symbol);
 
             node.symbol = symbol;
             node.d = symbol.d;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1529,7 +1529,7 @@ class SemanticPass {
                     }
 
                     if (node.object.symbol.type === 'import') {
-                        symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
+                        symbol = node.object.symbol.exports[node.property.value];
                         if (symbol === undefined) {
                             throw errors.compileError('NOT-EXPORTED', {
                                 name: node.property.value,
@@ -1537,6 +1537,8 @@ class SemanticPass {
                                 location: node.location
                             });
                         }
+
+                        this.check_symbol(node, symbol);
 
                         node.symbol = this.scope.get(node.object.name).exports[node.property.value];
                     }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1108,7 +1108,6 @@ class SemanticPass {
             sub = this.scope.lookup_module_sub(node.op.object.name, node.op.property.value);
             if (sub === undefined) {
                 throw errors.compileError('NOT-EXPORTED', {
-                    thing: 'sub',
                     name: node.op.property.value,
                     module: node.op.object.name,
                     location: node.location
@@ -1257,7 +1256,6 @@ class SemanticPass {
                 symbol = this.scope.lookup_module_func(node.callee.object.name, node.callee.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
-                        thing: 'function',
                         name: node.callee.property.value,
                         module: node.callee.object.name,
                         location: node.location
@@ -1493,7 +1491,6 @@ class SemanticPass {
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {
                     throw errors.compileError('NOT-EXPORTED', {
-                        thing: 'variable',
                         name: node.property.value,
                         module: node.object.name,
                         location: node.location
@@ -1532,7 +1529,6 @@ class SemanticPass {
                         symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                         if (symbol === undefined) {
                             throw errors.compileError('NOT-EXPORTED', {
-                                thing: 'variable',
                                 name: node.property.value,
                                 module: node.object.name,
                                 location: node.location

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -126,8 +126,7 @@ class SemanticPass {
                 seed:   { type: 'function', exported: true, uname: 'juttle.modules.math.seed',   arg_count: 1             },
                 sqrt:   { type: 'function', exported: true, uname: 'juttle.modules.math.sqrt',   arg_count: 1             },
                 tan:    { type: 'function', exported: true, uname: 'juttle.modules.math.tan',    arg_count: 1             },
-            },
-            d: true
+            }
         });
     }
     import_null_module() {
@@ -137,8 +136,7 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.null.toString', arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_array_module() {
@@ -161,8 +159,7 @@ class SemanticPass {
                 splice: { type: 'function', exported: true, uname: 'juttle.modules.array.splice', arg_count: [1, Infinity]},
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.array.toString', arg_count: 1},
                 unshift:  { type: 'function', exported: true, uname: 'juttle.modules.array.unshift',   arg_count: [1, Infinity] },
-            },
-            d: true
+            }
         });
     }
     import_boolean_module() {
@@ -172,8 +169,7 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.boolean.toString', arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_number_module() {
@@ -191,8 +187,7 @@ class SemanticPass {
                 /* Functions (sorted alphabetically) */
                 fromString: { type: 'function', exported: true, uname: 'juttle.modules.number.fromString', arg_count: 1 },
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.number.toString', arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_string_module() {
@@ -219,8 +214,7 @@ class SemanticPass {
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.string.toString', arg_count: 1   },
                 toUpperCase: { type: 'function', exported: true, uname: 'juttle.modules.string.toUpperCase', arg_count: 1   },
                 trim: { type: 'function', exported: true, uname: 'juttle.modules.string.trim', arg_count: 1                 },
-            },
-            d: true
+            }
         });
     }
     import_object_module() {
@@ -232,8 +226,7 @@ class SemanticPass {
                 keys: { type: 'function', exported: true, uname: 'juttle.modules.object.keys', arg_count: 1 },
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.object.toString', arg_count: 1},
                 values: { type: 'function', exported: true, uname: 'juttle.modules.object.values', arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_regexp_module() {
@@ -243,8 +236,7 @@ class SemanticPass {
             exports: {
                 /* Functions (sorted alphabetically) */
                 toString: { type: 'function', exported: true, uname: 'juttle.modules.regexp.toString', arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_date_module() {
@@ -266,8 +258,7 @@ class SemanticPass {
                 toString:    { type: 'function', exported: true, uname: 'juttle.modules.date.toString',    arg_count: 1      },
                 unix:        { type: 'function', exported: true, uname: 'juttle.modules.date.unix',        arg_count: 1      },
                 unixms:      { type: 'function', exported: true, uname: 'juttle.modules.date.unixms',      arg_count: 1      },
-            },
-            d: true
+            }
         });
     }
     import_duration_module() {
@@ -283,8 +274,7 @@ class SemanticPass {
                 new:          { type: 'function', exported: true, uname: 'juttle.modules.duration.new',          arg_count: 1 },
                 seconds:      { type: 'function', exported: true, uname: 'juttle.modules.duration.seconds',      arg_count: 1 },
                 toString:     { type: 'function', exported: true, uname: 'juttle.modules.duration.toString',     arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_json_module() {
@@ -294,8 +284,7 @@ class SemanticPass {
             exports: {
                 parse:       { type: 'function', exported: true, uname: 'juttle.modules.json.parse',       arg_count: 1 },
                 stringify:   { type: 'function', exported: true, uname: 'juttle.modules.json.stringify',   arg_count: 1 },
-            },
-            d: true
+            }
         });
     }
     import_juttle_module() {
@@ -305,8 +294,7 @@ class SemanticPass {
             exports: {
                 version: { type: 'const', exported: true, uname: 'juttle.modules.juttle.version', d: true },
                 adapters: { type: 'function', exported: true, uname: 'juttle.modules.juttle.adapters' }
-            },
-            d: true
+            }
         });
     }
     analyze(ast) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1540,7 +1540,7 @@ class SemanticPass {
 
                         this.check_symbol(node, symbol);
 
-                        node.symbol = this.scope.get(node.object.name).exports[node.property.value];
+                        node.symbol = symbol;
                     }
                 }
             }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -98,14 +98,14 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Constants */
-                E:      { type: 'const', exported: true, uname: 'Math.E'                                   },
-                LN10:   { type: 'const', exported: true, uname: 'Math.LN10'                                },
-                LN2:    { type: 'const', exported: true, uname: 'Math.LN2'                                 },
-                LOG2E:  { type: 'const', exported: true, uname: 'Math.LOG2E'                               },
-                LOG10E: { type: 'const', exported: true, uname: 'Math.LOG10E'                              },
-                PI:     { type: 'const', exported: true, uname: 'Math.PI'                                  },
-                SQRT1_2:{ type: 'const', exported: true, uname: 'Math.SQRT1_2'                             },
-                SQRT2:  { type: 'const', exported: true, uname: 'Math.SQRT2'                               },
+                E:      { type: 'const', exported: true, uname: 'Math.E',       d: true                    },
+                LN10:   { type: 'const', exported: true, uname: 'Math.LN10',    d: true                    },
+                LN2:    { type: 'const', exported: true, uname: 'Math.LN2',     d: true                    },
+                LOG2E:  { type: 'const', exported: true, uname: 'Math.LOG2E',   d: true                    },
+                LOG10E: { type: 'const', exported: true, uname: 'Math.LOG10E',  d: true                    },
+                PI:     { type: 'const', exported: true, uname: 'Math.PI',      d: true                    },
+                SQRT1_2:{ type: 'const', exported: true, uname: 'Math.SQRT1_2', d: true                    },
+                SQRT2:  { type: 'const', exported: true, uname: 'Math.SQRT2',   d: true                    },
                 /* Functions */
                 abs:    { type: 'function', exported: true, uname: 'juttle.modules.math.abs',    arg_count: 1             },
                 acos:   { type: 'function', exported: true, uname: 'juttle.modules.math.acos',   arg_count: 1             },
@@ -182,11 +182,11 @@ class SemanticPass {
             exported: false,
             exports: {
                 /* Constants (sorted alphabetically) */
-                MAX_VALUE:         { type: 'const', exported: true, uname: 'Number.MAX_VALUE'         },
-                MIN_VALUE:         { type: 'const', exported: true, uname: 'Number.MIN_VALUE'         },
-                NaN:               { type: 'const', exported: true, uname: 'Number.NaN'               },
-                NEGATIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.NEGATIVE_INFINITY' },
-                POSITIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.POSITIVE_INFINITY' },
+                MAX_VALUE:         { type: 'const', exported: true, uname: 'Number.MAX_VALUE',         d: true },
+                MIN_VALUE:         { type: 'const', exported: true, uname: 'Number.MIN_VALUE',         d: true },
+                NaN:               { type: 'const', exported: true, uname: 'Number.NaN',               d: true },
+                NEGATIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.NEGATIVE_INFINITY', d: true },
+                POSITIVE_INFINITY: { type: 'const', exported: true, uname: 'Number.POSITIVE_INFINITY', d: true },
 
                 /* Functions (sorted alphabetically) */
                 fromString: { type: 'function', exported: true, uname: 'juttle.modules.number.fromString', arg_count: 1 },
@@ -303,7 +303,7 @@ class SemanticPass {
             type: 'import',
             exported: false,
             exports: {
-                version: { type: 'const', exported: true, uname: 'juttle.modules.juttle.version' },
+                version: { type: 'const', exported: true, uname: 'juttle.modules.juttle.version', d: true },
                 adapters: { type: 'function', exported: true, uname: 'juttle.modules.juttle.adapters' }
             },
             d: true

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -86,7 +86,7 @@
   "NON-TOPLEVEL-IMPORT": "Cannot import from within a {entity}",
   "CYCLIC-IMPORT": "Import cycle detected ({path})",
   "REDUCER-TOPLEVEL-STATEMENT": "Cannot use {thing} at the top level of a reducer.",
-  "NOT-EXPORTED": "{thing} '{name}' is not exported by module {module}",
+  "NOT-EXPORTED": "'{name}' is not exported by module {module}",
   "WRONG-ARG-COUNT-SINGULAR": "{type} {name} expects 1 argument but was called with {actual_count}",
   "WRONG-ARG-COUNT-PLURAL": "{type} {name} expects {expected_count} arguments but was called with {actual_count}",
   "WRONG-ARG-COUNT-RANGE": "{type} {name} expects {min_count} to {max_count} arguments but was called with {actual_count}",

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -283,7 +283,7 @@ describe('Juttle basic language tests', function() {
         })
         .catch(function(err) {
             expect(err.name).to.equal('CompileError');
-            expect(err.message).to.match(/.* not exported by/);
+            expect(err.message).to.match(/.* is not defined/);
         });
     });
 

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -283,7 +283,7 @@ describe('Juttle basic language tests', function() {
         })
         .catch(function(err) {
             expect(err.name).to.equal('CompileError');
-            expect(err.message).to.match(/function .* not exported by/);
+            expect(err.message).to.match(/.* not exported by/);
         });
     });
 
@@ -296,7 +296,7 @@ describe('Juttle basic language tests', function() {
         })
         .catch(function(err) {
             expect(err.name).to.equal('CompileError');
-            expect(err.message).to.match(/sub .* not exported by/);
+            expect(err.message).to.match(/.* not exported by/);
         });
     });
 

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
@@ -31,7 +31,7 @@
 
 ### Errors
 
-  * CompileError: 'f' is not exported by module m
+  * CompileError: Cannot use a function as a variable
 
 ## Produces an error when used on a module, accessing a reducer
 
@@ -50,7 +50,7 @@
 
 ### Errors
 
-  * CompileError: 'r' is not exported by module m
+  * CompileError: Cannot use a reducer as a variable
 
 ## Produces an error when used on a module, accessing a subgraph
 
@@ -68,4 +68,4 @@
 
 ### Errors
 
-  * CompileError: 's' is not exported by module m
+  * CompileError: Cannot use a subgraph as a variable

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-modules.spec.md
@@ -31,7 +31,7 @@
 
 ### Errors
 
-  * CompileError: variable 'f' is not exported by module m
+  * CompileError: 'f' is not exported by module m
 
 ## Produces an error when used on a module, accessing a reducer
 
@@ -50,7 +50,7 @@
 
 ### Errors
 
-  * CompileError: variable 'r' is not exported by module m
+  * CompileError: 'r' is not exported by module m
 
 ## Produces an error when used on a module, accessing a subgraph
 
@@ -68,4 +68,4 @@
 
 ### Errors
 
-  * CompileError: variable 's' is not exported by module m
+  * CompileError: 's' is not exported by module m


### PR DESCRIPTION
This is basically the same thing as #561, just for `MemberExpression`. This concludes refactoring of `sa_CallExpression`, which now doesn’t contain various symbol-manipulating and symbol-checking code that doesn’t belong there and relies fully on `sa_Variable` and `sa_MemberExpression` to handle this.

A nice side effect of the change is fixing several incorrect error messages.

Part of work on #419.