### PR TITLE
Add support for importing using relative paths

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -159,7 +159,8 @@ function perform_compile(options) {
         moduleResolver: options.resolver,
         inputs: options.inputs,
         stripLocations: options.stripLocations,
-        implicit_view: config.implicit_view
+        implicit_view: config.implicit_view,
+        filename: options.filename
     };
 
     return compiler.compile(options.juttle_src, compile_options);
@@ -245,8 +246,9 @@ function perform_mode(options)
 
     var perform_options = {
         juttle_src: options.juttle_src,
-        resolver: function(module_name) {
-            return resolver(module_name)
+        filename: options.filename ? options.filename : 'main',
+        resolver: function(module_path, module_name, importer_path) {
+            return resolver(module_path, module_name, importer_path)
                 .then(function(module) {
                     modules[module.name] = module.source;
                     return module;
@@ -337,7 +339,7 @@ function setupCline() {
         perform_mode({
             action: mode,
             juttle_src: juttle_src,
-            filename: args.path
+            filename: path.resolve(args.path)
         });
     });
 
@@ -430,7 +432,7 @@ if (opts._.length > 1) {
         action: mode,
         juttle_src: juttle_src,
         prompt_when_done: false,
-        filename: opts._[0]
+        filename: path.resolve(opts._[0])
     })
     .then(function() {
         process.exit(0);

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -159,10 +159,27 @@ location, then in another program you can import it as a module, using the
     import "<module_path>" as local_name;
 ```
 
-How the `<module_path>` is resolved depends on the specific capabilities of the
-application in which Juttle is running. For the Juttle CLI, it can be either a
-relative or absolute filesystem path or a URL to a remote Juttle file containing
-exported code.
+`<module_path>` can either refer to a *user import* or a *system
+import*.
+
+User imports are references to individual modules. User imports can
+either be a url, a full pathname starting with `/`, or a relative
+pathname starting with `./` or `../`. All other paths are considered
+system imports.
+
+When resolving user imports with relative pathnames, the pathname is
+always applied relative to the file doing the import. See the below
+examples for details.
+
+System imports load predefined modules from standard
+locations. Examples of system imports are the
+[Juttle Standard Library](./juttle_standard_library.md). For system
+imports, module_path is a path suffix that is combined with one of the
+standard locations to result in a full pathname.
+
+For both user and system imports, when referring to files, a `.juttle`
+extension will be added if not present, and when referring to
+directories, an `/index.juttle` will be added.
 
 Once it is resolved, the import statement pulls all exported symbols from the
 specified Juttle module and makes them available under the specified local
@@ -216,18 +233,45 @@ emit
 | view table;
 ```
 
-_Example: import by filename_
+_Example: user import by filename_
 
 This example assumes that the program with exports is saved at path
-`docs/examples/concepts/export_module.juttle`.
+`docs/examples/concepts/export_module.juttle`, and that the program
+being run is at `docs/examples/concepts/import_module.juttle`.
 
 ```juttle-no-syntax-check
 // This program is runnable from CLI from the juttle repo root,
 // juttle docs/examples/concepts/import_module.juttle
 
-import 'docs/examples/concepts/export_module.juttle' as my_module;
+import './export_module.juttle' as my_module;
 emit
 | my_module.stamper -mark 'test'
+```
+
+_Example: modules importing modules with relative paths_
+
+This example uses the following files:
+
+`docs/examples/concepts/import_module_nested.juttle`:
+```juttle-no-syntax-check
+// This program is runnable from CLI from the juttle repo root,
+// juttle docs/examples/concepts/import_module_nested.juttle.
+
+import "./shared/module.juttle" as mod;
+
+emit -limit 1 | put val=mod.myvalue | view table;
+```
+
+`docs/examples/concepts/shared/module.juttle`:
+```juttle-no-syntax-check
+import './second_module.juttle' as mod2;
+
+export const myvalue=mod2.value;
+```
+
+`docs/examples/concepts/shared/second_module.juttle`:
+```juttle-no-syntax-check
+export const value = 10;
 ```
 
 _Example: import by URL_
@@ -244,6 +288,22 @@ import 'https://gist.githubusercontent.com/jut-test/273396ac4efcc838687b/raw/dde
   as this_module;
 emit
 | this_module.stamper -mark "test"
+```
+
+_Example: using system import_
+
+This example loads the file `random` from the juttle standard
+library. Note the use of the implied `.juttle` extension that is added
+when resolving.
+
+```juttle-no-syntax-check
+// This program is runnable from CLI from the juttle repo root,
+// juttle docs/examples/concepts/import_module_from_stdlib.juttle
+
+import "random" as random;
+emit -limit 3 -from :0:
+| put pure = random.normal(0, 1)
+
 ```
 
 Subgraphs

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -192,7 +192,7 @@ You can reference the imported symbol(s) like this:
 ```
 
 -  local_name is the local name from the import command above.
--  symbol_name is the name of the exported subgraph, constant, function, 
+-  symbol_name is the name of the exported subgraph, constant, function,
    or other code fragment from the imported program file.
 
 Module Behavior
@@ -215,7 +215,7 @@ When defining or importing modules:
 
 _Example: export from module_
 
-This juttle module exports a function, a subgraph, and a constant. 
+This juttle module exports a function, a subgraph, and a constant.
 
 ```juttle
 export const pi = 3.14;                                // exported constant
@@ -223,8 +223,8 @@ const not_exported = 2;                                     // not exported
 export function double(x) { return x * not_exported; } // exported function
 
 export sub stamper(mark) {                             // exported subgraph
-	put stamp = mark
-	| put stamp2 = mark
+    put stamp = mark
+    | put stamp2 = mark
 }
 
 // top-level flowgraph is not exported

--- a/docs/examples/concepts/import_module_from_stdlib.juttle
+++ b/docs/examples/concepts/import_module_from_stdlib.juttle
@@ -1,3 +1,6 @@
-import "random.juttle" as random;
+// This program is runnable from CLI from the juttle repo root,
+// juttle docs/examples/concepts/import_module_from_stdlib.juttle
+
+import "random" as random;
 emit -limit 3 -from :0:
 | put pure = random.normal(0, 1)

--- a/docs/examples/concepts/import_module_nested.juttle
+++ b/docs/examples/concepts/import_module_nested.juttle
@@ -1,0 +1,7 @@
+// This program is runnable from CLI from the juttle repo root,
+// juttle docs/examples/concepts/import_module_nested.juttle.
+
+import "./shared/module.juttle" as mod;
+
+emit -limit 1 | put val=mod.myvalue | view table;
+

--- a/docs/examples/concepts/shared/module.juttle
+++ b/docs/examples/concepts/shared/module.juttle
@@ -1,3 +1,7 @@
+// examples-check:ignore
+// This module imports a second module and then exports the value from
+// that module.
+
 import './second_module.juttle' as mod2;
 
 export const myvalue=mod2.value;

--- a/docs/examples/concepts/shared/module.juttle
+++ b/docs/examples/concepts/shared/module.juttle
@@ -1,0 +1,3 @@
+import './second_module.juttle' as mod2;
+
+export const myvalue=mod2.value;

--- a/docs/examples/concepts/shared/second_module.juttle
+++ b/docs/examples/concepts/shared/second_module.juttle
@@ -1,0 +1,1 @@
+export const value = 10;

--- a/docs/examples/concepts/shared/second_module.juttle
+++ b/docs/examples/concepts/shared/second_module.juttle
@@ -1,1 +1,4 @@
+// examples-check:ignore
+// This module exports a single constant value.
+
 export const value = 10;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -161,7 +161,13 @@ gulp.task('examples-check', ['peg'], function() {
             var juttles = [];
             var ext = path.extname(file.path);
             var contents = fs.readFileSync(file.path, 'utf8');
-            if (ext === '.juttle') {
+
+            // Skip files containing 'examples-check:ignore'. These
+            // are files like modules that can't be compiled on their
+            // own.
+            if (contents.indexOf('examples-check:ignore') > 0) {
+                juttles = [];
+            } else if (ext === '.juttle') {
                 juttles = [contents];
             } else if (ext === '.md') {
                 var tokens = marked.lexer(contents);
@@ -177,7 +183,8 @@ gulp.task('examples-check', ['peg'], function() {
                 return compiler.compile(juttle_src, {
                     stage: 'compile',
                     moduleResolver: file_resolver.resolve,
-                    fg_processors: [implicit_views, optimize]
+                    fg_processors: [implicit_views, optimize],
+                    filename: file.path
                 });
             })
             .then(function() {

--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -14,9 +14,9 @@ var show_in_context = function(options) {
     options.filename = options.filename || '<input>';
 
     // Use the location from the error to figure out what juttle
-    // source to use. 'main' means the main juttle program, anything
-    // else is a module name.
-    if (options.err.info.location.filename === 'main') {
+    // source to use. The location is either one of the modules, or
+    // it's the main program.
+    if (! _.has(options.modules, options.err.info.location.filename)) {
         filename = options.filename;
         juttle_src = options.program;
     } else {

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -8,8 +8,7 @@ var logger = require('../logger').getLogger('file-resolver');
 
 function search_paths() {
     var env = process.env;
-    var cwd = process.cwd();
-    var paths = [ cwd ];
+    var paths = [];
     if (env.JUTTLE_MODULE_PATH) {
         paths = paths.concat(env.JUTTLE_MODULE_PATH.split(':'));
     }

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -4,6 +4,7 @@
 var fs = require('fs');
 var path = require('path');
 var Promise = require('bluebird');
+var logger = require('../logger').getLogger('file-resolver');
 
 function search_paths() {
     var env = process.env;
@@ -38,8 +39,10 @@ class FileResolver {
         }
     }
 
-    _search(module_path) {
+    _search(module_path, module_name, importer_path) {
         var self = this;
+
+        logger.debug(`Resolving module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
 
         var k, paths = self._search_paths;
         paths = paths.concat(self._additional_search_paths);
@@ -50,7 +53,10 @@ class FileResolver {
             var filename = paths[k] + '/' + module_path;
             if (self._is_file(filename)) {
                 try {
-                    return fs.readFileSync(filename, 'utf8');
+                    return {
+                        name: filename,
+                        source: fs.readFileSync(filename, 'utf8')
+                    };
                 }
                 catch (e) {
                     // continue looking for a module we can successfully load
@@ -60,14 +66,14 @@ class FileResolver {
         return false;
     }
 
-    _resolve(module_path) {
+    _resolve(module_path, module_name, importer_path) {
         var self = this;
 
-        var src_code = self._search(module_path);
-        if (src_code === false) {
+        var found = self._search(module_path, module_name, importer_path);
+        if (found === false) {
             return Promise.reject(new Error('could not find module: ' + module_path));
         }
-        return Promise.resolve({ source: src_code, name: module_path});
+        return Promise.resolve(found);
     }
 }
 

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -39,22 +39,68 @@ class FileResolver {
         }
     }
 
-    _search(module_path, module_name, importer_path) {
+    _canonicalize(filename) {
+        if (path.extname(filename) !== '.juttle') {
+            filename = filename + '.juttle';
+        }
+
+        return filename;
+    }
+
+    _is_local_import(module_path) {
+        return (module_path.startsWith('./') ||
+                module_path.startsWith('../') ||
+                path.isAbsolute(module_path));
+    }
+
+    _search_local_import(module_path, module_name, importer_path) {
         var self = this;
 
-        logger.debug(`Resolving module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
+        logger.debug(`searching local module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
+
+        // Resolve module_path relative to importer_path or the
+        // current working directory.
+        let dir = process.cwd();
+        if (importer_path !== undefined &&
+            path.isAbsolute(importer_path)) {
+            // importer_path can be non-absolute when the program has
+            // a generic name like 'main'. That in turn happens for
+            // programs in the cli repl or when provided via -e.
+
+            dir = path.dirname(importer_path);
+        }
+
+        // Note this won't change module_path if it is already
+        // absolute.
+        let filename = path.resolve(dir, module_path);
+        filename = self._canonicalize(filename);
+        try {
+            return {
+                source: fs.readFileSync(filename, 'utf8'),
+                name: filename
+            };
+        }
+        catch (e) {
+            return false;
+        }
+    }
+
+    _search_system_import(module_path, module_name, importer_path) {
+        var self = this;
+
+        logger.debug(`searching system module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
 
         var k, paths = self._search_paths;
         paths = paths.concat(self._additional_search_paths);
-        if (path.extname(module_path) !== '.juttle') {
-            module_path = module_path + '.juttle';
-        }
         for (k = 0; k < paths.length; ++k) {
             var filename = paths[k] + '/' + module_path;
+
+            filename = self._canonicalize(filename);
+
             if (self._is_file(filename)) {
                 try {
                     return {
-                        name: filename,
+                        name: module_path,
                         source: fs.readFileSync(filename, 'utf8')
                     };
                 }
@@ -69,7 +115,12 @@ class FileResolver {
     _resolve(module_path, module_name, importer_path) {
         var self = this;
 
-        var found = self._search(module_path, module_name, importer_path);
+        var found = false;
+        if (self._is_local_import(module_path)) {
+            found = self._search_local_import(module_path, module_name, importer_path);
+        } else {
+            found = self._search_system_import(module_path, module_name, importer_path);
+        }
         if (found === false) {
             return Promise.reject(new Error('could not find module: ' + module_path));
         }

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -40,6 +40,15 @@ class FileResolver {
     }
 
     _canonicalize(filename) {
+        // If the filename is actually a directory, add a
+        // /index.juttle
+        if (fs.existsSync(filename)) {
+            let stats = fs.statSync(filename);
+            if (stats.isDirectory()) {
+                filename = path.join(filename, 'index.juttle');
+            }
+        }
+
         if (path.extname(filename) !== '.juttle') {
             filename = filename + '.juttle';
         }

--- a/lib/module-resolvers/resolver-utils.js
+++ b/lib/module-resolvers/resolver-utils.js
@@ -9,7 +9,7 @@ module.exports = {
         The module resolver returns the first successful resolution.
     */
     multiple: function(resolvers) {
-        return function(path, name) {
+        return function(path, name, importerPath) {
             var num_resolvers = resolvers.length;
             return new Promise(function(resolve, reject) {
                 if (resolvers.length === 0 ) {
@@ -17,7 +17,7 @@ module.exports = {
                 }
 
                 function try_resolver(index) {
-                    resolvers[index](path, name)
+                    resolvers[index](path, name, importerPath)
                         .then(function(m) {
                             resolve(m);
                         })

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -43,7 +43,8 @@ function parseValue(source) {
 //                             `moduleResolver` is provided. Optional, defaults
 //                             to `{}`.
 //   * `moduleResolver`:       A function that resolves imported modules. It
-//                             takes a module path and name and returns a
+//                             takes a module path, module name, and the path
+//                             of the file doing the import and returns a
 //                             promise which is resolved with an object
 //                             describing the resolved module or rejected with
 //                             an exception if the module cannot be resolved.
@@ -52,7 +53,7 @@ function parseValue(source) {
 function parse(juttle, options) {
     var asts = {};
 
-    function defaultResolver(path, name) {
+    function defaultResolver(path, name, importerPath) {
         if (_.has(options.modules, path)) {
             return Promise.resolve({
                 name: path,
@@ -64,7 +65,7 @@ function parse(juttle, options) {
     }
 
     function resolveImport(node) {
-        return options.moduleResolver(node.modulename.value, node.localname)
+        return options.moduleResolver(node.modulename.value, node.localname, options.filename)
             .catch(function(err) {
                 throw errors.compileError('MODULE-NOT-FOUND', {
                     module: node.modulename.value,
@@ -97,7 +98,7 @@ function parse(juttle, options) {
 
     options = processOptions(options, defaultResolver);
 
-    return parseModule({ source: juttle, name: 'main' })
+    return parseModule({ source: juttle, name: options.filename })
         .then(function() {
             asts.main.modules = buildModuleDefs(asts);
 
@@ -122,7 +123,8 @@ function parse(juttle, options) {
 //                             `moduleResolver` is provided. Optional, defaults
 //                             to `{}`.
 //   * `moduleResolver`:       A function that resolves imported modules. It
-//                             takes a module path and name and returns an
+//                             takes a module path, module name, and the path
+//                             of the file doing the import and returns an
 //                             object describing the resolved module or throws
 //                             an exception if the module cannot be resolved.
 //                             Optional, the `modules` option is used when not
@@ -130,7 +132,7 @@ function parse(juttle, options) {
 function parseSync(juttle, options) {
     var asts = {};
 
-    function defaultResolver(path, name) {
+    function defaultResolver(path, name, importerPath) {
         if (_.has(options.modules, path)) {
             return {
                 name: path,
@@ -143,7 +145,7 @@ function parseSync(juttle, options) {
 
     function resolveImport(node) {
         try {
-            return options.moduleResolver(node.modulename.value, node.localname);
+            return options.moduleResolver(node.modulename.value, node.localname, options.filename);
         } catch (e) {
             throw errors.compileError('MODULE-NOT-FOUND', {
                 module: node.modulename.value,
@@ -171,7 +173,7 @@ function parseSync(juttle, options) {
 
     options = processOptions(options, defaultResolver);
 
-    parseModule({ source: juttle, name: 'main' });
+    parseModule({ source: juttle, name: options.filename });
     asts.main.modules = buildModuleDefs(asts);
 
     return asts.main;

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -66,6 +66,16 @@ function parse(juttle, options) {
 
     function resolveImport(node) {
         return options.moduleResolver(node.modulename.value, node.localname, options.filename)
+            .then(function(module) {
+                // With relative pathnames now allowed in import
+                // statements, it's possible that multiple imports
+                // contain a similar value like '../index/', relative
+                // to different locations. So change this import to
+                // refer to the full pathname rather than the relative
+                // pathname.
+                node.modulename.value = module.name;
+                return module;
+            })
             .catch(function(err) {
                 throw errors.compileError('MODULE-NOT-FOUND', {
                     module: node.modulename.value,
@@ -98,11 +108,12 @@ function parse(juttle, options) {
 
     options = processOptions(options, defaultResolver);
 
-    return parseModule({ source: juttle, name: options.filename })
+    let mainFilename = options.filename;
+    return parseModule({ source: juttle, name: mainFilename })
         .then(function() {
-            asts.main.modules = buildModuleDefs(asts);
+            asts[mainFilename].modules = buildModuleDefs(asts, mainFilename);
 
-            return asts.main;
+            return asts[mainFilename];
         });
 }
 
@@ -145,7 +156,15 @@ function parseSync(juttle, options) {
 
     function resolveImport(node) {
         try {
-            return options.moduleResolver(node.modulename.value, node.localname, options.filename);
+            let module = options.moduleResolver(node.modulename.value, node.localname, options.filename);
+            // With relative pathnames now allowed in import
+            // statements, it's possible that multiple imports
+            // contain a similar value like '../index/', relative
+            // to different locations. So change this import to
+            // refer to the full pathname rather than the relative
+            // pathname.
+            node.modulename.value = module.name;
+            return module;
         } catch (e) {
             throw errors.compileError('MODULE-NOT-FOUND', {
                 module: node.modulename.value,
@@ -173,10 +192,11 @@ function parseSync(juttle, options) {
 
     options = processOptions(options, defaultResolver);
 
-    parseModule({ source: juttle, name: options.filename });
-    asts.main.modules = buildModuleDefs(asts);
+    let mainFilename = options.filename;
+    parseModule({ source: juttle, name: mainFilename });
+    asts[mainFilename].modules = buildModuleDefs(asts, mainFilename);
 
-    return asts.main;
+    return asts[mainFilename];
 }
 
 function processOptions(options, defaultResolver) {
@@ -207,8 +227,8 @@ function checkImport(node) {
     }
 }
 
-function buildModuleDefs(asts) {
-    return _.map(_.omit(asts, 'main'), function(ast, name) {
+function buildModuleDefs(asts, mainFilename) {
+    return _.map(_.omit(asts, mainFilename), function(ast, name) {
         return { type: 'ModuleDef', name: name, elements: ast.elements };
     });
 }

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -181,7 +181,7 @@ describe('Juttle CLI Tests', function() {
         it('returns errors for modules containing a syntax error', function() {
             return runJuttle([
                 '-e',
-                'import "test/cli/juttles/syntax-error.juttle" as error;',
+                'import "./test/cli/juttles/syntax-error.juttle" as error;',
             ]).then(function(result) {
                 expect(result.code).to.equal(1);
                 expect(result.stderr).to.include('In module included from <input>');

--- a/test/module-resolvers/file-resolver.spec.js
+++ b/test/module-resolvers/file-resolver.spec.js
@@ -4,13 +4,13 @@ var expect = require('chai').expect;
 var path = require('path');
 var FileResolver = require('../../lib/module-resolvers/file-resolver');
 
-function resolveWith(module, path) {
+function resolveWith(module, path, module_name, importer_path) {
 
     var modulePath = process.env.JUTTLE_MODULE_PATH;
     process.env.JUTTLE_MODULE_PATH = path;
 
     var file_resolver = new FileResolver();
-    return file_resolver.resolve(module)
+    return file_resolver.resolve(module, module_name, importer_path)
     .finally(function() {
         process.env.JUTTLE_MODULE_PATH = modulePath;
     });
@@ -73,6 +73,20 @@ describe('file-resolver', function() {
         return resolveWith('module1', modulePath)
         .then(function(result) {
             expect(result.source).to.equal('// first module1\n');
+        });
+    });
+
+    it('can resolve by filename', function() {
+        return resolveWith(`${__dirname}/input/modules1/foo`, [])
+        .then(function(result) {
+            expect(result.name).to.equal(`${__dirname}/input/modules1/foo.juttle`);
+        });
+    });
+
+    it('can resolve by relative filename', function() {
+        return resolveWith(`./input/modules1/foo`, [], 'main', `${__dirname}/test.juttle`)
+        .then(function(result) {
+            expect(result.name).to.equal(`${__dirname}/input/modules1/foo.juttle`);
         });
     });
 });

--- a/test/runtime/juttles/index.juttle
+++ b/test/runtime/juttles/index.juttle
@@ -1,0 +1,1 @@
+export const value = 10;

--- a/test/runtime/juttles/subdir/index.juttle
+++ b/test/runtime/juttles/subdir/index.juttle
@@ -1,0 +1,3 @@
+import "../index.juttle" as m3;
+
+export const value = m3.value;

--- a/test/runtime/juttles/subdir/subdir2/index.juttle
+++ b/test/runtime/juttles/subdir/subdir2/index.juttle
@@ -1,0 +1,3 @@
+import '../index.juttle' as m4;
+
+export const value=m4.value;

--- a/test/runtime/juttles/subdir/updir_module.juttle
+++ b/test/runtime/juttles/subdir/updir_module.juttle
@@ -1,0 +1,3 @@
+import "../module" as m3;
+
+export const up_value=m3.value;

--- a/test/runtime/modules.spec.js
+++ b/test/runtime/modules.spec.js
@@ -10,6 +10,7 @@ var expect = require('chai').expect;
 
 var parser = require('../../lib/parser');
 
+var FileResolver = require('../../lib/module-resolvers/file-resolver');
 
 describe('Juttle modules ', function() {
 
@@ -460,6 +461,49 @@ describe('Juttle modules ', function() {
             })
             .catch(function(err) {
                 expect(err.message).to.contain('Import cycle detected (cycle1 -> cycle3 -> cycle2 -> cycle1)');
+            });
+        });
+
+        describe('With the file resolver', function() {
+            var file_resolver = new FileResolver();
+            it('Can import a module from a relative pathname', function() {
+                return check_juttle({
+                    moduleResolver: file_resolver.resolve,
+                    program: `import "${__dirname}/juttles/index.juttle" as m; emit -limit 1 | put x=m.value | view sink`,
+                })
+                .then(function(res) {
+                    expect(res.sinks.sink[0].x).to.equal(10);
+                });
+            });
+
+            it('Can import a module from a directory', function() {
+                return check_juttle({
+                    moduleResolver: file_resolver.resolve,
+                    program: `import "${__dirname}/juttles" as m; emit -limit 1 | put x=m.value | view sink`,
+                })
+                .then(function(res) {
+                    expect(res.sinks.sink[0].x).to.equal(10);
+                });
+            });
+
+            it('Can import a nested set of modules from relative pathnames', function() {
+                return check_juttle({
+                    moduleResolver: file_resolver.resolve,
+                    program: `import "${__dirname}/juttles/subdir/index.juttle" as m; emit -limit 1 | put x=m.value | view sink`,
+                })
+                .then(function(res) {
+                    expect(res.sinks.sink[0].x).to.equal(10);
+                });
+            });
+
+            it('Can import a nested set of modules from relative pathnames with duplicates', function() {
+                return check_juttle({
+                    moduleResolver: file_resolver.resolve,
+                    program: `import "${__dirname}/juttles/subdir/subdir2/index.juttle" as m; emit -limit 1 | put x=m.value | view sink`,
+                })
+                .then(function(res) {
+                    expect(res.sinks.sink[0].x).to.equal(10);
+                });
             });
         });
     });


### PR DESCRIPTION
See commits for specific changes.

I'd like feedback on the technique of modifying the ast to handle the case of potentially duplicate import statements with the same relative pathname. Not sure whether this is bad practice or not.

One open question--do we want imports of standard library modules to have a 'stdlib' prefix? Currently, the stdlib directory is in the set of search paths so one imports those files with a 'import "random" as random" rather than 'import "stdlib/random". I think I'd have to move the lib/stdlib directory somewhere as a part of this change--we don't want lib/ as a search path.

@demmer @dmajda 

This fixes #513.
