### PR TITLE
change the runaway error message to something more useful

### DIFF
--- a/lib/compiler/flowgraph/check_runaway.js
+++ b/lib/compiler/flowgraph/check_runaway.js
@@ -17,6 +17,13 @@ function isRunaway(readNode, graph) {
         return;
     }
 
+    function throwRunawayError(readNode) {
+        throw errors.compileError('RUNAWAY-PROGRAM', {
+            extra: 'Make your read time bounded, or batch your stream',
+            location: readNode.location
+        });
+    }
+
     var outs;
     var nextNode = readNode;
     while (true) {
@@ -34,23 +41,16 @@ function isRunaway(readNode, graph) {
             case 'batch':
                 return;
             case 'tail':
-                throw errors.compileError('RUNAWAY-PROGRAM', {
-                    extra: 'Add a -to option to read?',
-                    location: readNode.location
-                });
+                throwRunawayError(readNode);
+                break;
             case 'reduce':
                 if (!graph.node_has_option(nextNode, 'every')) {
-                    throw errors.compileError('RUNAWAY-PROGRAM', {
-                        extra: 'Add a -to option to read or a -every option to reduce?',
-                        location: readNode.location
-                    });
+                    throwRunawayError(readNode);
                 }
                 break;
             case 'sort':
-                throw errors.compileError('RUNAWAY-PROGRAM', {
-                    extra: 'Add a -to option to read?',
-                    location: readNode.location
-                });
+                throwRunawayError(readNode);
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
fixes #577

the old message was way off topic suggesting to use a `-to` when the
fact is that you simply need to make your read range time bound or batch
the underlying stream