### PR TITLE
Add nested expression tests for “.” and “[]” operators

### DIFF
--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-nested.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-rvalue-nested.spec.md
@@ -1,0 +1,25 @@
+# The `.` operator (in rvalue, nested)
+
+## Returns correct result when used in a nested expression
+
+### Juttle
+
+    const c = { a: 1, b: { d: 4, e: { g: 7, h: 8, i: 9 }, f: 6, }, c: 3 };
+
+    emit -from :0: -limit 1 | put result = c.b.e.h | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 8 }
+
+## Produces an error when a property in the middle of the chain is missing
+
+### Juttle
+
+    const c = { a: 1, b: { d: 4, e: { g: 7, h: 8, i: 9 }, f: 6, }, c: 3 };
+
+    emit -from :0: -limit 1 | put result = c.b.g.h | view result
+
+### Errors
+
+  * RuntimeError: Invalid operand types for "[]": null and string (h).

--- a/test/runtime/specs/juttle-spec/expressions/get-operator-rvalue-nested.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator-rvalue-nested.spec.md
@@ -1,0 +1,25 @@
+# The `[]` operator (in rvalue, nested)
+
+## Returns correct result when used in a nested expression
+
+### Juttle
+
+    const c = [ 1, [ 4, [ 7, 8, 9 ], 6, ], 3 ];
+
+    emit -from :0: -limit 1 | put result = c[1][1][1] | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: 8 }
+
+## Produces an error when an element in the middle of the chain is missing
+
+### Juttle
+
+    const c = [ 1, [ 4, [ 7, 8, 9 ], 6, ], 3 ];
+
+    emit -from :0: -limit 1 | put result = c[1][3][1] | view result
+
+### Errors
+
+  * RuntimeError: Invalid operand types for "[]": null and number (1).


### PR DESCRIPTION
Just to make sure this situation is covered.

Part of work on #419.