### PR TITLE
Use instanceOf JuttleError to identify Juttle Errors.

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -43,6 +43,7 @@ var URLResolver = require('../lib/module-resolvers/url-resolver');
 var FileResolver = require('../lib/module-resolvers/file-resolver');
 var resolver_utils = require('../lib/module-resolvers/resolver-utils');
 var compiler = require('../lib/compiler');
+var errors = require('../lib/errors');
 
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
 function usage() {
@@ -219,11 +220,6 @@ function perform_run(options) {
     });
 }
 
-function is_juttle_error(e)
-{
-    return (_.has(e.info, 'location') && _.has(e.info.location, 'start'));
-}
-
 function perform_mode(options)
 {
     if (options.prompt_when_done === undefined) {
@@ -273,15 +269,14 @@ function perform_mode(options)
         // Log the full error object at debug level to get the stack trace
         logger.debug('juttle error:', e, e.stack, Object.keys(e));
 
-        // If the error doesn't have a location, it's not a juttle error. Just re-throw it.
-        if (is_juttle_error(e)) {
-            console.error(CliErrors.show_in_context({
-                err: e,
+        // If it's a juttle error, try to show it in context and go
+        // back to the prompt. Otherwise, re-throw it.
+        if (e instanceof errors.JuttleError) {
+            CliErrors.handle_juttle_error(e, {
                 program: options.juttle_src,
                 modules: modules,
                 filename: options.filename
-            }));
-
+            });
             if (options.prompt_when_done) {
                 cli.prompt(prompt);
             } else {

--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -1,6 +1,11 @@
 'use strict';
+/* eslint no-console: 0 */
 
 var _ = require('underscore');
+
+var error_string = function(e) {
+    return `Error: ${e.message} (${e.code})`;
+};
 
 // Given an error, a corresponding juttle program, and optional
 // filename for that juttle program, return a string that shows the
@@ -51,13 +56,29 @@ var show_in_context = function(options) {
         ret += highlight + '\n';
     }
 
-    ret += 'Error: ' + options.err.message + ' (' + options.err.code + ')\n';
+    ret += error_string(options.err) + '\n';
 
     return ret;
 };
 
+// context should be an object containing:
+// program: the source code for the program
+// modules: the modules for the program
+// filename: the filename of the program
+var handle_juttle_error = function(e, context) {
+    if (_.has(e, 'info') &&
+        _.has(e.info, 'location')) {
+        console.error(show_in_context(_.extend({
+            err: e
+        }, context)));
+    } else {
+        console.error(error_string(e));
+    }
+};
+
 module.exports = {
-    show_in_context: show_in_context
+    show_in_context: show_in_context,
+    handle_juttle_error: handle_juttle_error
 };
 
 


### PR DESCRIPTION
Instead of assuming that any error with a location is a Juttle Error,
use instanceof JuttleError instead.

This means we should only call show_in_context when the error has a
location, and just generically print the error otherwise.

This fixes #563.

@dmajda @rlgomes