### PR TITLE
Rewrite mutability checks in the semantic pass

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -57,24 +57,6 @@ class Scope {
             return undefined;
         }
     }
-    is_mutable(name, context) {
-        var symbol;
-
-        if (this.symbols.hasOwnProperty(name)) {
-            symbol = this.symbols[name];
-
-            switch (symbol.type) {
-                case 'const':
-                    return false;
-                case 'var':
-                    return true;
-            }
-        }
-        if (this.next) {
-            return this.next.is_mutable(name, context);
-        }
-        return undefined;
-    }
     exports() {
         var result = {};
 

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1332,12 +1332,6 @@ class SemanticPass {
                     location: node.location
                 });
             }
-            if (!this.scope.is_mutable(node.name, this.scope.type)) {
-                throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
-                    name: node.name,
-                    location: node.location
-                });
-            }
         }
 
         if (this.expr_mode === 'call') {
@@ -1350,6 +1344,15 @@ class SemanticPass {
         }
 
         if (symbol) {
+            if (this.expr_mode === 'assign') {
+                if (!this.scope.is_mutable(node.name, this.scope.type)) {
+                    throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
+                        name: node.name,
+                        location: node.location
+                    });
+                }
+            }
+
             this.check_symbol(node, symbol);
 
             node.symbol = symbol;

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1171,7 +1171,7 @@ class SemanticPass {
                 this.with_expr_mode('update', () => {
                     this.sa_expr(node.expression);
                 });
-                if (!this.scope.is_mutable(name, this.scope.type)) {
+                if (!node.expression.symbol || node.expression.symbol.type !== 'var') {
                     throw errors.compileError('INVALID-POSTFIX-USE', {
                         operator: node.operator,
                         variable: name,
@@ -1237,7 +1237,7 @@ class SemanticPass {
                 });
                 name = node.argument.type === 'Variable' ?
                     node.argument.name : node.argument.object.name;
-                if (!this.scope.is_mutable(name, this.scope.type)) {
+                if (!node.argument.symbol || node.argument.symbol.type !== 'var') {
                     throw errors.compileError('INVALID-PREFIX-USE', {
                         operator: op,
                         variable: name,
@@ -1345,7 +1345,7 @@ class SemanticPass {
 
         if (symbol) {
             if (this.expr_mode === 'assign') {
-                if (!this.scope.is_mutable(node.name, this.scope.type)) {
+                if (symbol.type !== 'var') {
                     throw errors.compileError('VARIABLE-NOT-ASSIGNABLE', {
                         name: node.name,
                         location: node.location
@@ -1402,7 +1402,7 @@ class SemanticPass {
         });
 
         if (this.expr_mode === 'assign') {
-            if (!this.scope.is_mutable(node.object.name, this.scope.type)) {
+            if (!node.object.symbol || node.object.symbol.type !== 'var') {
                 throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
                     name: node.object.name,
                     location: node.location

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1394,6 +1394,13 @@ class SemanticPass {
     sa_MemberExpression(node) {
         var symbol;
 
+        this.with_expr_mode('member', () => {
+            this.sa_expr(node.object);
+        });
+        this.with_expr_mode('result', () => {
+            this.sa_expr(node.property);
+        });
+
         if (this.expr_mode === 'assign') {
             if (!this.scope.is_mutable(node.object.name, this.scope.type)) {
                 throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
@@ -1402,13 +1409,6 @@ class SemanticPass {
                 });
             }
         }
-
-        this.with_expr_mode('member', () => {
-            this.sa_expr(node.object);
-        });
-        this.with_expr_mode('result', () => {
-            this.sa_expr(node.property);
-        });
 
         if (this.expr_mode === 'assign' || this.expr_mode === 'update') {
             if (!node.computed) {


### PR DESCRIPTION
This PR rewrites mutability checks in the semantic pass as symbol checks. This is the right thing conceptually, it leads to more straightforward code, it avoids repeated symbol lookups, and it paves the path for allowing nested member assignments.

Part of work on #419.