### PR TITLE
Revert reduce every emits marks

### DIFF
--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -97,7 +97,6 @@ class reduce_base extends periodic_fanin {
         if (this.to && this.to.lte(time)) {
             var out = this.advance_epoch(this.to);
             this.emit(out);
-            this.emit_mark({ time: this.to });
         }
         return false;
     }
@@ -318,18 +317,11 @@ class reduce_every extends reduce_base {
         return 'reduce';
     }
     first_epoch(epoch) {
-        // emit initial mark (before any points arrive)
-        this.emit_mark({ time: epoch });
         this.after_first_epoch = true;
     }
     //
     // mark() and process() are from periodic. tick() from reduce_runner_funcs
     //
-
-    other_epoch(epoch) {
-        super.other_epoch(epoch);
-        this.emit_mark({ time: epoch });
-    }
 
     eof(from) {
         // Edge case - 0 points followed immediately by eof. To be consistent
@@ -349,7 +341,6 @@ class reduce_every extends reduce_base {
             // run once more for a trailing partial batch of points
             var out = this.advance_epoch(this.next_epoch);
             this.emit(out);
-            this.emit_mark({ time: this.next_epoch });
         }
         this.emit_eof();
     }

--- a/lib/stdlib/predict.juttle
+++ b/lib/stdlib/predict.juttle
@@ -250,7 +250,6 @@ export sub predict(field = "value", over = :w:, every=null, pct=0.5, nonneg=true
                    detrend=true, deseason=true, denoise=true, revise=true) {
     const __every = every ?? subdivide_duration(over);
     reduce -every __every time= Date.quantize(first(time), __every), *field = percentile(field, pct)
-    | unbatch
     | trend -field field -every __every -over over -revise revise
     | put T = detrend ? T : 0
     | put __detrend = *field  - T

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce-paranoia.spec.md
@@ -16,12 +16,10 @@ resetting in order to replay the correct window of points at each epoch.
     emit -from Date.new(0) -limit 8
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -69,14 +67,12 @@ results are same as group A's plus 10.
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2 ;
-            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2 ;
+        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;
@@ -184,12 +180,10 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     emit -from Date.new(0) -limit 4 -every :4s:
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -259,14 +253,12 @@ a group witness affects reset/teardown, and this is not true in a non-groupby se
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
-            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
+        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;
@@ -421,12 +413,10 @@ ID=last(ID) is a placeholder so that ID appears first in output, for readability
     emit -from Date.new(0) -limit 4 -every :8s:
     | put T = Duration.seconds(time - Date.new(0))
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=2;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) | put ID=3;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) | put ID=5;
@@ -532,14 +522,12 @@ a non-groupby setting.
     | put T = Duration.seconds(time - Date.new(0))
     | ( put name = "A" ; put name = "B", T = T + 10)
     | (
-        (
-            reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
-            reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
-            reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
-            reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
-            reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
-            reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
-        ) | unbatch;
+        reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=1;
+        reduce -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=2;
+        reduce -every :2s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=8 ;
+        reduce -every :2s: -over :4s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=3;
+        reduce -every :2s: -over :4s: -forget false ID=last(ID), a = avg(T), f = first(T) by name | put ID=9;
+        reduce -reset false -every :2s: ID=last(ID), a = avg(T), f = first(T) by name | put ID=4;
         batch :2s:
         | (
             reduce ID=last(ID), a = avg(T), f = first(T) by name | put ID=5;

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -172,24 +172,21 @@ default values of null for when no -every is specified.
     { "min": 1, "time": "1970-01-01T00:00:00.005Z"}
     { "min": 1, "time": "1970-01-01T00:00:00.010Z"}
 
-## reduce -every emits marks at batch boundaries
+## reduce -every ignores upstream batches and does not emit any
 
 ### Juttle
 
     emit  -hz 1000 -from Date.new(0) -limit 6
     | reduce -every :0.002s: a=count()
     | put c=count()
-    | view result -marks true -times true
+    | view result
 
 ### Output
 
     {"mark": true, "time": "1970-01-01T00:00:00.000Z"}
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.002Z"}
-    {"mark": true, "time": "1970-01-01T00:00:00.002Z"}
-    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.004Z"}
-    {"mark": true, "time": "1970-01-01T00:00:00.004Z"}
-    {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.006Z"}
-    {"mark": true, "time": "1970-01-01T00:00:00.006Z"}
+    {"a": 2, "c": 2, "time": "1970-01-01T00:00:00.004Z"}
+    {"a": 2, "c": 3, "time": "1970-01-01T00:00:00.006Z"}
 
 ## batch | reduce emits marks at batch boundaries
 

--- a/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-reduce.spec.md
@@ -183,7 +183,6 @@ default values of null for when no -every is specified.
 
 ### Output
 
-    {"mark": true, "time": "1970-01-01T00:00:00.000Z"}
     {"a": 2, "c": 1, "time": "1970-01-01T00:00:00.002Z"}
     {"a": 2, "c": 2, "time": "1970-01-01T00:00:00.004Z"}
     {"a": 2, "c": 3, "time": "1970-01-01T00:00:00.006Z"}
@@ -469,11 +468,6 @@ default values of null for when no -every is specified.
     { time: "1970-01-01T00:01:00.000Z" }
     { time: "1970-01-01T00:01:02.000Z" }
 
-### Warnings
-
-   * out-of-order assignment of time
-   * out-of-order assignment of time
-
 ## complains about out-of-order points
 
 ### Juttle
@@ -517,10 +511,13 @@ default values of null for when no -every is specified.
 
 ### Warnings
 
-   * out-of-order assignment of time 1969-12-31T23:59:58.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
-   * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
-   * out-of-order assignment of time 1969-12-31T23:59:56.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
-   * out-of-order assignment of time 1969-12-31T23:59:55.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:57.000Z after 1969-12-31T23:59:58.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:56.000Z after 1969-12-31T23:59:58.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:55.000Z after 1969-12-31T23:59:58.000Z, point(s) dropped
+
+### Output
+
+    { "time": "1969-12-31T23:59:58.000Z" }
 
 ## complains about out-of-order assignment to the `time` field in batch mode
 
@@ -543,12 +540,12 @@ default values of null for when no -every is specified.
 
 ### Warnings
 
-   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:01.000Z, point(s) dropped
-   * out-of-order assignment of time 1970-01-01T00:00:00.000Z after 1970-01-01T00:00:02.000Z, point(s) dropped
-   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:03.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
+   * out-of-order assignment of time 1969-12-31T23:59:59.000Z after 1970-01-01T00:00:00.000Z, point(s) dropped
 
 ### Output
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
+    { time: "1970-01-01T00:00:00.000Z", n: 3 }
 
 ## emits grouped results in order when time is assigned
 ### Juttle

--- a/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
+++ b/test/runtime/specs/juttle-spec/reducers/delta-reducer.spec.md
@@ -32,7 +32,6 @@
     | put n = count()
     | filter n < 4 or n > 5
     | reduce -every :0.1s: n = last(n)
-    | unbatch
     | put delta = delta("n", "empty")
     | remove n
     | view result


### PR DESCRIPTION
Revert 'reduce -every emits marks' work. Should fix #594.

Commits which are plain reverts reference the reverted ones, those which had to be updated do not.