### PR TITLE
compiler: Fix fg_processors processing when an empty array is passed

### DIFF
--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -81,16 +81,13 @@ function compile(juttle, options) {
     var parserOptions = _.pick(options, 'filename', 'modules', 'moduleResolver');
     parserOptions.now = now;
 
-    var fg_processors = _.isEmpty(options.fg_processors) ?
-                        DEFAULT_PROCESSORS : options.fg_processors;
-
     var compilerOptions = _.defaults(_.clone(options), {
         stage: 'eval',
         now: now,
         inputs: {},
         input_defaults: {},
         implicit_view: 'table',
-        fg_processors: fg_processors,
+        fg_processors: DEFAULT_PROCESSORS,
         stripLocations: false,
         scheduler: new Scheduler()
     });
@@ -120,16 +117,13 @@ function compileSync(juttle, options) {
     var parserOptions = _.pick(options, 'filename', 'modules', 'moduleResolver');
     parserOptions.now = now;
 
-    var fg_processors = _.isEmpty(options.fg_processors) ?
-                        DEFAULT_PROCESSORS : options.fg_processors;
-
     var compilerOptions = _.defaults(_.clone(options), {
         stage: 'eval',
         now: now,
         inputs: {},
         input_defaults: {},
         implicit_view: 'table',
-        fg_processors: fg_processors,
+        fg_processors: DEFAULT_PROCESSORS,
         stripLocations: false,
         scheduler: new Scheduler()
     });


### PR DESCRIPTION
Currently, passing an empty array as a value of the `fg_processors` option causes the compiler to run the default processors. That shouldn’t be the case, it should simply run no processors. This commit fixes the compiler to do just that.