### PR TITLE
SemanticPass: Refactor sa_FunctionProc

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -181,9 +181,6 @@ class Scope {
         }
         return undefined;
     }
-    lookup_module_sub(mod, name) {
-        return this.lookup_module_any(mod, name, 'sub');
-    }
 }
 
 module.exports = {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1117,37 +1117,26 @@ class SemanticPass {
         this.sa_builtin_proc(node);
     }
     sa_FunctionProc(node) {
-        var sub;
+        this.with_expr_mode('sub', () => {
+            this.sa_expr(node.op);
+        });
 
-        if (node.op.type === 'MemberExpression') {
-            sub = this.scope.lookup_module_sub(node.op.object.name, node.op.property.value);
-            if (sub === undefined) {
-                throw errors.compileError('NOT-EXPORTED', {
-                    name: node.op.property.value,
-                    module: node.op.object.name,
-                    location: node.location
-                });
-            }
-            node.op.object.symbol = this.scope.get(node.op.object.name);
-        } else {
-            sub = this.scope.get(node.op.name);
-            if (!sub) {
-                throw errors.compileError('NO-SUCH-SUB', {
-                    name: node.op.name,
-                    location: node.location
-                });
-            }
-            if (sub.type !== 'sub') {
+        if (node.op.symbol) {
+            if (node.op.symbol.type === 'sub') {
+                this.stats.subs++;
+                this.sa_sub_call(node, node.op.symbol);
+            } else {
                 throw errors.compileError('NOT-A-SUB', {
-                    name: node.op.name,
+                    name: this.function_name(node.op),
                     location: node.location
                 });
             }
-            node.op.symbol = sub;
+        } else {
+            throw errors.compileError('NO-SUCH-SUB', {
+                name: this.function_name(node.op),
+                location: node.location
+            });
         }
-
-        this.stats.subs++;
-        this.sa_sub_call(node, sub);
     }
 
     sa_assignment_lhs(node) {

--- a/test/runtime/basic-language.spec.js
+++ b/test/runtime/basic-language.spec.js
@@ -296,7 +296,7 @@ describe('Juttle basic language tests', function() {
         })
         .catch(function(err) {
             expect(err.name).to.equal('CompileError');
-            expect(err.message).to.match(/.* not exported by/);
+            expect(err.message).to.match(/.* is not defined/);
         });
     });
 


### PR DESCRIPTION
The idea is the same as in refactoring of `sa_CallExpression` (#515, #561, #566) — rely on `sa_Variable` and `sa_MemberExpression` for symbol processing and avoid duplicating it in `sa_FunctionProc`.

A nice side effect of the change is fixing an incorrect error message.

Part of work on #419.