### PR TITLE
Make the “[]” operator work properly in lvalues

### DIFF
--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -768,8 +768,11 @@ class Build extends CodeGenerator {
             return node.symbol.uname;
         } else {
             if (opts.lhs) {
-                return this.gen_expr(node.object)
-                    + '[' + this.gen_expr(node.property) + '] = ' + opts.right_code;
+                return 'juttle.ops.set('
+                    + this.gen_expr(node.object) + ','
+                    + this.gen_expr(node.property) + ','
+                    + opts.right_code
+                    + ')';
             } else {
                 return 'juttle.ops.get('
                     + this.gen_expr(node.object) + ','

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -414,7 +414,7 @@ class Build extends CodeGenerator {
     }
     gen_AssignmentExpression(node) {
         var code = this.gen_expr(node.left, { lhs: true });
-        code += ' ' + node.operator + ' ';
+        code += ' = ';
         code += this.gen_expr(node.right);
         return code;
     }

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -413,10 +413,8 @@ class Build extends CodeGenerator {
         this.emit(this.gen_expr(node.expression) + ';\n');
     }
     gen_AssignmentExpression(node) {
-        var code = this.gen_expr(node.left, { lhs: true });
-        code += ' = ';
-        code += this.gen_expr(node.right);
-        return code;
+        var right_code = this.gen_expr(node.right);
+        return this.gen_expr(node.left, { lhs: true, right_code: right_code });
     }
 
     gen_VarStatement(node) {
@@ -748,14 +746,18 @@ class Build extends CodeGenerator {
         code += 'return out;\n})()\n';
         return code;
     }
-    gen_Variable(node) {
-        switch (node.symbol.type) {
-            case 'const':
-                return 'builder.get_const("' + node.symbol.uname + '")';
-            case 'var':
-                return node.symbol.uname;
-            default:
-                throw new Error('Invalid symbol type: ' + node.symbol.type + '.');
+    gen_Variable(node, opts) {
+        if (opts.lhs) {
+            return node.symbol.uname + ' = ' + opts.right_code;
+        } else {
+            switch (node.symbol.type) {
+                case 'const':
+                    return 'builder.get_const("' + node.symbol.uname + '")';
+                case 'var':
+                    return node.symbol.uname;
+                default:
+                    throw new Error('Invalid symbol type: ' + node.symbol.type + '.');
+            }
         }
     }
     gen_Field(node) {
@@ -767,7 +769,7 @@ class Build extends CodeGenerator {
         } else {
             if (opts.lhs) {
                 return this.gen_expr(node.object)
-                    + '[' + this.gen_expr(node.property) + ']';
+                    + '[' + this.gen_expr(node.property) + '] = ' + opts.right_code;
             } else {
                 return 'juttle.ops.get('
                     + this.gen_expr(node.object) + ','

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -689,8 +689,11 @@ class GraphCompiler extends CodeGenerator {
             return node.symbol.uname;
         } else {
             if (opts.lhs) {
-                return this.gen_expr(node.object)
-                    + '[' + this.gen_expr(node.property) + '] = ' + opts.right_code;
+                return 'juttle.ops.set('
+                    + this.gen_expr(node.object) + ','
+                    + this.gen_expr(node.property) + ','
+                    + opts.right_code
+                    + ')';
             } else {
                 return 'juttle.ops.get('
                     + this.gen_expr(node.object) + ','

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -372,10 +372,8 @@ class GraphCompiler extends CodeGenerator {
         this.emit(this.gen_expr(node.expression) + ';\n');
     }
     gen_AssignmentExpression(node) {
-        var code = this.gen_expr(node.left, { lhs: true });
-        code += ' = ';
-        code += this.gen_expr(node.right);
-        return code;
+        var right_code = this.gen_expr(node.right);
+        return this.gen_expr(node.left, { lhs: true, right_code: right_code });
     }
 
     gen_VarStatement(node) {
@@ -624,7 +622,7 @@ class GraphCompiler extends CodeGenerator {
         switch (op) {
             case '*':
                 if (opts.lhs) {
-                    return 'pt[' + expr + ']';
+                    return 'pt[' + expr + '] = ' + opts.right_code;
                 } else {
                     return 'juttle.ops.pget(pt,' + expr + ')';
                 }
@@ -671,13 +669,17 @@ class GraphCompiler extends CodeGenerator {
             + this.gen_expr(node.alternate) + '):('
             + this.gen_expr(node.consequent) + '))';
     }
-    gen_Variable(node) {
-        return node.symbol.uname;
+    gen_Variable(node, opts) {
+        if (opts.lhs) {
+            return node.symbol.uname + ' = ' + opts.right_code;
+        } else {
+            return node.symbol.uname;
+        }
     }
     gen_Field(node, opts) {
         var name = JSON.stringify(node.name);
         if (opts.lhs) {
-            return 'pt[' + name + ']';
+            return 'pt[' + name + '] = ' + opts.right_code;
         } else {
             return 'juttle.ops.pget(pt,' + name + ')';
         }
@@ -688,7 +690,7 @@ class GraphCompiler extends CodeGenerator {
         } else {
             if (opts.lhs) {
                 return this.gen_expr(node.object)
-                    + '[' + this.gen_expr(node.property) + ']';
+                    + '[' + this.gen_expr(node.property) + '] = ' + opts.right_code;
             } else {
                 return 'juttle.ops.get('
                     + this.gen_expr(node.object) + ','

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -373,7 +373,7 @@ class GraphCompiler extends CodeGenerator {
     }
     gen_AssignmentExpression(node) {
         var code = this.gen_expr(node.left, { lhs: true });
-        code += ' ' + node.operator + ' ';
+        code += ' = ';
         code += this.gen_expr(node.right);
         return code;
     }

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1416,7 +1416,7 @@ class SemanticPass {
         });
 
         if (this.expr_mode === 'assign') {
-            if (!node.object.symbol || node.object.symbol.type !== 'var') {
+            if (node.object.symbol && node.object.symbol.type !== 'var') {
                 throw errors.compileError('VARIABLE-NOT-MODIFIABLE', {
                     name: node.object.name,
                     location: node.location

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -9,6 +9,7 @@
 //   node with resolved names
 
 var _ = require('underscore');
+var clone = require('clone');
 var Scope = require('./scope').Scope;
 var reset_scope = require('./scope').reset;
 var StaticInputDetector = require('./static-input-detector');
@@ -774,6 +775,19 @@ class SemanticPass {
         this.sa_expr(node.expression);
     }
     sa_AssignmentExpression(node) {
+        // Desugar expression like "a += 5" to "a = a + 5". This simplifies
+        // later compiler stages as they need to handle only "=".
+        if (node.operator !== '=') {
+            node.right = {
+                type: 'BinaryExpression',
+                operator: node.operator.slice(0, -1),
+                left: clone(node.left),
+                right: node.right,
+                location: node.location
+            };
+            node.operator = '=';
+        }
+
         this.with_expr_mode('assign', () => {
             this.sa_expr(node.left);
         });

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -124,5 +124,6 @@
   "INVALID-OPTION-COMBINATION": "option {option} can only be used with {rule}",
   "FILTER-FEATURE-NOT-SUPPORTED": "Filters do not support {feature} in this context.",
   "HTTP-ERROR": "HTTP request failed with {status}: {message}",
-  "CANNOT-FILTER-ON-TIME": "Cannot filter on \"time\" in read. Use -to, -from, or -last instead."
+  "CANNOT-FILTER-ON-TIME": "Cannot filter on \"time\" in read. Use -to, -from, or -last instead.",
+  "INDEX-OUT-OF-BOUNDS": "Index out of bounds: {index}."
 }

--- a/lib/runtime/errors.js
+++ b/lib/runtime/errors.js
@@ -31,9 +31,9 @@ var errors = {
         return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
     },
 
-    typeErrorGet: function(value, index) {
+    typeErrorGet: function(object, index) {
         var message = 'Invalid operand types for "[]": '
-            + values.typeDisplayName(values.typeOf(value)) + valueString(value)
+            + values.typeDisplayName(values.typeOf(object)) + valueString(object)
             + ' and '
             + values.typeDisplayName(values.typeOf(index)) + valueString(index) + '.';
 

--- a/lib/runtime/errors.js
+++ b/lib/runtime/errors.js
@@ -31,7 +31,7 @@ var errors = {
         return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
     },
 
-    typeErrorGet: function(object, index) {
+    typeErrorGetSet: function(object, index) {
         var message = 'Invalid operand types for "[]": '
             + values.typeDisplayName(values.typeOf(object)) + valueString(object)
             + ' and '

--- a/lib/runtime/ops.js
+++ b/lib/runtime/ops.js
@@ -288,6 +288,10 @@ var ops = {
         }
     },
 
+    set: function(object, index, value) {
+        return object[index] = value;
+    },
+
     pget: function(point, index) {
         return doGet(point, index);
     },

--- a/lib/runtime/ops.js
+++ b/lib/runtime/ops.js
@@ -9,9 +9,9 @@ var JuttleMoment = require('../runtime/types/juttle-moment');
 var values = require('./values');
 
 
-function doGet(value, index) {
-    if (Object.prototype.hasOwnProperty.call(value, index)) {
-        return value[index];
+function doGet(object, index) {
+    if (Object.prototype.hasOwnProperty.call(object, index)) {
+        return object[index];
     } else {
         return null;
     }
@@ -276,15 +276,15 @@ var ops = {
         return !values.isNull(left) ? left : right;
     },
 
-    get: function(value, index) {
-        if (values.isString(value) && values.isNumber(index)) {
-            return doGet(value, index);
-        } else if (values.isArray(value) && values.isNumber(index)) {
-            return doGet(value, index);
-        } else if (values.isObject(value) && values.isString(index)) {
-            return doGet(value, index);
+    get: function(object, index) {
+        if (values.isString(object) && values.isNumber(index)) {
+            return doGet(object, index);
+        } else if (values.isArray(object) && values.isNumber(index)) {
+            return doGet(object, index);
+        } else if (values.isObject(object) && values.isString(index)) {
+            return doGet(object, index);
         } else {
-            throw errors.typeErrorGet(value, index);
+            throw errors.typeErrorGet(object, index);
         }
     },
 

--- a/lib/runtime/ops.js
+++ b/lib/runtime/ops.js
@@ -17,6 +17,28 @@ function doGet(object, index) {
     }
 }
 
+function doSetArray(object, index, value) {
+    if (index < 0) {
+        throw juttleErrors.runtimeError('INDEX-OUT-OF-BOUNDS', {
+            index: index
+        });
+    }
+
+    // Fill-in any potential elements between the end of the array and the set
+    // element with "null"s (otherwise JavaScript would set them to "undefined",
+    // which is not a valid Juttle value).
+    for (let i = object.length; i < index; i++) {
+        object[i] = null;
+    }
+
+    return object[index] = value;
+
+}
+
+function doSetObject(object, index, value) {
+    return object[index] = value;
+}
+
 var ops = {
     str: function(value) {
         return values.toString(value);
@@ -284,12 +306,18 @@ var ops = {
         } else if (values.isObject(object) && values.isString(index)) {
             return doGet(object, index);
         } else {
-            throw errors.typeErrorGet(object, index);
+            throw errors.typeErrorGetSet(object, index);
         }
     },
 
     set: function(object, index, value) {
-        return object[index] = value;
+        if (values.isArray(object) && values.isNumber(index)) {
+            return doSetArray(object, index, value);
+        } else if (values.isObject(object) && values.isString(index)) {
+            return doSetObject(object, index, value);
+        } else {
+            throw errors.typeErrorGetSet(object, index);
+        }
     },
 
     pget: function(point, index) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bluebird": "^2.9.30",
     "cli-table": "^0.3.1",
     "cline": "^0.8.2",
+    "clone": "^1.0.2",
     "content-type": "^1.0.1",
     "csv-write-stream": "^1.0.0",
     "double-ended-queue": "^0.9.7",

--- a/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-entities.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-entities.spec.md
@@ -1,0 +1,117 @@
+# The `[]` operator (in lvalue, on entities)
+
+## Assigns correctly when used on a variable
+
+### Juttle
+
+    function f() {
+      var v = [ 1, 2, 3 ];
+      v[1] = 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: [ 1, 5, 3 ] }
+
+## (Skip) Assigns correctly when used on a point field
+
+### Juttle
+
+    emit -from :0: -limit 1 | put f = [ 1, 2, 3 ] | put f[1] = 5 | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", f: [ 1, 5, 3 ] }
+
+## Produces an error when used on a constant
+
+### Juttle
+
+    function f() {
+      const c = [ 1, 2, 3 ];
+      c[1] = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "c" cannot be modified
+
+## Produces an error when used on a function
+
+### Juttle
+
+    function f() {
+      function g() {
+      }
+
+      g[1] = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "g" cannot be modified
+
+## Produces an error when used on a reducer
+
+### Juttle
+
+    reducer r() {
+      function update() { }
+      function result() { }
+    }
+
+    function f() {
+      r[1] = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "r" cannot be modified
+
+## Produces an error when used on a subgraph
+
+### Juttle
+
+    sub s() {
+      pass
+    }
+
+    function f() {
+      s[1] = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "s" cannot be modified
+
+## Produces an error when used on a module
+
+### Module `m`
+
+    export const c = 5;
+
+### Juttle
+
+    import 'm' as m;
+
+    function f() {
+      m[1] = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "m" cannot be modified

--- a/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-nested.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-nested.spec.md
@@ -1,0 +1,35 @@
+# The `[]` operator (in lvalue, nested)
+
+## Assigns correctly result when used in a nested expression
+
+### Juttle
+
+    function f() {
+      var v = [ 1, [ 4, [ 7, 8, 9 ], 6 ], 3 ];
+      v[1][1][1] = 11;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: [ 1, [ 4, [ 7, 11, 9 ], 6 ], 3 ] }
+
+## Produces an error when an element in the middle of the chain is missing
+
+### Juttle
+
+    function f() {
+      var v = [ 1, [ 4, [ 7, 8, 9 ], 6 ], 3 ];
+      v[1][3][1] = 11;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": null and number (1).

--- a/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-values.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-values.spec.md
@@ -1,0 +1,163 @@
+# The `[]` operator (in lvalue, on values)
+
+## Assigns correctly when used on an `Array` with a `Number` index
+
+### Juttle
+
+    function in1() {
+      var v = [1, 2, 3];
+      v[0] = 4;
+
+      return v;
+    }
+
+    function in2() {
+      var v = [1, 2, 3];
+      v[1] = 5;
+
+      return v;
+    }
+
+    function in3() {
+      var v = [1, 2, 3];
+      v[2] = 6;
+
+      return v;
+    }
+
+    function out1() {
+      var v = [1, 2, 3];
+      v[3] = 4;
+
+      return v;
+    }
+
+    function out2() {
+      var v = [1, 2, 3];
+      v[4] = 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1
+    | put in1 = in1()
+    | put in2 = in2()
+    | put in3 = in3()
+    | put out1 = out1()
+    | put out2 = out2()
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", in1: [ 4, 2, 3 ], in2: [ 1, 5, 3 ], in3: [ 1, 2, 6 ], out1: [1, 2, 3, 4], out2: [1, 2, 3, null, 5] }
+
+## Produces an error when used on an `Array` with a negative index
+
+### Juttle
+
+    function f() {
+      var v = [ 1, 2, 3 ];
+      v[-1] = 5;
+    }
+
+    emit -from :0: -limit 1
+    | put result = f()
+    | view result
+
+### Warnings
+
+  * Index out of bounds: -1.
+
+## Produces an error when used on an `Array` with an index of invalid type
+
+### Juttle
+
+    function f() {
+      var v = [ 1, 2, 3 ];
+      v[null] = 5;
+    }
+
+    emit -from :0: -limit 1
+    | put result = f()
+    | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": array ([ 1, 2, 3 ]) and null.
+
+## Assigns correctly when used on an `Object` with a `String` index
+
+### Juttle
+
+    function in1() {
+      var v = { a: 1, b: 2, c: 3 };
+      v['a'] = 4;
+
+      return v;
+    }
+
+    function in2() {
+      var v = { a: 1, b: 2, c: 3 };
+      v['b'] = 5;
+
+      return v;
+    }
+
+    function in3() {
+      var v = { a: 1, b: 2, c: 3 };
+      v['c'] = 6;
+
+      return v;
+    }
+
+    function out() {
+      var v = { a: 1, b: 2, c: 3 };
+      v['d'] = 4;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1
+    | put in1 = in1()
+    | put in2 = in2()
+    | put in3 = in3()
+    | put out = out()
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", in1: { a: 4, b: 2, c: 3 }, in2: { a: 1, b: 5, c: 3 }, in3: { a: 1, b: 2, c: 6 }, out: { a: 1, b: 2, c: 3, d: 4 } }
+
+## Produces an error when used on an `Object` with an index of invalid type
+
+### Juttle
+
+    function f() {
+      var v = { a: 1, b: 2, c: 3 };
+      v[null] = 5;
+    }
+
+    emit -from :0: -limit 1
+    | put result = f()
+    | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": object ({ a: 1, b: 2, c: 3 }) and null.
+
+## Produces an error when used on a value of invalid type
+
+### Juttle
+
+    function f() {
+      var v = null;
+      v[1] = 5;
+    }
+
+    emit -from :0: -limit 1
+    | put result = f()
+    | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": null and number (1).


### PR DESCRIPTION
After some preparatory work, this PR adds tests that specify behavior of the `[]` operator in lvalues and adjusts the implementation to match. Specifically, it adds missing type checks and allows modification of expressions not associated with a symbol (which enables nested member assignment).
    
Note that member assignment in `put`/`reduce` still isn't allowed. Making it work requires more substantial changes which will be done later.

Part of work on #419.