### PR TITLE
Fix processing of argument of the “*” operator

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1270,39 +1270,44 @@ class SemanticPass {
         var op = node.operator;
         var name;
 
-        if (op === '++' || op === '--') {
-            this.with_lhs(true, () => {
+        switch (op) {
+            case '*':
                 this.with_expr_mode('result', () => {
                     this.sa_expr(node.argument);
                 });
-            });
-        } else {
-            this.with_expr_mode('result', () => {
-                this.sa_expr(node.argument);
-            });
-        }
+                if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
+                    throw errors.compileError('INVALID-FIELD-REFERENCE', {
+                        location: node.location
+                    });
+                }
+                node.d = false;
+                return;
 
-        if (op === '*') {
-            if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
-                throw errors.compileError('INVALID-FIELD-REFERENCE', {
-                    location: node.location
+            case '++':
+            case '--':
+                this.with_lhs(true, () => {
+                    this.with_expr_mode('result', () => {
+                        this.sa_expr(node.argument);
+                    });
                 });
-            }
-            node.d = false;
-            return;
-        }
-        node.d = node.argument.d;
-        //XXX limit allowable operators?  why only look for these two?
-        if (op === '++' || op === '--') {
-            name = node.argument.type === 'Variable' ?
-                node.argument.name : node.argument.object.name;
-            if (!this.scope.is_mutable(name, this.scope.type)) {
-                throw errors.compileError('INVALID-PREFIX-USE', {
-                    operator: op,
-                    variable: name,
-                    location: node.location
+                name = node.argument.type === 'Variable' ?
+                    node.argument.name : node.argument.object.name;
+                if (!this.scope.is_mutable(name, this.scope.type)) {
+                    throw errors.compileError('INVALID-PREFIX-USE', {
+                        operator: op,
+                        variable: name,
+                        location: node.location
+                    });
+                }
+                node.d = node.argument.d;
+                return;
+
+            default:
+                this.with_expr_mode('result', () => {
+                    this.sa_expr(node.argument);
                 });
-            }
+                node.d = node.argument.d;
+                return;
         }
     }
     sa_BinaryExpression(node) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1272,8 +1272,10 @@ class SemanticPass {
 
         switch (op) {
             case '*':
-                this.with_expr_mode('result', () => {
-                    this.sa_expr(node.argument);
+                this.with_lhs(false, () => {
+                    this.with_expr_mode('result', () => {
+                        this.sa_expr(node.argument);
+                    });
                 });
                 if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
                     throw errors.compileError('INVALID-FIELD-REFERENCE', {

--- a/test/runtime/specs/juttle-spec/expressions/star-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/star-operator.spec.md
@@ -1,0 +1,16 @@
+# The unary `*` operator
+
+## Processes its argument as rvalue
+
+Regression test for #598.
+
+### Juttle
+
+    function f() {
+    }
+    
+    emit -from :0: -limit 1 | put *f['x'] = 5
+
+### Errors
+
+  * Cannot use a function as a variable


### PR DESCRIPTION
Consider an expression like this:

```juttle
*field = "foo"
```

The `field` variable is evaluated and its value is used to select a point field. It is not itself assigned to. In semantic pass, this corresponds to processing with `this.lhs == false`.

Before this commit, code in `sa_UnaryExpression` wrongly processed `*` arguments with the same `this.lhs` value as the operator itself. This PR fixes it to always process them with `this.lhs == false`.

Fixes #598.