### PR TITLE
Support indexed assignment in assignment expressions

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1290,7 +1290,7 @@ ConditionalExpressionToplevel 'expression'
     / CoalesceExpressionToplevel
 
 AssignmentExpression 'expression'
-    = left:Variable __
+    = left:AssignmentLHS __
       operator:AssignmentOperator __
       right:AssignmentExpression {
           return createNode('AssignmentExpression', location(), {
@@ -1302,7 +1302,7 @@ AssignmentExpression 'expression'
     / ConditionalExpression
 
 AssignmentExpressionToplevel 'expression'
-    = left:Variable __
+    = left:AssignmentLHS __
       operator:AssignmentOperator __
       right:AssignmentExpressionToplevel {
           return createNode('AssignmentExpression', location(), {

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1324,6 +1324,26 @@ StrictAssignmentExpression 'field assignment'
           });
       }
 
+AssignmentLHS
+    = left:Variable
+      accessors:(
+          __ '[' __ name:Expression __ ']' {
+              return {
+                  name: name,
+                  computed: true,
+                  location: locationWithFilename(location())
+              };
+          }
+      )* {
+          return buildTree(left, accessors, function(result, element) {
+              return createNode('MemberExpression', spanningLocation(result.location, element.location), {
+                  object: result,
+                  property: element.name,
+                  computed: element.computed
+              })
+          });
+      }
+
 AssignmentOperator
     = '=' !('=' / '~') { return '='; }
     / '*='
@@ -1917,32 +1937,12 @@ EmptyStatement
     = ';' { return createNode('EmptyStatement', location()); }
 
 AssignmentStatement
-    = left:AssignmentStatementLHS __
+    = left:AssignmentLHS __
       '='
       __ expr:Expression __ ';' {
           return createNode('AssignmentStatement', location(), {
               left:left,
               expr:expr
-          });
-      }
-
-AssignmentStatementLHS
-    = left:Variable
-      accessors:(
-          __ '[' __ name:Expression __ ']' {
-              return {
-                  name: name,
-                  computed: true,
-                  location: locationWithFilename(location())
-              };
-          }
-      )* {
-          return buildTree(left, accessors, function(result, element) {
-              return createNode('MemberExpression', spanningLocation(result.location, element.location), {
-                  object: result,
-                  property: element.name,
-                  computed: element.computed
-              })
           });
       }
 

--- a/test/runtime/specs/juttle-spec/expressions/assignment-expression.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/assignment-expression.spec.md
@@ -1,0 +1,23 @@
+# Assignment expression
+
+This is a simple temporary test before #419 gets fully implemented, making
+indexed assignment work properly in all cases. That work will be covered by
+additional, more detailed tests. Once done, this test will become redundant and
+can be scrapped.
+
+## Can assign to indexed expressions
+
+### Juttle
+
+    function f() {
+      var v = [1, 2, 3];
+      const c = v[1] = 4;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: [1, 4, 3] }


### PR DESCRIPTION
This change brings assignment expressions closer to assignment statements which already support indexed assignment.

Part of work on #426.