### PR TITLE
Inputs register

### DIFF
--- a/lib/compiler/flowgraph/program_stats.js
+++ b/lib/compiler/flowgraph/program_stats.js
@@ -24,10 +24,10 @@ function input_stats(g) {
     var stats = {};
     var inputs = g.get_inputs();
     _.each(inputs, function (input) {
-        if (!_.has(stats, input.name)) {
-            stats[input.name] = 1;
+        if (!_.has(stats, input.type)) {
+            stats[input.type] = 1;
         } else {
-            stats[input.name]++;
+            stats[input.type]++;
         }
     });
     return stats;

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -3,6 +3,7 @@
 var _ = require('underscore');
 var values = require('../runtime/values');
 var procs = require('../runtime/procs');
+var inputs = require('../inputs');
 var errors = require('../errors');
 var SemanticPass = require('./semantic');
 
@@ -173,10 +174,23 @@ class GraphBuilder {
         }
         return key + '[' + this.input_seqnos[key]  + ']';
     }
-    define_input(bname, input_name, options, isStatic) {
-        var input = {id: bname, name: input_name, options: options, static: isStatic};
-        input.value = this._compute_input_val(input);
-        this.inputs.push(input);
+    define_input(bname, input_type, params, isStatic) {
+        let InputConstructor = inputs[input_type];
+
+        if (!InputConstructor) {
+            throw errors.compileError('UNKNOWN-INPUT', {
+                input_type: input_type
+            });
+        }
+
+        let input = new InputConstructor(bname, params);
+
+        if (_.has(this.input_values, input.id)) {
+            input.setValue(this.input_values[bname]);
+        }
+
+        this.inputs.push(input.toObj());
+
         return input.value;
     }
     add_function(ast) {

--- a/lib/inputs/base-input.js
+++ b/lib/inputs/base-input.js
@@ -1,20 +1,20 @@
 'use strict';
 
 class BaseInput {
-    constructor(type, id, options, inputDefaultValue) {
+    constructor(type, id, params, inputDefaultValue) {
         this.type = type;
         this.id = id;
-        this.options = this.normalizeOptions(options);
+        this.params = this.normalizeParams(params || {});
 
-        this.value = this.options.default ? this.normalizeValue(this.options.default) : this.getInputDefaultValue();
+        this.value = this.params.default || this.getInputDefaultValue();
     }
 
     getInputDefaultValue() {
         throw new Error('getInputDefaultValue must be implemented');
     }
 
-    normalizeOptions(options) {
-        return options || {};
+    normalizeParams(params) {
+        return params || {};
     }
 
     normalizeValue() {
@@ -30,7 +30,7 @@ class BaseInput {
             id: this.id,
             type: this.type,
             value: this.value,
-            options: this.options
+            params: this.params
         };
     }
 }

--- a/lib/inputs/base-input.js
+++ b/lib/inputs/base-input.js
@@ -1,0 +1,38 @@
+'use strict';
+
+class BaseInput {
+    constructor(type, id, options, inputDefaultValue) {
+        this.type = type;
+        this.id = id;
+        this.options = this.normalizeOptions(options);
+
+        this.value = this.options.default ? this.normalizeValue(this.options.default) : this.getInputDefaultValue();
+    }
+
+    getInputDefaultValue() {
+        throw new Error('getInputDefaultValue must be implemented');
+    }
+
+    normalizeOptions(options) {
+        return options || {};
+    }
+
+    normalizeValue() {
+        throw new Error('normalizeValue must be implemented');
+    }
+
+    setValue(value) {
+        this.value = this.normalizeValue(value);
+    }
+
+    toObj() {
+        return {
+            id: this.id,
+            type: this.type,
+            value: this.value,
+            options: this.options
+        };
+    }
+}
+
+module.exports = BaseInput;

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
 var TextInput = require('./text-input');
+var NumberInput = require('./number-input');
+var SelectInput = require('./select-input');
 
 module.exports = {
-    text: TextInput 
+    text: TextInput,
+    number: NumberInput,
+    select: SelectInput
 };

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var TextInput = require('./text-input');
+
+module.exports = {
+    text: TextInput 
+};

--- a/lib/inputs/number-input.js
+++ b/lib/inputs/number-input.js
@@ -2,16 +2,38 @@
 
 var _ = require('underscore');
 var BaseInput = require('./base-input');
+var errors = require('../errors');
 
 const DEFAULT_VALUE = 0;
 
 class NumberInput extends BaseInput {
-    constructor(id, options) {
-        super('number', id, options);
+    constructor(id, params) {
+        super('number', id, params);
     }
 
     getInputDefaultValue() {
         return DEFAULT_VALUE;
+    }
+
+    normalizeParams(params) {
+        if (params.default) {
+            try {
+                params = Object.assign({}, params, {
+                    default: this.normalizeValue(params.default)
+                });
+            } catch (err) {
+                if (!(err instanceof errors.CompileError)) throw err;
+
+                throw errors.compileError('INPUT-INVALID-PARAM', {
+                    input_id: this.id,
+                    param: 'default',
+                    param_value: params.default,
+                    message: err.message
+                });
+            }
+        }
+
+        return params;
     }
 
     normalizeValue(value) {
@@ -19,7 +41,11 @@ class NumberInput extends BaseInput {
             return value;
         }
 
-        throw new Error('invalid input value');
+        throw errors.compileError('INPUT-INVALID-VALUE', {
+            input_id: this.id,
+            value: value,
+            message: 'Value must be a number'
+        });
     }
 }
 

--- a/lib/inputs/number-input.js
+++ b/lib/inputs/number-input.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var _ = require('underscore');
+var BaseInput = require('./base-input');
+
+const DEFAULT_VALUE = 0;
+
+class NumberInput extends BaseInput {
+    constructor(id, options) {
+        super('number', id, options);
+    }
+
+    getInputDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    normalizeValue(value) {
+        if (_.isNumber(value)) {
+            return value;
+        }
+
+        throw new Error('invalid input value');
+    }
+}
+
+module.exports = NumberInput;

--- a/lib/inputs/select-input.js
+++ b/lib/inputs/select-input.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var _ = require('underscore');
+var BaseInput = require('./base-input');
+
+class SelectInput extends BaseInput {
+    constructor(id, options) {
+        super('select', id, options);
+    }
+
+    getInputDefaultValue() {
+        return this.options.items[0].value;
+    }
+
+    normalizeOptions(options) {
+        options = Object.assign({}, options) || {};
+
+        if (!options.items || !_.isArray(options.items)) {
+            throw new Error('invalid options');
+        }
+
+        options.items = options.items.map((item) => {
+            return _.isString(item) ? { value: item, label: item } : item;
+        });
+
+        return options;
+    }
+
+    normalizeValue(value) {
+        let retrievedValue = _.findWhere(this.options.items, { value });
+
+        if (!retrievedValue) {
+            throw new Error('invalid value');
+        }
+
+        return retrievedValue.value;
+    }
+}
+
+module.exports = SelectInput;

--- a/lib/inputs/select-input.js
+++ b/lib/inputs/select-input.js
@@ -2,35 +2,87 @@
 
 var _ = require('underscore');
 var BaseInput = require('./base-input');
+var errors = require('../errors');
 
 class SelectInput extends BaseInput {
-    constructor(id, options) {
-        super('select', id, options);
+    constructor(id, params) {
+        super('select', id, params);
     }
 
     getInputDefaultValue() {
-        return this.options.items[0].value;
+        return this.params.items[0].value;
     }
 
-    normalizeOptions(options) {
-        options = Object.assign({}, options) || {};
+    normalizeParams(params) {
+        params = Object.assign({}, params);
 
-        if (!options.items || !_.isArray(options.items)) {
-            throw new Error('invalid options');
+        if (!params.items) {
+            throw errors.compileError('INPUT-REQ-PARAMS-MISSING', {
+                input_id: this.id,
+                missing_params: 'items'
+            });
         }
 
-        options.items = options.items.map((item) => {
-            return _.isString(item) ? { value: item, label: item } : item;
+        if (!_.isArray(params.items)) {
+            throw errors.compileError('INPUT-INVALID-PARAM', {
+                input_id: this.id,
+                param: 'items',
+                param_value: params.items,
+                message: 'Item param must be an array'
+            });
+        }
+
+        params.items = params.items.map((item) => {
+            // if value is string, number or array expand to obj with value and label
+            if (_.isString(item) || _.isNumber(item) || _.isArray(item)) {
+                return { value: item, label: item.toString() };
+            }
+
+            if (!item.value || !item.label) {
+                throw errors.compileError('INPUT-INVALID-PARAM', {
+                    input_id: this.id,
+                    param: 'items',
+                    param_value: params.items,
+                    message: 'All object item options must have a value and label attribute.'
+                });
+            }
+
+            return item;
         });
 
-        return options;
+        if (params.default) {
+            try {
+                params = Object.assign({}, params, {
+                    default: this.normalizeValue(params.default, params.items)
+                });
+            } catch (err) {
+                if (!(err instanceof errors.CompileError)) throw err;
+
+                throw errors.compileError('INPUT-INVALID-PARAM', {
+                    input_id: this.id,
+                    param: 'default',
+                    param_value: params.default,
+                    message: err.message
+                });
+            }
+        }
+
+        return params;
     }
 
-    normalizeValue(value) {
-        let retrievedValue = _.findWhere(this.options.items, { value });
+    normalizeValue(value, items) {
+        items = items || this.params.items;
+
+        let retrievedValue = _.find(items, (item) => {
+            return _.isEqual(value, item.value);
+        });
 
         if (!retrievedValue) {
-            throw new Error('invalid value');
+            throw errors.compileError('INPUT-INVALID-VALUE', {
+                input_id: this.id,
+                value: value,
+                message: 'Value must be a member of -items'
+            });
         }
 
         return retrievedValue.value;

--- a/lib/inputs/text-input.js
+++ b/lib/inputs/text-input.js
@@ -2,16 +2,40 @@
 
 var _ = require('underscore');
 var BaseInput = require('./base-input');
+var errors = require('../errors');
 
 const DEFAULT_VALUE = '';
 
 class TextInput extends BaseInput {
-    constructor(id, options) {
-        super('text', id, options);
+    constructor(id, params) {
+        super('text', id, params);
     }
 
     getInputDefaultValue() {
         return DEFAULT_VALUE;
+    }
+
+    normalizeParams(params) {
+        if (params.default) {
+            try {
+                params = Object.assign({}, params, {
+                    default: this.normalizeValue(params.default)
+                });
+            } catch (err) {
+                if (!(err instanceof errors.CompileError)) {
+                    throw err;
+                }
+
+                throw errors.compileError('INPUT-INVALID-PARAM', {
+                    input_id: this.id,
+                    param: 'default',
+                    param_value: params.default,
+                    message: err.message
+                });
+            }
+        }
+
+        return params;
     }
 
     normalizeValue(value) {
@@ -21,7 +45,11 @@ class TextInput extends BaseInput {
             return value.toString();
         }
 
-        throw new Error('invalid input value');
+        throw errors.compileError('INPUT-INVALID-VALUE', {
+            input_id: this.id,
+            value: value,
+            message: 'Value must be either a string or number'
+        });
     }
 }
 

--- a/lib/inputs/text-input.js
+++ b/lib/inputs/text-input.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var _ = require('underscore');
+var BaseInput = require('./base-input');
+
+const DEFAULT_VALUE = '';
+
+class TextInput extends BaseInput {
+    constructor(id, options) {
+        super('text', id, options);
+    }
+
+    getInputDefaultValue() {
+        return DEFAULT_VALUE;
+    }
+
+    normalizeValue(value) {
+        if (_.isString(value)) {
+            return value;
+        } else if (_.isNumber(value)) {
+            return value.toString();
+        }
+
+        throw new Error('invalid input value');
+    }
+}
+
+module.exports = TextInput;

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -125,5 +125,10 @@
   "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
   "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context.",
   "HTTP-ERROR": "HTTP request failed with {status}: {message}",
-  "CANNOT-FILTER-ON-TIME": "Cannot filter on \"time\" in read. Use -to, -from, or -last instead."
+  "CANNOT-FILTER-ON-TIME": "Cannot filter on \"time\" in read. Use -to, -from, or -last instead.",
+
+  "UNKNOWN-INPUT": "Unknown input type {input_type}",
+  "INPUT-REQ-PARAMS-MISSING": "Input \"{input_id}\" is missing the follow required param(s): {missing_params}",
+  "INPUT-INVALID-PARAM": "Input \"{input_id}\" has an invalid param \"{param}\" with value \"{param_value}\": {message}",
+  "INPUT-INVALID-VALUE": "Invalid value \"{value}\" for input \"{input_id}\": {message}"
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "body-parser": "^1.14.1",
     "chai": "^3.5.0",
+    "chai-as-promised": "^5.2.0",
     "child-process-promise": "^1.1.0",
     "express": "^4.13.3",
     "find-free-port": "^1.0.2",

--- a/test/compiler/program_stats.spec.js
+++ b/test/compiler/program_stats.spec.js
@@ -265,10 +265,10 @@ describe('Program instrumentation', function() {
         imports: 1
     });
 
-    test('input a: text -default ""; input b: dropdown -default ""; emit | view view', {
+    test('input a: text -default ""; input b: select -items ["a", "b"]; emit | view view', {
         inputs: {
             text: 1,
-            dropdown: 1
+            select: 1
         },
         input_total: 2,
         source_total: 1,

--- a/test/inputs/input-test-utils.js
+++ b/test/inputs/input-test-utils.js
@@ -1,0 +1,19 @@
+'use strict';
+
+function expectError(fn) {
+    let err;
+
+    try {
+        fn();
+    } catch (e) {
+        err = e;
+    }
+
+    if (!err) throw new Error('expected function to throw error');
+
+    return err;
+}
+
+module.exports = {
+    expectError: expectError
+};

--- a/test/inputs/number-input.spec.js
+++ b/test/inputs/number-input.spec.js
@@ -2,6 +2,7 @@
 
 var expect = require('chai').expect;
 var NumberInput = require('../../lib/inputs/number-input');
+var expectError = require('./input-test-utils').expectError;
 
 describe('number input', () => {
     describe('valid cases', () => {
@@ -9,7 +10,7 @@ describe('number input', () => {
             id: 'id',
             type: 'number',
             value: 1,
-            options: {
+            params: {
                 default: 1
             }
         };
@@ -19,7 +20,7 @@ describe('number input', () => {
         }
 
         it('handles normal input with default and value', () => {
-            let input = new NumberInput('id', testObj.options);
+            let input = new NumberInput('id', testObj.params);
             expect(input.toObj()).to.deep.equal(testObj);
 
             input.setValue(2);
@@ -36,17 +37,25 @@ describe('number input', () => {
 
     describe('error cases', () => {
         it('non number default throws error', () => {
-            expect(() => {
-                new NumberInput('id', {
-                    default: { 'obj': 5 }
-                });
-            }).to.throw(/invalid input value/);
+            let err = expectError(() => new NumberInput('id', { default: { 'obj': 5 } }));
+
+            expect(err.code).to.equal('INPUT-INVALID-PARAM');
+            expect(err.info).to.contain({
+                input_id: 'id',
+                param: 'default'
+            });
+            expect(err.info.param_value).to.eql({ 'obj': 5 });
         });
 
         it('setting string value throws error', () => {
             let input = new NumberInput('id');
+            let err = expectError(() => input.setValue('hi'));
 
-            expect(() => input.setValue('hi')).to.throw(/invalid input value/);
+            expect(err.code).to.equal('INPUT-INVALID-VALUE');
+            expect(err.info).to.contain({
+                input_id: 'id',
+                value: 'hi'
+            });
         });
     });
 });

--- a/test/inputs/number-input.spec.js
+++ b/test/inputs/number-input.spec.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var expect = require('chai').expect;
+var NumberInput = require('../../lib/inputs/number-input');
+
+describe('number input', () => {
+    describe('valid cases', () => {
+        const testObj = {
+            id: 'id',
+            type: 'number',
+            value: 1,
+            options: {
+                default: 1
+            }
+        };
+
+        function updateTestObj(update) {
+            return Object.assign({}, testObj, update);
+        }
+
+        it('handles normal input with default and value', () => {
+            let input = new NumberInput('id', testObj.options);
+            expect(input.toObj()).to.deep.equal(testObj);
+
+            input.setValue(2);
+            expect(input.toObj()).to.deep.equal(updateTestObj({
+                value: 2
+            }));
+        });
+
+        it('not setting value or default has value of 0', () => {
+            let input = new NumberInput('id');
+            expect(input.value).to.equal(0);
+        });
+    });
+
+    describe('error cases', () => {
+        it('non number default throws error', () => {
+            expect(() => {
+                new NumberInput('id', {
+                    default: { 'obj': 5 }
+                });
+            }).to.throw(/invalid input value/);
+        });
+
+        it('setting string value throws error', () => {
+            let input = new NumberInput('id');
+
+            expect(() => input.setValue('hi')).to.throw(/invalid input value/);
+        });
+    });
+});

--- a/test/inputs/select-input.spec.js
+++ b/test/inputs/select-input.spec.js
@@ -2,12 +2,13 @@
 
 var expect = require('chai').expect;
 var SelectInput = require('../../lib/inputs/select-input');
+var expectError = require('./input-test-utils').expectError;
 
 const testObj = {
     id: 'id',
     type: 'select',
     value: '1',
-    options: {
+    params: {
         default: '1',
         items: [
             {value: '1', label: '1'},
@@ -24,7 +25,7 @@ const updateTestObj = (updateObj) => {
 describe('select-input', () => {
     describe('valid cases', () => {
         it('handles normal text input with default and value', () => {
-            let select = new SelectInput('id', testObj.options);
+            let select = new SelectInput('id', testObj.params);
             expect(select.toObj()).to.deep.equal(testObj);
 
             select.setValue('2');
@@ -41,13 +42,39 @@ describe('select-input', () => {
             expect(select.toObj()).to.deep.equal(testObj);
         });
 
+        it('propery transforms array items with shortened syntax', () => {
+            let select = new SelectInput('id', {
+                items: [['1', '2', '3'], ['4', '5', '6']]
+            });
+            expect(select.toObj()).to.deep.equal(updateTestObj({
+                value: ['1', '2', '3'],
+                params: {
+                    items: [
+                        { value: ['1', '2', '3'], label: '1,2,3' },
+                        { value: ['4', '5', '6'], label: '4,5,6' }
+                    ]
+                }
+            }));
+
+            select.setValue(['4', '5', '6']);
+            expect(select.toObj()).to.deep.equal(updateTestObj({
+                value: ['4', '5', '6'],
+                params: {
+                    items: [
+                        { value: ['1', '2', '3'], label: '1,2,3' },
+                        { value: ['4', '5', '6'], label: '4,5,6' }
+                    ]
+                }
+            }));
+        });
+
         it('defaults to first value when no default is specified', () => {
             let select = new SelectInput('id', {
                 items: ['first', 'second', 'third']
             });
             expect(select.toObj()).to.deep.equal(updateTestObj({
                 value: 'first',
-                options: {
+                params: {
                     items: [
                         { value: 'first', label: 'first' },
                         { value: 'second', label: 'second' },
@@ -59,17 +86,45 @@ describe('select-input', () => {
     });
 
     describe('error cases', () => {
-        it('instantiating without options.items throws error', () => {
-            expect(() => new SelectInput('id')).to.throw(/invalid options/);
+        it('instantiating without params.items throws error', () => {
+            let error = expectError(() => new SelectInput('id'));
+
+            expect(error.code).to.equal('INPUT-REQ-PARAMS-MISSING');
+            expect(error.info).to.contain({
+                input_id: 'id',
+                missing_params: 'items'
+            });
         });
 
-        it('instantiating with non-array options.items throws error', () => {
-            expect(() => new SelectInput('id', { items: { 'error': 'error' } })).to.throw(/invalid options/);
+        it('instantiating with non-array params.items throws error', () => {
+            let error = expectError(() => new SelectInput('id', {
+                items: { 'error': 'error' }
+            }));
+
+            expect(error.code).to.equal('INPUT-INVALID-PARAM');
+            expect(error.info).to.contain({ input_id: 'id', param: 'items' });
+            expect(error.info.param_value).to.eql({ 'error': 'error' });
         });
 
         it('setting invalid value throw error', () => {
-            let input = new SelectInput('id', testObj.options);
-            expect(() => input.setValue('ten')).to.throw(/invalid value/);
+            let input = new SelectInput('id', testObj.params);
+            let error = expectError(() => input.setValue('ten'));
+
+            expect(error.code).to.equal('INPUT-INVALID-VALUE');
+            expect(error.info).to.contain({
+                input_id: 'id',
+                value: 'ten'
+            });
+        });
+
+        it('item thats an object without a label and value throws error', () => {
+            let error = expectError(() => new SelectInput('id', {
+                items: [ '4', '5', { error: 'error' } ]
+            }));
+
+            expect(error.code).to.equal('INPUT-INVALID-PARAM');
+            expect(error.info).to.contain({ input_id: 'id', param: 'items' });
+            expect(error.info.param_value).to.eql([ '4', '5', { error: 'error' }]);
         });
     });
 });

--- a/test/inputs/select-input.spec.js
+++ b/test/inputs/select-input.spec.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var expect = require('chai').expect;
+var SelectInput = require('../../lib/inputs/select-input');
+
+const testObj = {
+    id: 'id',
+    type: 'select',
+    value: '1',
+    options: {
+        default: '1',
+        items: [
+            {value: '1', label: '1'},
+            {value: '2', label: '2'},
+            {value: '3', label: '3'}
+        ]
+    }
+};
+
+const updateTestObj = (updateObj) => {
+    return Object.assign({}, testObj, updateObj);
+};
+
+describe('select-input', () => {
+    describe('valid cases', () => {
+        it('handles normal text input with default and value', () => {
+            let select = new SelectInput('id', testObj.options);
+            expect(select.toObj()).to.deep.equal(testObj);
+
+            select.setValue('2');
+            expect(select.toObj()).to.deep.equal(updateTestObj({
+                value: '2'
+            }));
+        });
+
+        it('properly transforms items with shortened syntax', () => {
+            let select = new SelectInput('id', {
+                default: '1',
+                items: [ '1', '2', '3']
+            });
+            expect(select.toObj()).to.deep.equal(testObj);
+        });
+
+        it('defaults to first value when no default is specified', () => {
+            let select = new SelectInput('id', {
+                items: ['first', 'second', 'third']
+            });
+            expect(select.toObj()).to.deep.equal(updateTestObj({
+                value: 'first',
+                options: {
+                    items: [
+                        { value: 'first', label: 'first' },
+                        { value: 'second', label: 'second' },
+                        { value: 'third', label: 'third' }
+                    ]
+                }
+            }));
+        });
+    });
+
+    describe('error cases', () => {
+        it('instantiating without options.items throws error', () => {
+            expect(() => new SelectInput('id')).to.throw(/invalid options/);
+        });
+
+        it('instantiating with non-array options.items throws error', () => {
+            expect(() => new SelectInput('id', { items: { 'error': 'error' } })).to.throw(/invalid options/);
+        });
+
+        it('setting invalid value throw error', () => {
+            let input = new SelectInput('id', testObj.options);
+            expect(() => input.setValue('ten')).to.throw(/invalid value/);
+        });
+    });
+});

--- a/test/inputs/text-input.spec.js
+++ b/test/inputs/text-input.spec.js
@@ -2,6 +2,7 @@
 
 var expect = require('chai').expect;
 var TextInput = require('../../lib/inputs/text-input');
+var expectError = require('./input-test-utils').expectError;
 
 describe('text input', () => {
     describe('valid cases', () => {
@@ -9,7 +10,7 @@ describe('text input', () => {
             id: 'id',
             type: 'text',
             value: 'default value',
-            options: {
+            params: {
                 default: 'default value'
             }
         };
@@ -19,7 +20,7 @@ describe('text input', () => {
         }
 
         it('handles normal text input with default and value', () => {
-            let input = new TextInput('id', testObj.options);
+            let input = new TextInput('id', testObj.params);
             expect(input.toObj()).to.deep.equal(testObj);
 
             input.setValue('other value');
@@ -35,7 +36,7 @@ describe('text input', () => {
                 id: 'id',
                 type: 'text',
                 value: '',
-                options: {}
+                params: {}
             });
         });
 
@@ -47,8 +48,8 @@ describe('text input', () => {
 
             expect(input.toObj()).to.deep.equal(updateTestObj({
                 value: '10',
-                options: {
-                    default: 5
+                params: {
+                    default: '5'
                 }
             }));
         });
@@ -56,11 +57,16 @@ describe('text input', () => {
 
     describe('error cases', () => {
         it('non string or number default throws error', () => {
-            expect(() => {
-                new TextInput('id', {
-                    default: { 'obj': 5 }
-                });
-            }).to.throw(/invalid input value/);
+            let err = expectError(() => {
+                new TextInput('id', { default: { 'obj': 5 } });
+            });
+
+            expect(err.code).to.equal('INPUT-INVALID-PARAM');
+            expect(err.info).to.contain({
+                input_id: 'id',
+                param: 'default'
+            });
+            expect(err.info.param_value).to.deep.equal({ 'obj': 5 });
         });
 
         it('non string or number value throws error', () => {
@@ -68,7 +74,11 @@ describe('text input', () => {
                 default: 'default'
             });
 
-            expect(input.setValue.bind(input, [1, 2])).to.throw(/invalid input value/);
+            let err = expectError(() => input.setValue([1, 2]));
+
+            expect(err.code).to.equal('INPUT-INVALID-VALUE');
+            expect(err.info.input_id).to.equal('id');
+            expect(err.info.value).to.eql([1, 2]);
         });
     });
 });

--- a/test/inputs/text-input.spec.js
+++ b/test/inputs/text-input.spec.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var expect = require('chai').expect;
+var TextInput = require('../../lib/inputs/text-input');
+
+describe('text input', () => {
+    describe('valid cases', () => {
+        it('handles normal text input with default and value', () => {
+            let inputObj = {
+                id: 'id',
+                type: 'text',
+                value: 'default value',
+                options: {
+                    default: 'default value'
+                }
+            };
+
+            let input = new TextInput('id', inputObj.options);
+            expect(input.toObj()).to.deep.equal(inputObj);
+
+            input.setValue('other value');
+            expect(input.toObj()).to.deep.equal(Object.assign({}, inputObj, {
+                value: 'other value'
+            }));
+        });
+
+        it('not setting value returns default', () => {
+            let input = new TextInput('id', {
+                default: 'my default'
+            });
+
+            expect(input.toObj()).to.deep.equal({
+                id: 'id',
+                type: 'text',
+                value: 'my default',
+                options: {
+                    default: 'my default'
+                }
+            });
+        });
+
+        it('not setting value or default has value of emptry string', () => {
+            let input = new TextInput('id');
+
+            expect(input.toObj()).to.deep.equal({
+                id: 'id',
+                type: 'text',
+                value: '',
+                options: {}
+            });
+        });
+
+        it('coerce number values into strings', () => {
+            let input = new TextInput('id', {
+                default: 5
+            });
+            input.setValue(10);
+
+            expect(input.toObj()).to.deep.equal({
+                id: 'id',
+                type: 'text',
+                value: '10',
+                options: {
+                    default: 5
+                }
+            });
+        });
+    });
+
+    describe('error cases', () => {
+        it('non string or number default throws error', () => {
+            expect(() => {
+                new TextInput('id', {
+                    default: { 'obj': 5 }
+                });
+            }).to.throw(/invalid input value/);
+        });
+
+        it('non string or number value throws error', () => {
+            let input = new TextInput('id', {
+                default: 'default'
+            });
+
+            expect(input.setValue.bind(input, [1, 2])).to.throw(/invalid input value/);
+        });
+    });
+});

--- a/test/inputs/text-input.spec.js
+++ b/test/inputs/text-input.spec.js
@@ -5,38 +5,27 @@ var TextInput = require('../../lib/inputs/text-input');
 
 describe('text input', () => {
     describe('valid cases', () => {
-        it('handles normal text input with default and value', () => {
-            let inputObj = {
-                id: 'id',
-                type: 'text',
-                value: 'default value',
-                options: {
-                    default: 'default value'
-                }
-            };
+        const testObj = {
+            id: 'id',
+            type: 'text',
+            value: 'default value',
+            options: {
+                default: 'default value'
+            }
+        };
 
-            let input = new TextInput('id', inputObj.options);
-            expect(input.toObj()).to.deep.equal(inputObj);
+        function updateTestObj(update) {
+            return Object.assign({}, testObj, update);
+        }
+
+        it('handles normal text input with default and value', () => {
+            let input = new TextInput('id', testObj.options);
+            expect(input.toObj()).to.deep.equal(testObj);
 
             input.setValue('other value');
-            expect(input.toObj()).to.deep.equal(Object.assign({}, inputObj, {
+            expect(input.toObj()).to.deep.equal(updateTestObj({
                 value: 'other value'
             }));
-        });
-
-        it('not setting value returns default', () => {
-            let input = new TextInput('id', {
-                default: 'my default'
-            });
-
-            expect(input.toObj()).to.deep.equal({
-                id: 'id',
-                type: 'text',
-                value: 'my default',
-                options: {
-                    default: 'my default'
-                }
-            });
         });
 
         it('not setting value or default has value of emptry string', () => {
@@ -56,14 +45,12 @@ describe('text input', () => {
             });
             input.setValue(10);
 
-            expect(input.toObj()).to.deep.equal({
-                id: 'id',
-                type: 'text',
+            expect(input.toObj()).to.deep.equal(updateTestObj({
                 value: '10',
                 options: {
                     default: 5
                 }
-            });
+            }));
         });
     });
 


### PR DESCRIPTION
Add input value and param validation and normalization in the compiler. 

Essentially I've created a registry of input types that the compiler supports. The input classes will validate and morph params and values passed into it and throw errors accordingly. 

If an input-type is not supported an error is thrown.

Resolves #148 
Resolves #558 

Will eventually help juttle/juttle-viewer#34

TODO:
- [ ] Add support for multi-select input
- [ ] Add support for date input
- [ ] Add support for duration input
