### PR TITLE
read: include the full stack trace in the debug log on a read error

### DIFF
--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -197,7 +197,7 @@ class Read extends source {
         })
         .catch((err) => {
             this.reading = null;
-            this.logger.debug('read returned error', err.toString());
+            this.logger.debug('read returned error', err.stack);
             this.trigger('error', err);
             this.emit_eof();
         });


### PR DESCRIPTION
If an error occurs as part of the read implementation, it's useful
to have the full stack trace as context when logging at debug level.