### PR TITLE
Generalize assignment LHS handling

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -554,7 +554,7 @@ class Build extends CodeGenerator {
             case 'MemberExpression':
                 return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return node.symbol.uname;
+                return this.gen_Variable(node, { lhs: true });
             case 'Field':
                 return this.gen_Field(node, { lhs: true });
             default:

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -550,13 +550,13 @@ class Build extends CodeGenerator {
     gen_assignment_lhs(node) {
         switch (node.type) {
             case 'UnaryExpression':
-                return this.gen_UnaryExpression(node);
+                return this.gen_UnaryExpression(node, { lhs: true });
             case 'MemberExpression':
                 return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
                 return node.symbol.uname;
             case 'Field':
-                return this.gen_Field(node);
+                return this.gen_Field(node, { lhs: true });
             default:
                 throw new Error('unrecognized expression lhs ' + node.type);
         }

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -583,7 +583,9 @@ class Build extends CodeGenerator {
         });
         return node;
     }
-    gen_expr(node) {
+    gen_expr(node, opts) {
+        opts = opts || {};
+
         switch (node.type) {
             case 'AssignmentExpression':
             case 'CallExpression':
@@ -610,10 +612,8 @@ class Build extends CodeGenerator {
             case 'PostfixExpression':
             case 'MomentLiteral':
             case 'DurationLiteral':
-                return this['gen_' + node.type](node);
-
             case 'MemberExpression':
-                return this.gen_MemberExpression(node, {});
+                return this['gen_' + node.type](node, opts);
 
             default:
                 throw new Error('unrecognized expression type ' + node.type);

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -413,7 +413,7 @@ class Build extends CodeGenerator {
         this.emit(this.gen_expr(node.expression) + ';\n');
     }
     gen_AssignmentExpression(node) {
-        var code = this.gen_assignment_lhs(node.left);
+        var code = this.gen_expr(node.left, { lhs: true });
         code += ' ' + node.operator + ' ';
         code += this.gen_expr(node.right);
         return code;
@@ -546,20 +546,6 @@ class Build extends CodeGenerator {
 
         code += 'builder.set_const("' + uname + '",' + uname + ');\n';
         this.emit( code);
-    }
-    gen_assignment_lhs(node) {
-        switch (node.type) {
-            case 'UnaryExpression':
-                return this.gen_UnaryExpression(node, { lhs: true });
-            case 'MemberExpression':
-                return this.gen_MemberExpression(node, { lhs: true });
-            case 'Variable':
-                return this.gen_Variable(node, { lhs: true });
-            case 'Field':
-                return this.gen_Field(node, { lhs: true });
-            default:
-                throw new Error('unrecognized expression lhs ' + node.type);
-        }
     }
 
     //

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -551,7 +551,7 @@ class GraphCompiler extends CodeGenerator {
             case 'MemberExpression':
                 return this.gen_MemberExpression(node, { lhs: true });
             case 'Variable':
-                return node.symbol.uname;
+                return this.gen_Variable(node, { lhs: true });
             case 'Field':
                 return this.gen_Field(node, { lhs: true });
             default:

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -559,7 +559,8 @@ class GraphCompiler extends CodeGenerator {
         }
     }
 
-    gen_expr(node) {
+    gen_expr(node, opts) {
+        opts = opts || {};
 
         switch (node.type) {
             case 'AssignmentExpression':
@@ -583,16 +584,10 @@ class GraphCompiler extends CodeGenerator {
             case 'PostfixExpression':
             case 'MomentLiteral':
             case 'DurationLiteral':
-                return this['gen_' + node.type](node);
-
             case 'Field':
-                return this.gen_Field(node, {});
-
             case 'UnaryExpression':
-                return this.gen_UnaryExpression(node, {});
-
             case 'MemberExpression':
-                return this.gen_MemberExpression(node, {});
+                return this['gen_' + node.type](node, opts);
 
             default:
                 throw new Error('unrecognized expression type ' + node.type +

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -372,7 +372,7 @@ class GraphCompiler extends CodeGenerator {
         this.emit(this.gen_expr(node.expression) + ';\n');
     }
     gen_AssignmentExpression(node) {
-        var code = this.gen_assignment_lhs(node.left);
+        var code = this.gen_expr(node.left, { lhs: true });
         code += ' ' + node.operator + ' ';
         code += this.gen_expr(node.right);
         return code;
@@ -543,20 +543,6 @@ class GraphCompiler extends CodeGenerator {
     }
     gen_PutProc(node) {
         return this.gen_ReifierProc(node, 'put');
-    }
-    gen_assignment_lhs(node) {
-        switch (node.type) {
-            case 'UnaryExpression':
-                return this.gen_UnaryExpression(node, { lhs: true });
-            case 'MemberExpression':
-                return this.gen_MemberExpression(node, { lhs: true });
-            case 'Variable':
-                return this.gen_Variable(node, { lhs: true });
-            case 'Field':
-                return this.gen_Field(node, { lhs: true });
-            default:
-                throw new Error('unrecognized expression lhs ' + node.type);
-        }
     }
 
     gen_expr(node, opts) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -57,7 +57,6 @@ class SemanticPass {
 
         this.context = 'build';
         this.coercion_mode = 'none';
-        this.lhs = false;
         this.expr_mode = 'result';
         this.reducers = null;
         this.index = null;
@@ -323,15 +322,6 @@ class SemanticPass {
             fn();
         } finally {
             this.coercion_mode = saved_coercion_mode;
-        }
-    }
-    with_lhs(lhs, fn) {
-        var saved_lhs = this.lhs;
-        this.lhs = lhs;
-        try {
-            fn();
-        } finally {
-            this.lhs = saved_lhs;
         }
     }
     with_expr_mode(expr_mode, fn) {
@@ -784,10 +774,10 @@ class SemanticPass {
         this.sa_expr(node.expression);
     }
     sa_AssignmentExpression(node) {
+        this.with_expr_mode('assign', () => {
+            this.sa_assignment_lhs(node.left);
+        });
         this.with_expr_mode('result', () => {
-            this.with_lhs(true, () => {
-                this.sa_assignment_lhs(node.left);
-            });
             this.sa_expr(node.right);
         });
         node.d = node.left.d && node.right.d;
@@ -1219,10 +1209,8 @@ class SemanticPass {
             case 'MemberExpression':
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
-                this.with_lhs(true, () => {
-                    this.with_expr_mode('result', () => {
-                        this.sa_expr(node.expression);
-                    });
+                this.with_expr_mode('assign', () => {
+                    this.sa_expr(node.expression);
                 });
                 if (!this.scope.is_mutable(name, this.scope.type)) {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
@@ -1272,10 +1260,8 @@ class SemanticPass {
 
         switch (op) {
             case '*':
-                this.with_lhs(false, () => {
-                    this.with_expr_mode('result', () => {
-                        this.sa_expr(node.argument);
-                    });
+                this.with_expr_mode('result', () => {
+                    this.sa_expr(node.argument);
                 });
                 if (this.context !== 'put' && this.context !== 'reduce' && this.context !== 'filter') {
                     throw errors.compileError('INVALID-FIELD-REFERENCE', {
@@ -1287,10 +1273,8 @@ class SemanticPass {
 
             case '++':
             case '--':
-                this.with_lhs(true, () => {
-                    this.with_expr_mode('result', () => {
-                        this.sa_expr(node.argument);
-                    });
+                this.with_expr_mode('assign', () => {
+                    this.sa_expr(node.argument);
                 });
                 name = node.argument.type === 'Variable' ?
                     node.argument.name : node.argument.object.name;
@@ -1440,7 +1424,7 @@ class SemanticPass {
             this.sa_expr(node.property);
         });
 
-        if (this.lhs) {
+        if (this.expr_mode === 'assign') {
             if (!node.computed) {
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1209,7 +1209,7 @@ class SemanticPass {
             case 'MemberExpression':
                 name = node.expression.type === 'Variable' ?
                    node.expression.name : node.expression.object.name;
-                this.with_expr_mode('assign', () => {
+                this.with_expr_mode('update', () => {
                     this.sa_expr(node.expression);
                 });
                 if (!this.scope.is_mutable(name, this.scope.type)) {
@@ -1273,7 +1273,7 @@ class SemanticPass {
 
             case '++':
             case '--':
-                this.with_expr_mode('assign', () => {
+                this.with_expr_mode('update', () => {
                     this.sa_expr(node.argument);
                 });
                 name = node.argument.type === 'Variable' ?
@@ -1424,7 +1424,7 @@ class SemanticPass {
             this.sa_expr(node.property);
         });
 
-        if (this.expr_mode === 'assign') {
+        if (this.expr_mode === 'assign' || this.expr_mode === 'update') {
             if (!node.computed) {
                 symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
                 if (symbol === undefined) {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1128,18 +1128,6 @@ class SemanticPass {
                 break;
 
             case 'Variable':
-                if (!this.scope.lookup_variable(node.name)) {
-                    throw errors.compileError('UNDEFINED-VARIABLE', {
-                        name: node.name,
-                        location: node.location
-                    });
-                }
-                if (!this.scope.is_mutable(node.name, this.scope.type)) {
-                    throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
-                        name: node.name,
-                        location: node.location
-                    });
-                }
                 this.sa_Variable(node);
                 break;
 
@@ -1148,12 +1136,6 @@ class SemanticPass {
                 break;
 
             case 'MemberExpression':
-                if (!this.scope.is_mutable(node.object.name, this.scope.type)) {
-                    throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
-                        name: node.object.name,
-                        location: node.location
-                    });
-                }
                 this.sa_MemberExpression(node);
                 break;
 
@@ -1366,6 +1348,21 @@ class SemanticPass {
     sa_Variable(node) {
         var symbol;
 
+        if (this.expr_mode === 'assign') {
+            if (!this.scope.lookup_variable(node.name)) {
+                throw errors.compileError('UNDEFINED-VARIABLE', {
+                    name: node.name,
+                    location: node.location
+                });
+            }
+            if (!this.scope.is_mutable(node.name, this.scope.type)) {
+                throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
+                    name: node.name,
+                    location: node.location
+                });
+            }
+        }
+
         if (this.expr_mode === 'call') {
             // XXX(dmajda): Remove the fake built-in reducer symbol entries hack.
             symbol = is_builtin_reducer(node.name)
@@ -1416,6 +1413,15 @@ class SemanticPass {
     }
     sa_MemberExpression(node) {
         var symbol;
+
+        if (this.expr_mode === 'assign') {
+            if (!this.scope.is_mutable(node.object.name, this.scope.type)) {
+                throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
+                    name: node.object.name,
+                    location: node.location
+                });
+            }
+        }
 
         this.with_expr_mode('member', () => {
             this.sa_expr(node.object);

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -775,7 +775,7 @@ class SemanticPass {
     }
     sa_AssignmentExpression(node) {
         this.with_expr_mode('assign', () => {
-            this.sa_assignment_lhs(node.left);
+            this.sa_expr(node.left);
         });
         this.with_expr_mode('result', () => {
             this.sa_expr(node.right);
@@ -1118,29 +1118,6 @@ class SemanticPass {
                 name: this.function_name(node.op),
                 location: node.location
             });
-        }
-    }
-
-    sa_assignment_lhs(node) {
-        switch (node.type) {
-            case 'UnaryExpression':
-                this.sa_UnaryExpression(node);
-                break;
-
-            case 'Variable':
-                this.sa_Variable(node);
-                break;
-
-            case 'Field':
-                this.sa_Field(node);
-                break;
-
-            case 'MemberExpression':
-                this.sa_MemberExpression(node);
-                break;
-
-            default:
-                throw new Error('unrecognized expression lhs ' + node.type);
         }
     }
 


### PR DESCRIPTION
Assignment LHS was handled specially both in the semantic pass and in later compiler stages. This was  bad design which was largely unnecessary with the current compiler structure. This PR removes all traces of this special handling and makes it so that assignments are handled mostly like all other expressions.

Part of work on #419.