### PR TITLE
use node-grok from npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ node_js:
 before_script:
     - npm install -g gulp
       # grok parser tests need node-grok
-    - npm install rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe
+    - npm install node-grok@1.0.5
 
 script:
     - gulp lint examples-check test-coverage

--- a/lib/adapters/parsers/grok.js
+++ b/lib/adapters/parsers/grok.js
@@ -19,7 +19,7 @@ class GrokParser extends base {
                 // we're doing this to avoid installing a more heavy weight dependency
                 // as part of the regular juttle dependencies.
                 throw Error('Grok parser requires a manual installation of node-grok like so:\n' +
-                            ' > npm install rlgomes/node-grok#b3b810f4277d7b9d765853214bf20adfdb010ebe\n');
+                            ' > npm install node-grok@1.0.5\n');
             } else {
                 throw err;
             }


### PR DESCRIPTION
fixes #213

we no longer have to depend on our own fork containing a fix and can
correctly rely on node-grok from npm