### PR TITLE
make the cli exit with non zero exit code on failure

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -179,11 +179,13 @@ function perform_run(options) {
         });
 
         var views_done = view_mgr.setup(program);
+        var had_an_error = false;
 
         // Start listening for callbacks from the program and view
         // manager for errors/warnings/view data.
         program.events.on('error', function(msg, err) {
             console.error('Error: ' + msg, err);
+            had_an_error = true;
         });
 
         program.events.on('warning', function(msg, warn) {
@@ -192,6 +194,7 @@ function perform_run(options) {
 
         view_mgr.events.on('error', function(msg, err) {
             console.error('Error: ' + msg, err);
+            had_an_error = true;
         });
 
         view_mgr.events.on('warning', function(msg, warn) {
@@ -214,6 +217,10 @@ function perform_run(options) {
             program.deactivate();
         }).finally(function() {
             current_program = undefined;
+
+            if (had_an_error) {
+                return Promise.reject(Error('Program terminated with errors'));
+            }
         });
     });
 }

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -31,6 +31,24 @@ describe('Juttle CLI Tests', function() {
                 });
         });
 
+        it('exits with non zero return code when the program fails to compile', function() {
+            return runJuttle([
+                '-e',
+                'read bananas'
+            ]).then(function(result) {
+                expect(result.code).to.not.equal(0);
+            });
+        });
+
+        it('exits with non zero return code when the program fails at runtime', function() {
+            return runJuttle([
+                '-e',
+                'read http -url "http://no.mans.land.com"'
+            ]).then(function(result) {
+                expect(result.code).to.not.equal(0);
+            });
+        });
+
         it('can execute juttle with the -e option', function() {
             return runJuttle([
                 '-e',


### PR DESCRIPTION
fixes #575

fixed by making sure we reject any program that had errors at runtime
with the exact error being sent back as part of the promise rejection.