### PR TITLE
gulpfile.js: Lower functions coverage threshold to 91%

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,7 +115,7 @@ gulp.task('test-coverage', ['peg', 'juttle-spec', 'instrument'], function() {
                 global: {
                     statements: 93,
                     branches: 87,
-                    functions: 92,
+                    functions: 91,
                     lines: 93
                 }
             }


### PR DESCRIPTION
Recent increase of functions coverage threshold to 92% (#533) broke at least one refactoring-only PR (#573) with another one suspected (#566). Let’s revert the change.