### PR TITLE
Support more operators in assignment statements

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -409,16 +409,12 @@ class Build extends CodeGenerator {
     }
     gen_EmptyStatement(node) {
     }
-    // this type of assignment lives only in places where there are
-    // no points or reducers
     gen_AssignmentStatement(node) {
         var code = this.gen_assignment_lhs(node.left);
         //XXX need to handle op's other than "="
         code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
-    // this type of assignment lives in places where there can be
-    // points or reducers
     gen_AssignmentExpression(node) {
         var code = this.gen_assignment_lhs(node.left);
         code += ' ' + node.operator + ' ';

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -411,8 +411,8 @@ class Build extends CodeGenerator {
     }
     gen_AssignmentStatement(node) {
         var code = this.gen_assignment_lhs(node.left);
-        //XXX need to handle op's other than "="
-        code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
+        code += ' ' + node.operator + ' ';
+        code += this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
     gen_AssignmentExpression(node) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -370,8 +370,8 @@ class GraphCompiler extends CodeGenerator {
     }
     gen_AssignmentStatement(node) {
         var code = this.gen_assignment_lhs(node.left);
-        //XXX need to handle op's other than "="
-        code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
+        code += ' ' + node.operator + ' ';
+        code += this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
     gen_AssignmentExpression(node) {

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -368,16 +368,12 @@ class GraphCompiler extends CodeGenerator {
 
     gen_EmptyStatement(node) {
     }
-    // this type of assignment lives only in places where there are
-    // no points or reducers
     gen_AssignmentStatement(node) {
         var code = this.gen_assignment_lhs(node.left);
         //XXX need to handle op's other than "="
         code +=  ' = ' + this.gen_expr(node.expr) + ';\n';
         this.emit(code);
     }
-    // this type of assignment lives in places where there can be
-    // points or reducers
     gen_AssignmentExpression(node) {
         var code = this.gen_assignment_lhs(node.left);
         code += ' ' + node.operator + ' ';

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -784,7 +784,6 @@ class SemanticPass {
         this.with_lhs(true, () => {
             this.sa_assignment_lhs(node.left);
         });
-        //XXX need to handle op's other than "="
         this.sa_expr(node.expr);
     }
     sa_AssignmentExpression(node) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -778,8 +778,6 @@ class SemanticPass {
 
     sa_EmptyStatement(node) {
     }
-    // this type of assignment lives only in places where there are
-    // no points or reducers
     sa_AssignmentStatement(node) {
         this.check_reducer_toplevel(node, 'an assignment');
 
@@ -789,8 +787,6 @@ class SemanticPass {
         //XXX need to handle op's other than "="
         this.sa_expr(node.expr);
     }
-    // this type of assignment lives in places where there can be
-    // points or reducers
     sa_AssignmentExpression(node) {
         this.with_expr_mode('result', () => {
             this.with_lhs(true, () => {

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1938,10 +1938,11 @@ EmptyStatement
 
 AssignmentStatement
     = left:AssignmentLHS __
-      '='
+      operator:AssignmentOperator
       __ expr:Expression __ ';' {
           return createNode('AssignmentStatement', location(), {
               left:left,
+              operator:operator,
               expr:expr
           });
       }

--- a/test/runtime/specs/juttle-spec/statements/assignment-statement.spec.md
+++ b/test/runtime/specs/juttle-spec/statements/assignment-statement.spec.md
@@ -1,0 +1,188 @@
+# Assignment statement
+
+## Supports the `*=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v *= 6;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 30 }
+
+## Supports the `/=` operator
+
+### Juttle
+
+    function f() {
+      var v = 30;
+      v /= 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 6 }
+
+## Supports the `%=` operator
+
+### Juttle
+
+    function f() {
+      var v = 30;
+      v %= 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 0 }
+
+## Supports the `+=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v += 6;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 11 }
+
+## Supports the `-=` operator
+
+### Juttle
+
+    function f() {
+      var v = 6;
+      v -= 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 1 }
+
+## Supports the `<<=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v <<= 1;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 10 }
+
+## Supports the `>>=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v >>= 1;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 2 }
+
+## Supports the `>>>=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v >>= 1;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 2 }
+
+## Supports the `&=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v &= 6;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 4 }
+
+## Supports the `^=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v ^= 6;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 3 }
+
+## Supports the `|=` operator
+
+### Juttle
+
+    function f() {
+      var v = 5;
+      v |= 6;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { "time": "1970-01-01T00:00:00.000Z", result: 7 }


### PR DESCRIPTION
Adds support for `*=`, `/=`, `%=`, `+=`, `-=`, `<<=`, `>>=`, `>>>=`, `&=`, `^=`, and `|=`.

This change brings assignment statements closer to assignment expressions, which already support these assignment operators.

Part of work on #426.