### PR TITLE
pace.js - remove decelerate towards realtime rate feature

### DIFF
--- a/lib/runtime/procs/pace.js
+++ b/lib/runtime/procs/pace.js
@@ -49,9 +49,7 @@ class pace extends fanin {
         this.wakeup_timer = null;
         // true if we have received a mark
         this.batched = false;
-        // first timestamp received
-        this.data_t0 = null;
-        // from - data_t0
+        // from - first timestamp received
         this.offset = null;
         // true if we have received eof
         this.has_eof = false;
@@ -71,9 +69,6 @@ class pace extends fanin {
         clearTimeout(this.wakeup_timer);
     }
     offset_time(time) {
-        if (!this.data_t0) {
-            this.data_t0 = time;
-        }
         if (this.from && !this.offset && time) {
             // offset is based on the first timestamp we see.
             this.offset = this.from.subtract(time) ;
@@ -185,13 +180,6 @@ class pace extends fanin {
                 var q1 = this.q[1][0];
                 var delta = q1.time.subtract(q0.time);
                 var interval = (this.every) ? this.every : delta.divide(this.x);
-                if (this.has_realtime) {
-                    // decelerate towards a realtime rate as time gets real
-                    var then = this.program.now;
-                    var u = q1.time.subtract(this.data_t0).divide(then.subtract(this.data_t0));
-                    u = Math.min(u, 1) ; // u  === 0 at data_t0, 1 at program.now
-                    interval = interval.subtract(delta).multiply(Math.pow(1 - u, 1/4)).add(delta);
-                }
                 this.last_t = this.last_t.add(interval);
                 var timeout = this.last_t.unixms() - Date.now();
                 this.timer = setTimeout(this.playback, timeout);


### PR DESCRIPTION
This was used in Jut 1.0 times and is not that relevant anymore.

As the logic is complex, the behavior unintuitive (and there is also a
bug with unitialized `data_t0` when `-from` is not passed), drop the
feature.

Fix: #608