### PR TITLE
Stronger juttle spec assertions

### DIFF
--- a/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/function-call.spec.md
@@ -251,7 +251,7 @@ in runtime.
         error 'Boom!';
     }
 
-    emit -from :0: -limit 10 | put a = f()
+    emit -from :0: -limit 1 | put a = f()
 
 ### Output
 
@@ -273,7 +273,7 @@ in runtime.
         error 'Boom!';
     }
 
-    emit -from :0: -limit 10 | reduce a = f()
+    emit -from :0: -limit 1 | reduce a = f()
 
 ### Output
 
@@ -295,7 +295,7 @@ in runtime.
         error 'Boom!';
     }
 
-    emit -from :0: -limit 10 | filter f() < 5
+    emit -from :0: -limit 1 | filter f() < 5
 
 ### Output
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/and-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/and-operator.spec.md
@@ -19,7 +19,7 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 4
+    emit -from Date.new(0) -limit 1
       | filter x != null AND x < null
       | view result
 

--- a/test/runtime/specs/juttle-spec/filter-expressions/or-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/filter-expressions/or-operator.spec.md
@@ -21,7 +21,7 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 4
+    emit -from Date.new(0) -limit 1
       | filter x == null OR x < null
       | view result
 

--- a/test/runtime/specs/juttle-spec/juttle-calendar-moments.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-calendar-moments.spec.md
@@ -12,7 +12,7 @@
 
 ## rejects mixed calendar durations for quantization
 ### Juttle
-    emit -from :2014-01-15: -every :month: -limit 5
+    emit -from :2014-01-15: -every :month: -limit 1
     | put t=time, m=:1/02.03:04:05:, d=Date.quantize(time, m)
     | view result
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-filter.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-filter.spec.md
@@ -18,3 +18,4 @@
 ### Warnings
 
   * Invalid operand types for ">": null and number (0).
+  * Invalid operand types for ">": null and number (0).

--- a/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
@@ -28,7 +28,7 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 3 | put n=count(), time = :s: | view result
+    emit -from Date.new(0) -limit 1 | put n=count(), time = :s: | view result
 
 ### Warnings
 
@@ -43,6 +43,7 @@
 ### Warnings
 
    * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
 
 ### Output
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
@@ -56,6 +57,7 @@
 
 ### Warnings
 
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
    * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
 
 ### Output
@@ -152,4 +154,5 @@ of d is 2 instead of 3.
 
 ### Warnings
 
+  * Invalid operand types for ">": null and number (0).
   * Invalid operand types for ">": null and number (0).

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -387,6 +387,9 @@ default values of null for when no -every is specified.
     { "count": 5, "x": 0, "y": null }
     { "count": 5, "x": 1, "y": null }
 
+### Warnings
+
+  * group by undefined field "y"
 
 ## custom reducer is torn down at batch epochs
 
@@ -456,18 +459,23 @@ default values of null for when no -every is specified.
 ### Warnings
 
   * Invalid operand types for ">": null and number (0).
+  * Invalid operand types for ">": null and number (0).
 
 ## Allows direct assignment to the `time` field
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 6 | reduce -every :2s: time = first(time) + :1m: | view result
+    emit -from Date.new(0) -limit 4 | reduce -every :2s: time = first(time) + :1m: | view result
 
 ### Output
 
     { time: "1970-01-01T00:01:00.000Z" }
     { time: "1970-01-01T00:01:02.000Z" }
-    { time: "1970-01-01T00:01:04.000Z" }
+
+### Warnings
+
+   * out-of-order assignment of time
+   * out-of-order assignment of time
 
 ## complains about out-of-order points
 
@@ -521,11 +529,12 @@ default values of null for when no -every is specified.
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 6 | batch :s: | reduce -reset false time = last(time) - 2 * count() * :s: | view result
+    emit -from Date.new(0) -limit 2 | batch :s: | reduce -reset false time = last(time) - 2 * count() * :s: | view result
 
 ### Warnings
 
    * out-of-order assignment of time 1969-12-31T23:59:58.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
 
 ## complains about out-of-order assignment to the `time` field with -every
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
@@ -1,10 +1,24 @@
 # Juttle "sort" processor
 
+## Limits: sort emits warning about dropped points
+
+### Juttle
+
+    emit -limit 2 -hz 10 | put c=count() | sort -limit 1 c | keep c | view result
+
+### Output
+
+    
+
+### Warnings
+
+  * sort limit exceeded, dropping points
+
 ## Limits: non-batched flow
 
 ### Juttle
 
-    emit -limit 10 -hz 10 | put c=count() | sort -limit 3 c | keep c | view result
+    emit -limit 3 -hz 10 | put c=count() | sort -limit 3 c | keep c | view result
 
 ### Output
 
@@ -16,7 +30,7 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 10 -hz 10 | put c=count() | sort -limit 3 c | keep c | view result
+    emit -from Date.new(0) -limit 3 -hz 10 | put c=count() | sort -limit 3 c | keep c | view result
 
 ### Output
 
@@ -28,7 +42,7 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 10 -hz 10 | batch 0.5 | put c=count() | sort -limit 3 c
+    emit -from Date.new(0) -limit 10 -hz 10 | batch 0.5 | put c=count() | sort -limit 4 c
       | keep c | view result
 
 ### Output
@@ -36,15 +50,22 @@
     {"c":1}
     {"c":2}
     {"c":3}
+    {"c":4}
     {"c":1}
     {"c":2}
     {"c":3}
