### PR TITLE
add env variable to control logging level

### DIFF
--- a/lib/cli/log-setup.js
+++ b/lib/cli/log-setup.js
@@ -10,7 +10,7 @@ function logSetup() {
     JuttleLogger.getLogger = log4js.getLogger;
 
     let levels = {
-        '[all]': 'info'
+        '[all]': process.env.LOGLEVEL === undefined ? 'info' : process.env.LOGLEVEL
     };
 
     // Handle node.js style debug configuration where DEBUG is a


### PR DESCRIPTION
fixes #569

with the env variable LOGLEVEL you can pick the exact logging level
you'd like ie. `LOGLEVEL=off`, `LOGLEVEL=debug`, etc.