### PR TITLE
shell adapter

### DIFF
--- a/lib/adapters/parsers/grok.js
+++ b/lib/adapters/parsers/grok.js
@@ -48,7 +48,7 @@ class GrokParser extends base {
                     input: stream,
                     terminal: false
                 });
-
+                
                 liner.on('line', function(line) {
                     currentPromise = currentPromise.then(function() {
                         return parse(line)

--- a/lib/adapters/shell/index.js
+++ b/lib/adapters/shell/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(config, Juttle) {
+    return {
+        name: 'shell',
+        read: require('./read'),
+        write: require('./write'),
+        optimizer: require('./optimize')
+    };
+};

--- a/lib/adapters/shell/optimize.js
+++ b/lib/adapters/shell/optimize.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var optimizer = {
+    optimize_head: function(read, head, graph, optimization_info) {
+        var limit = graph.node_get_option(head, 'arg');
+
+        if (optimization_info.hasOwnProperty('limit')) {
+            limit = Math.min(limit, optimization_info.limit);
+        }
+
+        optimization_info.type = 'head';
+        optimization_info.limit = limit;
+        return true;
+    }
+};
+
+module.exports = optimizer;
+

--- a/lib/adapters/shell/read.js
+++ b/lib/adapters/shell/read.js
@@ -1,0 +1,191 @@
+'use strict';
+/* eslint-env node */
+var _ = require('underscore');
+var AdapterRead = require('../adapter-read');
+var JuttleMoment = require('../../runtime/types/juttle-moment');
+var spawn = require('child_process').spawn;
+var parsers = require('../parsers');
+var errors = require('../../errors');
+
+var MemoryStream = require('memorystream');
+
+class Iterator {
+    constructor(adapter, from, to) {
+        this.logger = adapter.logger;
+
+        var stream = adapter.spawnChild();
+        this.adapter = adapter;
+        this.buffer = [];
+        this.eof = false;
+        this.error = null;
+        this.pending = null;
+
+        adapter.parser.parseStream(stream, (points) => {
+            points = adapter.parseTime(points, { timeField: adapter.timeField });
+            points = adapter.filterPoints(points, from, to);
+
+            this.logger.debug('parsed', points.length, 'points');
+            this.buffer = this.buffer.concat(points);
+
+            // go back to the event loop once before notifying out a response to
+            // avoid returning from read once for the last batch of points and
+            // then again once the parser promise resolves
+            setTimeout(() => { this.notify(); }, 0);
+        })
+        .then(() => {
+            this.eof = true;
+            this.notify();
+        })
+        .catch((err) => {
+            this.error = err;
+            this.notify();
+        });
+    }
+
+    read(from, to, limit, state) {
+        return new Promise((resolve, reject) => {
+            this.pending = {
+                resolve, reject
+            };
+
+            if (this.error || this.buffer.length !== 0 || this.eof) {
+                this.resolve();
+            }
+        });
+    }
+
+    notify() {
+        if (this.pending) {
+            this.resolve();
+        }
+    }
+
+    resolve() {
+        this.logger.debug('resolve: err:', this.error,
+                          'buffer:', this.buffer.length, 'eof:', this.eof);
+        var pending = this.pending;
+        this.pending = null;
+
+        if (this.error) {
+            pending.reject(this.error);
+        } else {
+            var points = this.buffer;
+            this.buffer = [];
+            pending.resolve({
+                points: points,
+                eof: this.eof,
+                state: this
+            });
+        }
+    }
+}
+
+class ReadShell extends AdapterRead {
+    constructor(options, params) {
+        super(options, params);
+
+        this.timeField = options.timeField;
+
+        this.format = options.format ? options.format : 'json'; // default to json
+        var optimization_info = params && params.optimization_info || {};
+        this.parser = parsers.getParser(this.format, _.extend({
+            optimization: optimization_info
+        }, options));
+
+        this.parser
+        .on('error', (err) => {
+            this.trigger('error', new errors.runtimeError('INTERNAL-ERROR', {
+                error: err.toString()
+            }));
+        });
+
+        if (params.filter_ast) {
+            throw new errors.compileError('ADAPTER-UNSUPPORTED-FILTER', {
+                proc: 'read shell',
+                filter: 'filtering'
+            });
+        }
+
+        this.command = options.command;
+        this.args = options.args || [];
+        this.points = [];
+        this.to = options.to;
+    }
+
+    defaultTimeOptions() {
+        return {
+            from: new JuttleMoment(0),
+            to: new JuttleMoment(Infinity),
+            every: JuttleMoment.duration(5, 's')
+        };
+    }
+
+    periodicLiveRead() { 
+        return true;
+    }
+
+    static allowedOptions() {
+        return AdapterRead.commonOptions().concat([
+            'command',
+            'args',
+            'timeField',
+            'format',
+            'pattern',
+            'separator'
+        ]);
+    }
+    
+    spawnChild() { 
+        // since the spawned process is completely external then we have to 
+        // immediately listen on the stdout otherwise it will start receiving
+        // data before we hook up the event listeners
+        var child = spawn(this.command, this.args);
+        var memStream = new MemoryStream();
+
+        child.stdout.on('data', (data) => {
+            memStream.write(data);
+        });
+        
+        child.stdout.on('end', (data) => {
+            memStream.end(data);
+        });
+
+        child.on('exit', (code, signal) => {
+            if (code !== null && code !== 0) {
+                this.trigger('error', new errors.runtimeError('INTERNAL-ERROR', {
+                    error: `process exited with exit code: ${code}`
+                }));
+            }
+
+            if (signal !== null) { 
+                this.trigger('error', new errors.runtimeError('INTERNAL-ERROR', {
+                    error: `process terminated with singal: ${signal}`
+                }));
+            }
+        });
+
+        return memStream;
+    }
+
+    read(from, to, limit, iterator) {
+        var getIterator = iterator
+            ? Promise.resolve(iterator)
+            : Promise.try(() => { return new Iterator(this, from, to); });
+
+        return getIterator
+        .then((iterator) => {
+            return iterator.read(from, to, limit);
+        })
+        .then((result) => {
+            if (result.eof && this.to !== undefined) { 
+                // force a rerun
+                result.eof = false;
+                result.state = undefined;
+                result.readEnd = to;
+            }
+            return result;
+        });
+    }
+}
+
+module.exports = ReadShell;

--- a/lib/adapters/shell/write.js
+++ b/lib/adapters/shell/write.js
@@ -1,0 +1,37 @@
+'use strict';
+/* eslint-env node */
+var serializers = require('../serializers');
+var AdapterWrite = require('../adapter-write');
+
+class WriteStdio extends AdapterWrite {
+    constructor(options, params) {
+        super(options, params);
+
+        this.format = options.format ? options.format : 'jsonl'; // default to jsonl
+        this.serializer = serializers.getSerializer(this.format, this.getStdout(), {});
+
+        this.serializer
+        .on('error', (err) => {
+            // during write no fatal errors
+            this.trigger('warning', err);
+        });
+    }
+
+    static allowedOptions() {
+        return ['format'];
+    }
+
+    getStdout() {
+        return process.stdout;
+    }
+
+    write(points) {
+        this.serializer.write(points);
+    }
+
+    eof() {
+        return this.serializer.done();
+    }
+}
+
+module.exports = WriteStdio;

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -12,7 +12,7 @@ var Module = require('module');
 var logger = require('../logger').getLogger('juttle-adapter');
 var JuttleAdapterAPI = require('../adapters/api');
 
-var BUILTIN_ADAPTERS = ['file', 'http', 'stdio', 'stochastic', 'http_server'];
+var BUILTIN_ADAPTERS = ['file', 'http', 'stdio', 'stochastic', 'http_server', 'shell'];
 
 var adapters = {};
 var adapterConfig = {};

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -36,7 +36,6 @@ class ViewManager {
 
         var views = self.program.get_views(program);
         views.forEach(function(view) {
-
             var view_class;
             if (_.has(self.view_classes, view.name)) {
                 view_class = self.view_classes[view.name];

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "js-beautify": "^1.5.4",
     "log4js": "^0.6.28",
     "marked": "0.3.3",
+    "memorystream": "^0.3.1",
     "minimist": "1.1.0",
     "moment": "^2.11.1",
     "moment-duration-format": "^1.3.0",


### PR DESCRIPTION
NOT READY FOR MERGE

@juttle/developers opinions requested...

This is merely a prototype to see what others think but I ran into the situation where I wanted to run an external program and then use its output to create a data stream and also had the situation where I wanted that run to be repeated as to create a pseudo live stream with a command line tool. 

The one situation I had was to use my battery charge/discharge information to plot how my battery life was doing over time but then I also found a few more useful situations such as being able to monitor the disk space using `df` of a local system:

```
> ./bin/juttle -e "read shell -command 'df' -format 'columns' | put time = Date.time()"            
┌────────────────────────────────────┬──────────────┬──────────────┬─────────────────────────────────┬─────────────────────┬──────────┬──────────┬──────────────┐
│ time                               │ 1K-blocks    │ Available    │ Filesystem                      │ Mounted             │ on       │ Use%     │ Used         │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 8047872      │ 8047868      │ udev                            │ /dev                │ null     │ 1%       │ 4            │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 1612688      │ 1611284      │ tmpfs                           │ /run                │ null     │ 1%       │ 1404         │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 23899880     │ 15401264     │ /dev/sda2                       │ /                   │ null     │ 33%      │ 7261532      │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 4            │ 4            │ none                            │ /sys/fs/cgroup      │ null     │ 0%       │ 0            │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 5120         │ 5120         │ none                            │ /run/lock           │ null     │ 0%       │ 0            │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 8063432      │ 7957560      │ none                            │ /run/shm            │ null     │ 2%       │ 105872       │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 102400       │ 102372       │ none                            │ /run/user           │ null     │ 1%       │ 28           │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.649Z           │ 192171612    │ 70616748     │ /dev/sda5                       │ /home               │ null     │ 62%      │ 111770032    │
├────────────────────────────────────┼──────────────┼──────────────┼─────────────────────────────────┼─────────────────────┼──────────┼──────────┼──────────────┤
│ 2016-03-16T21:13:38.650Z           │ 192171612    │ 70616748     │ /home/rlgomes/.Private          │ /home/rlgomes       │ null     │ 62%      │ 111770032    │
└────────────────────────────────────┴──────────────┴──────────────┴─────────────────────────────────┴─────────────────────┴──────────┴──────────┴──────────────┘
```
and then if you wanted to keep rerunning at the `-every` interval simply add the `-to :end:` and the program is re-executed every 5s generating new data from the `df` command.

I only implemented the `read` at this point and the write is just copy/pasta but wanted to get feedback on the name `shell` adapter vs any other suggestion and also if we should have differently named arguments ? For example I'm more included to have the user specify a single command line `-command 'df -h /special/mount/point'` than the current approach of `-command 'df' -args ['-h','/special/mount/point']` but only because its easier to write while the `-command`, and `-args` options give more flexibility.

The really nice thing is how the various parsers automatically give us the ability to nicely parse things as I used above the `columns` parser to transform the output of df directly into a point stream.