### PR TITLE
Generalize function call grammar

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1261,8 +1261,7 @@ class SemanticPass {
                     });
             }
         } else {
-            throw errors.compileError('NOT-A-FUNCTION-OR-REDUCER', {
-                name: this.function_name(node),
+            throw errors.compileError('CANNOT-USE-AS-FUNCTION-OR-REDUCER', {
                 location: node.location
             });
         }

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -79,6 +79,7 @@
   "PROC-MUST-END-FLOWGRAPH": "{proc} can only be used at the end of a flowgraph.",
   "WRONG-PROC-TYPE": "{proc} is a not a {type} proc.",
   "CANNOT-USE-AS-VARIABLE": "Cannot use a {thing} as a variable",
+  "CANNOT-USE-AS-FUNCTION-OR-REDUCER": "Cannot use an expression as a function or a reducer",
   "MISSING-FUNCTION-IN-REDUCER": "missing {function} in reducer {reducer}",
   "NON-TOPLEVEL-EXPORT": "Cannot export from within a {entity}",
   "NON-TOPLEVEL-IMPORT": "Cannot import from within a {entity}",

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -893,20 +893,18 @@ CoreExpression
     = object:PrimaryExpression
       accessors:(
             __ '[' __ property:Expression __ ']' {
-                return {
+                return createNode('MemberExpressionProperty', location(), {
                     property: property,
-                    computed: true,
-                    location: locationWithFilename(location())
-                };
+                    computed: true
+                });
             }
           / __ '.' __ property:Identifier {
-                return {
+                return createNode('MemberExpressionProperty', location(), {
                     property: createNode('StringLiteral', property.location, {
                         value: property.name
                     }),
-                    computed: false,
-                    location: locationWithFilename(location())
-                };
+                    computed: false
+                });
             }
       )* {
           return buildTree(object, accessors, function(result, element) {

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -906,40 +906,30 @@ CoreExpression
                     computed: false
                 });
             }
+          / __ args:Arguments {
+                return createNode('CallExpressionArguments', location(), {
+                    arguments: args
+                });
+            }
       )* {
           return buildTree(object, accessors, function(result, element) {
-              return createNode('MemberExpression', spanningLocation(result.location, element.location), {
-                  object: result,
-                  property: element.property,
-                  computed: element.computed
-              })
-          });
-      }
+              switch (element.type) {
+                  case 'MemberExpressionProperty':
+                      return createNode('MemberExpression', spanningLocation(result.location, element.location), {
+                          object: result,
+                          property: element.property,
+                          computed: element.computed
+                      });
 
-CallExpression
-    = object:FunctionCall
-      accessors:(
-            __ '[' __ property:Expression __ ']' {
-                return createNode('MemberExpressionProperty', location(), {
-                    property: property,
-                    computed: true
-                });
-            }
-          / __ '.' __ property:Identifier {
-                return createNode('MemberExpressionProperty', location(), {
-                    property: createNode('StringLiteral', property.location, {
-                        value: property.name
-                    }),
-                    computed: false
-                });
-            }
-      )* {
-          return buildTree(object, accessors, function(result, element) {
-              return createNode('MemberExpression', spanningLocation(result.location, element.location), {
-                  object: result,
-                  property: element.property,
-                  computed: element.computed
-              });
+                  case 'CallExpressionArguments':
+                      return createNode('CallExpression', spanningLocation(result.location, element.location), {
+                          callee: result,
+                          arguments: element.arguments
+                      });
+
+                  default:
+                      throw new Error('Invalid node type: ' + element.type + '.');
+              }
           });
       }
 
@@ -980,8 +970,7 @@ ArgumentList
       }
 
 LeftHandSideExpression
-    = CallExpression
-    / CoreExpression
+    = CoreExpression
 
 RealLeftHandSideExpression
     = '*' !'=' __ argument:UnaryExpression {


### PR DESCRIPTION
Instead of treating function calls specially in the grammar, handle them similarly to `[]` and `.` operators — that is, allow any expression before `()` and leave it to the semantic pass to decide whether this expression is callable or not.

Part of work on #419.