### PR TITLE
Represent marks as objects

### DIFF
--- a/lib/runtime/procs/base.js
+++ b/lib/runtime/procs/base.js
@@ -163,8 +163,8 @@ class base {
             this.trigger('error', err);
         }
     }
-    consume_mark(time, from) {
-        this.mark(time);
+    consume_mark(mark, from) {
+        this.mark(mark);
     }
     consume_tick(time, from) {
         this.tick(time);
@@ -180,8 +180,8 @@ class base {
     process(points) {
         this.emit(points);
     }
-    mark(time) {
-        this.emit_mark(time);
+    mark(mark) {
+        this.emit_mark(mark);
     }
     tick(time) {
         this.emit_tick(time);
@@ -210,10 +210,10 @@ class base {
         this.last_used_output = output_name || DEFAULT_OUT_NAME;
         this.stats.points_out += points.length;
     }
-    emit_mark(time, output_name) {
+    emit_mark(mark, output_name) {
         var k, out = this.out(output_name);
         for (k = 0; k < out.length; ++k) {
-            out[k].proc.consume_mark(time, out[k].from);
+            out[k].proc.consume_mark(mark, out[k].from);
         }
     }
     emit_tick(time, output_name) {

--- a/lib/runtime/procs/batch.js
+++ b/lib/runtime/procs/batch.js
@@ -80,7 +80,7 @@ class batch extends periodic_fanin {
         this.emit(points);
     }
     advance_epoch(epoch) {
-        this.emit_mark(epoch);
+        this.emit_mark({ time: epoch });
         // callers expect to receive an array of points to emit
         // which doesn't apply to batch
         return [];

--- a/lib/runtime/procs/fanin.js
+++ b/lib/runtime/procs/fanin.js
@@ -75,11 +75,11 @@ class Input {
             this.trigger('error', err);
         }
     }
-    consume_mark(time, from) {
+    consume_mark(mark, from) {
         if (this.ins.length === 1) {
-            this.mark(time) ;
+            this.mark(mark) ;
         } else {
-            this.mark_from(time, from);
+            this.mark_from(mark, from);
         }
     }
     consume_tick(time, from) {
@@ -104,8 +104,8 @@ class Input {
         _.each(points, function(pt) {
             self.advance_input({time:pt.time, point:pt}, self.in_from(from));});
     }
-    mark_from(time, from) {
-        this.advance_input({time:time, mark:true}, this.in_from(from));
+    mark_from(mark, from) {
+        this.advance_input({time:mark.time, mark:true}, this.in_from(from));
     }
     tick_from(time, from) {
         this.advance_input({time:time, tick:true}, this.in_from(from));
@@ -168,7 +168,7 @@ class Input {
 
             if (output.mark && output.time.gt(this.last_mark)) {
                 // de-dup marks
-                this.mark(output.time);
+                this.mark({ time: output.time });
                 this.last_mark = output.time;
                 this.last_emitted = output.time;
             } else if (output.tick && output.time.gt(this.last_tick)) {

--- a/lib/runtime/procs/head.js
+++ b/lib/runtime/procs/head.js
@@ -38,10 +38,10 @@ class head extends fanin {
             }
         }
     }
-    mark(time, from) {
+    mark(mark, from) {
         // process and publish each mark
         this.groups.reset();
-        this.emit_mark(time);
+        this.emit_mark(mark);
     }
     eof(from) {
         this.groups.reset();

--- a/lib/runtime/procs/join.js
+++ b/lib/runtime/procs/join.js
@@ -345,8 +345,8 @@ class join extends base {
             this.trigger('error', err);
         }
     }
-    consume_mark(time, from) {
-        this.mark_from(time, from);
+    consume_mark(mark, from) {
+        this.mark_from(mark, from);
     }
     consume_tick(time, from) {
         this.tick_from(time, from);
@@ -362,8 +362,8 @@ class join extends base {
         _.each(points, function(pt) {
             self.advance_input({time:pt.time, point:pt}, self.in_from(from));});
     }
-    mark_from(time, from) {
-        this.advance_input({time:time, mark:true}, this.in_from(from));
+    mark_from(mark, from) {
+        this.advance_input({time:mark.time, mark:true}, this.in_from(from));
     }
     tick_from(time, from) {
         this.advance_input({time:time, tick:true}, this.in_from(from));
@@ -775,7 +775,7 @@ class join extends base {
             if (time.lt(this.last_emitted)) {
                 throw new Error('join tried to emit mark out of order'); // "impossible"
             }
-            this.emit_mark(time);
+            this.emit_mark({ time: time });
             this.last_emitted = time;
             this.last_mark = time;
         }

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -47,16 +47,16 @@ class oops_fanin extends fanin {
         }
         fanin.prototype.emit.call(this, points, output_name);
     }
-    emit_mark(time, output_name) {
+    emit_mark(mark, output_name) {
         if (this.watch_oops) {
-            if (time.lt(this.last_output_time)) {
-                this.warn_oops(time, this.last_output_time);
+            if (mark.time.lt(this.last_output_time)) {
+                this.warn_oops(mark.time, this.last_output_time);
                 return;
             } else {
-                this.last_output_time = time;
+                this.last_output_time = mark.time;
             }
         }
-        fanin.prototype.emit_mark.call(this, time, output_name);
+        fanin.prototype.emit_mark.call(this, mark, output_name);
     }
     emit_tick(time, output_name) {
         if (this.watch_oops) {

--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -120,17 +120,17 @@ class pace extends fanin {
             }
         }
     }
-    mark(time) {
+    mark(mark) {
         if (this.dont_pace()) {
-            this.emit_mark(this.offset_time(time));
+            this.emit_mark({ time: this.offset_time(mark.time) });
             return;
         }
         if (!this.batched) {
             this.batched = true;
-            this.emit_mark(this.offset_time(time)); // emit first mark immediately
+            this.emit_mark({ time: this.offset_time(mark.time) }); // emit first mark immediately
         }
-        this.q.push([{time: this.offset_time(time), mark: true}]);
-        if (time.gte(this.program.now)) {
+        this.q.push([{time: this.offset_time(mark.time), mark: true}]);
+        if (mark.time.gte(this.program.now)) {
             this.has_realtime = true;
             if (!this.timer) {
                 this.playback();
@@ -206,7 +206,7 @@ class pace extends fanin {
             this.q.shift();
             this.emit_eof() ;
         } else if (this.q.length && this.q[0][0].mark) {
-            this.emit_mark(this.q[0][0].time) ; // mark end of batch (but don't shift yet)
+            this.emit_mark({ time: this.q[0][0].time }) ; // mark end of batch (but don't shift yet)
         }
     }
 

--- a/lib/runtime/procs/periodic-fanin.js
+++ b/lib/runtime/procs/periodic-fanin.js
@@ -47,9 +47,9 @@ class periodic_fanin extends oops_fanin {
     teardown() {
         this.dead = true;
     }
-    mark(time, from) {
+    mark(mark, from) {
         // ignore upstream marks, except for advancing time
-        this.advance(time);
+        this.advance(mark.time);
     }
     process_points(points) {
         // consume points, all in the same epoch

--- a/lib/runtime/procs/put.js
+++ b/lib/runtime/procs/put.js
@@ -113,11 +113,11 @@ class put extends oops_fanin {
             this.groups.reset_groups();
         }
     }
-    mark(time, from) {
+    mark(mark, from) {
         if (!this.accumulate) {
             this.reset();
         }
-        this.emit_mark(time, from);
+        this.emit_mark(mark, from);
     }
     eof() {
         this.reset();

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -97,7 +97,7 @@ class reduce_base extends periodic_fanin {
         if (this.to && this.to.lte(time)) {
             var out = this.advance_epoch(this.to);
             this.emit(out);
-            this.emit_mark(this.to);
+            this.emit_mark({ time: this.to });
         }
         return false;
     }
@@ -231,9 +231,9 @@ class reduce_batch extends reduce_base {
     process(points) {
         this.process_points(points);
     }
-    mark(time, from) {
+    mark(mark, from) {
         if (this.has_first_mark) {
-            var out = this.advance_epoch(time);
+            var out = this.advance_epoch(mark.time);
             this.emit(out, from);
         } else {
             this.has_first_mark = true;
@@ -242,7 +242,7 @@ class reduce_batch extends reduce_base {
         // those points will get timestamps epsilon less than this
         // batch end mark if they came from a sort/reduce/join
         // processor.
-        this.emit_mark(time, from);
+        this.emit_mark({ time: mark.time }, from);
     }
     eof(from) {
         var self = this;
@@ -319,7 +319,7 @@ class reduce_every extends reduce_base {
     }
     first_epoch(epoch) {
         // emit initial mark (before any points arrive)
-        this.emit_mark(epoch);
+        this.emit_mark({ time: epoch });
         this.after_first_epoch = true;
     }
     //
@@ -328,7 +328,7 @@ class reduce_every extends reduce_base {
 
     other_epoch(epoch) {
         super.other_epoch(epoch);
-        this.emit_mark(epoch);
+        this.emit_mark({ time: epoch });
     }
 
     eof(from) {
@@ -349,7 +349,7 @@ class reduce_every extends reduce_base {
             // run once more for a trailing partial batch of points
             var out = this.advance_epoch(this.next_epoch);
             this.emit(out);
-            this.emit_mark(this.next_epoch);
+            this.emit_mark({ time: this.next_epoch });
         }
         this.emit_eof();
     }

--- a/lib/runtime/procs/skip.js
+++ b/lib/runtime/procs/skip.js
@@ -39,10 +39,10 @@ class skip extends fanin {
             }
         }
     }
-    mark(time, from) {
+    mark(mark, from) {
         // process and publish each mark
         this.groups.reset();
-        this.emit_mark(time);
+        this.emit_mark(mark);
     }
     eof(from) {
         this.groups.reset();

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -82,10 +82,10 @@ class sort extends fanin {
         }
         this.n_pts += points.length;
     }
-    mark(time, from) {
+    mark(mark, from) {
         // process and publish each mark
-        this._run(time);
-        this.emit_mark(time);
+        this._run(mark.time);
+        this.emit_mark(mark);
     }
     eof(from) {
         this._run(null);

--- a/lib/runtime/procs/tail.js
+++ b/lib/runtime/procs/tail.js
@@ -43,10 +43,10 @@ class tail extends fanin {
         this.emit_ordered_points();
         this.groups.reset();
     }
-    mark(time, from) {
+    mark(mark, from) {
         // process and publish each mark
         this._run();
-        this.emit_mark(time);
+        this.emit_mark(mark);
     }
     eof(from) {
         this._run();

--- a/lib/runtime/procs/unbatch.js
+++ b/lib/runtime/procs/unbatch.js
@@ -15,7 +15,7 @@ class unbatch extends fanin {
     process(points) {
         this.emit(points);
     }
-    mark(time) { }
+    mark(mark) { }
     tick(time) {
         this.emit_tick(time);
     }

--- a/lib/runtime/procs/uniq.js
+++ b/lib/runtime/procs/uniq.js
@@ -59,9 +59,9 @@ class uniq extends fanin {
             this.emit(toEmit);
         }
     }
-    mark(time, from) {
+    mark(mark, from) {
         this.groups.reset();
-        this.emit_mark(time);
+        this.emit_mark(mark);
     }
     eof() {
         this.emit_eof();

--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -26,8 +26,8 @@ class view extends sink {
     // error/warning events and has special handling of arguments to
     // include proc names including the error/warning.
 
-    mark(time) {
-        this.program.events.emit('view:mark', {channel: this.channel, time: time});
+    mark(mark) {
+        this.program.events.emit('view:mark', {channel: this.channel, mark: mark});
     }
     tick(time) {
         this.program.events.emit('view:tick', {channel: this.channel, time: time});

--- a/lib/views/text.js
+++ b/lib/views/text.js
@@ -138,7 +138,7 @@ class TextView extends View {
     }
 
     // This is called when a batch finishes
-    mark(time) {
+    mark(mark) {
         var self = this;
 
         if (!self.options.marks || self.options.format !== 'raw') {
@@ -147,7 +147,7 @@ class TextView extends View {
 
         var text = self.mark_text;
         if (self.options.times) {
-            text += time.valueOf();
+            text += mark.time.valueOf();
         }
 
         self.write_item(text);

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -79,7 +79,7 @@ class ViewManager {
         });
 
         self.program.events.on('view:mark', function(data) {
-            self.views[data.channel].mark(data.time);
+            self.views[data.channel].mark(data.mark);
         });
 
         self.program.events.on('view:tick', function(data) {

--- a/lib/views/view.js
+++ b/lib/views/view.js
@@ -25,7 +25,7 @@ class View {
 
     // The subclass should override one or more of these callbacks to
     // handle marks, ticks, data, or eof.
-    mark(time) {
+    mark(mark) {
     }
 
     tick(time) {

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -110,9 +110,9 @@ class TestView extends View {
     consume(data) {
         this.data = this.data.concat(utils.fromNative(data.map(_.clone)));
     }
-    mark(time) {
+    mark(mark) {
         if (this.marks && this.times) {
-            this.data = this.data.concat(utils.fromNative([{time:time, mark:true}]));
+            this.data = this.data.concat(utils.fromNative([{time:mark.time, mark:true}]));
         } else if (this.marks) {
             this.data = this.data.concat({mark:true});
         }
@@ -234,7 +234,7 @@ function run_juttle(prog, options) {
 
         // Dispatch to correct test view
         prog.events.on('view:mark', function(data) {
-            views[data.channel].mark(data.time);
+            views[data.channel].mark(data.mark);
         });
 
         prog.events.on('view:tick', function(data) {


### PR DESCRIPTION
So far, marks were represented as a simple scalar value - time.

As a preparation for adding `interval` info into marks, change marks to
be objects, with `time` property containing the time stamp.

Modify all procs to create and access the `time` property, rename `time`
parameter of `consume_mark/emit_mark/mark` methods to `mark` and update
views to receive the complete mark object via the `view:mark` event, not
just time.