+    {"c":4}
+
+### Warnings
+
+  * sort limit exceeded, dropping points
+  * sort limit exceeded, dropping points
 
 ## Limits: non-batched flow, point by point, by grouping
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 10 -hz 10 | put c=count(), d=c%2 | sort -limit 2 c by d | keep c, d| sort c | view result
+    emit -from Date.new(0) -limit 2 -hz 10 | put c=count(), d=c%2 | sort -limit 2 c by d | keep c, d| sort c | view result
 
 ### Output
 
@@ -55,15 +76,24 @@
 
 ### Juttle
 
-    emit -from Date.new(0) -limit 10 -hz 10 | batch 0.5 | put c=count(), d=c%2 | sort -limit 2 c by d
+    emit -from Date.new(0) -limit 10 -hz 10 | batch 0.5 | put c=count(), d=c%4 | sort -limit 4 c by d
       | sort c | keep c, d | view result
 
 ### Output
 
     {"c":1,"d":1}
-    {"c":2,"d":0}
+    {"c":2,"d":2}
+    {"c":3,"d":3}
+    {"c":4,"d":0}
     {"c":1,"d":1}
-    {"c":2,"d":0}
+    {"c":2,"d":2}
+    {"c":3,"d":3}
+    {"c":4,"d":0}
+
+### Warnings
+
+  * sort limit exceeded, dropping points
+  * sort limit exceeded, dropping points
 
 ## Timestamps: unbatched flow
 

--- a/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-stochastic-adapter.spec.md
@@ -45,6 +45,10 @@
     { "host":"nyc.2", "service":"index", "count":422 }
     { "host":"nyc.2", "service":"authentication", "count":422 }
 
+### Warnings
+
+  * group by undefined field "service"
+
 ## historic read with source and a filter
 ### Juttle
     read stochastic -source "cdn" -nhosts 3 -from Date.new(0) -to Date.new(60)
@@ -56,6 +60,10 @@
     { "host":"sea.0", "service":null, "count":122 }
     { "host":"sea.0", "service":"search", "count":422 }
     { "host":"sea.0", "service":"authentication", "count":422 }
+
+### Warnings
+
+  * group by undefined field "service"
 
 ## historic read with source and a filter containing NOT
 
@@ -71,6 +79,10 @@ Regression test for PROD-8651.
     { "host":"sea.0", "service":null, "count":122 }
     { "host":"sea.0", "service":"search", "count":422 }
     { "host":"sea.0", "service":"authentication", "count":422 }
+
+### Warnings
+
+  * group by undefined field "service"
 
 ## historic read with source and -type metric
 ### Juttle

--- a/test/runtime/specs/juttle-spec/optimization/optimize-tail.spec.md
+++ b/test/runtime/specs/juttle-spec/optimization/optimize-tail.spec.md
@@ -44,7 +44,7 @@
 
 ### Juttle
 
-    read test -debug 'optimization' | tail 10 by bananas | view result
+    read test -debug 'optimization' | tail 10 by type | view result
 
 ### Output
 

--- a/test/runtime/specs/juttle-spec/stdlib/select.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/select.spec.md
@@ -42,7 +42,7 @@
     emit -limit 6 -from Date.new(0)
     | put x = count()
     | select.median -field 'x'
-    | sort parity
+    | keep x
     | view result
 
 ### Output

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -152,10 +152,12 @@ class SpecRenderer {
             parts.push('            expect(res.sinks.result).to.deep.equal(' + util.inspect(test.output, { depth: null }) + ');');
         }
 
+        parts.push('            expect(res.errors.length, "Expected test to emit ' + test.errors.length + ' errors: " + JSON.stringify(res.errors)).to.equal(' + test.errors.length + ');');
         for (var erri=0 ; erri < test.errors.length ; erri++) {
             parts.push('            expect(res.errors[' + erri + ']).to.include(' + JSON.stringify(test.errors[erri]) + ');');
         }
 
+        parts.push('            expect(res.warnings.length, "Expected test to emit ' + test.warnings.length + ' warnings: " + JSON.stringify(res.warnings)).to.equal(' + test.warnings.length + ');');
         for (var warni=0 ; warni < test.warnings.length ; warni++) {
             parts.push('            expect(res.warnings[' + warni + ']).to.include(' + JSON.stringify(test.warnings[warni]) + ');');
         }

--- a/test/spec/juttle-spec.js
+++ b/test/spec/juttle-spec.js
@@ -151,15 +151,13 @@ class SpecRenderer {
         if (test.output !== null) {
             parts.push('            expect(res.sinks.result).to.deep.equal(' + util.inspect(test.output, { depth: null }) + ');');
         }
-        if (test.errors.length > 0) {
-            for (var erri=0 ; erri < test.errors.length ; erri++) {
-                parts.push('            expect(res.errors[' + erri + ']).to.include(' + JSON.stringify(test.errors[erri]) + ');');
-            }
+
+        for (var erri=0 ; erri < test.errors.length ; erri++) {
+            parts.push('            expect(res.errors[' + erri + ']).to.include(' + JSON.stringify(test.errors[erri]) + ');');
         }
-        if (test.warnings.length > 0) {
-            for (var warni=0 ; warni < test.warnings.length ; warni++) {
-                parts.push('            expect(res.warnings[' + warni + ']).to.include(' + JSON.stringify(test.warnings[warni]) + ');');
-            }
+
+        for (var warni=0 ; warni < test.warnings.length ; warni++) {
+            parts.push('            expect(res.warnings[' + warni + ']).to.include(' + JSON.stringify(test.warnings[warni]) + ');');
         }
 
         if (test.errors.length > 0) {


### PR DESCRIPTION
Require tests to emit # of warnings / errors equal to the number of errors / warnings expected.

This also changes the semantics of juttle-spec's assertions. A missing errors/warnings section no longer means 'any number of errors', but 'no errors'.

Fix tests that were broken by this change.