### PR TITLE
Add adapter modules

### DIFF
--- a/docs/adapters/adapter_api.md
+++ b/docs/adapters/adapter_api.md
@@ -21,6 +21,7 @@ Here are the main steps involved in writing a new adapter:
 1. Create a JavaScript module that can be `require()`d by the juttle runtime.
 2. From that module, export an initialization function to define the read/write capabilities of the adapter.
 3. Implement ES6 classes deriving from AdapterRead/AdapterWrite that perform the work of reading from/writing to the backend data source.
+4. (Optional) Write [juttle modules](../concepts/programming_constructs.md#Modules) that provide useful functionality and include them with the adapter.
 
 We'll go through each of these steps in more detail below.
 
@@ -287,6 +288,25 @@ if (unknown.length > 0) {
         option: unknown[0]
     });
 }
+```
+
+## Adapter Modules
+
+An adapter may also include juttle modules that provide useful functionality for users writing juttle programs. An example of this is the [AWS adapter](https://github.com/juttle/juttle-aws-adapter), which includes modules that provide aggregations of raw data points into demographic and aggregate information.
+
+By convention, all files below the directory `<adapter installation dir>/juttle` are made available to juttle programs. They can be imported using the path `adapters/<adapter name>/<path-to-module-file>`. The path below the root `adapters/<adapter name>` should correspond to the path below `juttle`. Here's an example directory layout:
+
+```juttle-no-syntax-check
+// assuming .../node_modules/juttle-aws-adapter/juttle/aggregations.juttle exists
+
+import 'adapters/aws/aggregations.juttle' as Adapter_aws;
+
+read aws product='EC2'
+| Adapter_aws.aggregate_EC2
+| filter demographic='EC2 Instance Type'
+| keep demographic, name, value
+| view table
+
 ```
 
 ## Additional Resources

--- a/docs/concepts/programming_constructs.md
+++ b/docs/concepts/programming_constructs.md
@@ -173,9 +173,10 @@ examples for details.
 
 System imports load predefined modules from standard
 locations. Examples of system imports are the
-[Juttle Standard Library](./juttle_standard_library.md). For system
-imports, module_path is a path suffix that is combined with one of the
-standard locations to result in a full pathname.
+[Juttle Standard Library](./juttle_standard_library.md) or
+[adapter modules](../adapters/adapter_api.md#Adapter Modules). For
+system imports, module_path is a path suffix that is combined with one
+of the standard locations to result in a full pathname.
 
 For both user and system imports, when referring to files, a `.juttle`
 extension will be added if not present, and when referring to
@@ -304,6 +305,22 @@ import "random" as random;
 emit -limit 3 -from :0:
 | put pure = random.normal(0, 1)
 
+```
+
+_Example: adapter modules_
+
+This example loads the file `aggregations.juttle` from the aws
+adapter. Note the use of the implied `.juttle` extension in the import
+statement.
+
+```juttle-no-syntax-check
+import "adapters/aws/aggregations" as Adapter_aws;
+
+read aws product='EC2'
+| Adapter_aws.aggregate_EC2
+| filter demographic='EC2 Instance Type'
+| keep demographic, name, value
+| view table
 ```
 
 Subgraphs

--- a/lib/adapters/api.js
+++ b/lib/adapters/api.js
@@ -10,7 +10,7 @@ let juttle_utils = require('../runtime/juttle-utils');
 // changes were made to the adapter API.
 //
 let AdapterAPI = {
-    version: '0.5.2',
+    version: '0.5.3',
     AdapterRead: require('./adapter-read'),
     AdapterWrite: require('./adapter-write'),
     compiler: {

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -36,6 +36,23 @@ class FileResolver {
         }
     }
 
+    _read_file(filename, name) {
+
+        if (! this._is_file(filename)) {
+            return false;
+        }
+
+        try {
+            return {
+                source: fs.readFileSync(filename, 'utf8'),
+                name: (name ? name : filename)
+            };
+        }
+        catch (e) {
+            return false;
+        }
+    }
+
     _canonicalize(filename) {
         // If the filename is actually a directory, add a
         // /index.juttle
@@ -78,15 +95,8 @@ class FileResolver {
         // absolute.
         let filename = path.resolve(dir, module_path);
         filename = this._canonicalize(filename);
-        try {
-            return {
-                source: fs.readFileSync(filename, 'utf8'),
-                name: filename
-            };
-        }
-        catch (e) {
-            return false;
-        }
+
+        return this._read_file(filename);
     }
 
     _search_system_import(module_path, module_name, importer_path) {
@@ -99,16 +109,10 @@ class FileResolver {
 
             filename = this._canonicalize(filename);
 
-            if (this._is_file(filename)) {
-                try {
-                    return {
-                        name: module_path,
-                        source: fs.readFileSync(filename, 'utf8')
-                    };
-                }
-                catch (e) {
-                    // continue looking for a module we can successfully load
-                }
+            let module = this._read_file(filename, module_path);
+
+            if (module) {
+                return module;
             }
         }
         return false;

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -1,10 +1,14 @@
 'use strict';
 
 /* eslint-env node */
+var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
 var Promise = require('bluebird');
 var logger = require('../logger').getLogger('file-resolver');
+var adapters = require('../runtime/adapters');
+
+const ADAPTER_MODULE_SUBDIR = 'juttle';
 
 function search_paths() {
     var env = process.env;
@@ -24,6 +28,28 @@ class FileResolver {
 
         this._additional_search_paths = options.search_paths || search_paths();
 
+        // Also add the module root for all adapters.
+        this._adapter_roots = [];
+
+        for (let adapter of adapters.list()) {
+            // Only consider non built-in adapters that were loaded successfully.
+            if (! adapter.builtin && adapter.loaded) {
+                let install_path = this._canonicalize(adapter.path);
+                let module_root = [path.dirname(install_path), ADAPTER_MODULE_SUBDIR].join(path.sep);
+
+                // Only add the entry to adapter_roots if it exists and is a directory.
+                if (fs.existsSync(module_root)) {
+                    let stats = fs.statSync(module_root);
+                    if (stats.isDirectory()) {
+                        this._adapter_roots.push({
+                            adapter: adapter.adapter,
+                            module_root: module_root
+                        });
+                    }
+                }
+            }
+        }
+
         this.resolve = this._resolve.bind(this);
     }
 
@@ -37,7 +63,6 @@ class FileResolver {
     }
 
     _read_file(filename, name) {
-
         if (! this._is_file(filename)) {
             return false;
         }
@@ -99,8 +124,39 @@ class FileResolver {
         return this._read_file(filename);
     }
 
+    _search_adapter_import(module_path, module_name, importer_path) {
+
+        // Remove the top 'adapters' directory
+        let parts = module_path.split('/').slice(1);
+
+        // First see if the module_path matches one of the adapter
+        // roots. If it does, prefix the adapter's module root, drop
+        // the adapter name from the module path, and try to read the
+        // file.
+        let first_subdir = parts.shift();
+
+        let root = _.findWhere(this._adapter_roots, {adapter: first_subdir});
+
+        if (root) {
+            parts.unshift(root.module_root);
+            let filename = this._canonicalize(parts.join(path.sep));
+            let module = this._read_file(filename, module_path);
+            if (module) {
+                return module;
+            }
+        }
+
+        return false;
+    }
+
     _search_system_import(module_path, module_name, importer_path) {
         logger.debug(`searching system module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
+
+        // If the module_path starts with 'adapters' + pathsep, assume
+        // it's an adapter module load.
+        if (module_path.startsWith('adapters/')) {
+            return this._search_adapter_import(module_path, module_name, importer_path);
+        }
 
         var k, paths = this._search_paths;
         paths = paths.concat(this._additional_search_paths);

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -17,16 +17,14 @@ function search_paths() {
 
 class FileResolver {
     constructor(options) {
-        var self = this;
-
         options = options || {};
 
         // stdlib is always available
-        self._search_paths = [path.join(__dirname, '../stdlib/')];
+        this._search_paths = [path.join(__dirname, '../stdlib/')];
 
-        self._additional_search_paths = options.search_paths || search_paths();
+        this._additional_search_paths = options.search_paths || search_paths();
 
-        self.resolve = self._resolve.bind(self);
+        this.resolve = this._resolve.bind(this);
     }
 
     _is_file(module_path) {
@@ -62,8 +60,6 @@ class FileResolver {
     }
 
     _search_local_import(module_path, module_name, importer_path) {
-        var self = this;
-
         logger.debug(`searching local module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
 
         // Resolve module_path relative to importer_path or the
@@ -81,7 +77,7 @@ class FileResolver {
         // Note this won't change module_path if it is already
         // absolute.
         let filename = path.resolve(dir, module_path);
-        filename = self._canonicalize(filename);
+        filename = this._canonicalize(filename);
         try {
             return {
                 source: fs.readFileSync(filename, 'utf8'),
@@ -94,18 +90,16 @@ class FileResolver {
     }
 
     _search_system_import(module_path, module_name, importer_path) {
-        var self = this;
-
         logger.debug(`searching system module_path=${module_path} module_name=${module_name} importer_path=${importer_path}`);
 
-        var k, paths = self._search_paths;
-        paths = paths.concat(self._additional_search_paths);
+        var k, paths = this._search_paths;
+        paths = paths.concat(this._additional_search_paths);
         for (k = 0; k < paths.length; ++k) {
             var filename = paths[k] + '/' + module_path;
 
-            filename = self._canonicalize(filename);
+            filename = this._canonicalize(filename);
 
-            if (self._is_file(filename)) {
+            if (this._is_file(filename)) {
                 try {
                     return {
                         name: module_path,
@@ -121,13 +115,11 @@ class FileResolver {
     }
 
     _resolve(module_path, module_name, importer_path) {
-        var self = this;
-
         var found = false;
-        if (self._is_local_import(module_path)) {
-            found = self._search_local_import(module_path, module_name, importer_path);
+        if (this._is_local_import(module_path)) {
+            found = this._search_local_import(module_path, module_name, importer_path);
         } else {
-            found = self._search_system_import(module_path, module_name, importer_path);
+            found = this._search_system_import(module_path, module_name, importer_path);
         }
         if (found === false) {
             return Promise.reject(new Error('could not find module: ' + module_path));

--- a/lib/runtime/adapters.js
+++ b/lib/runtime/adapters.js
@@ -145,6 +145,7 @@ function list() {
         var version, installPath, moduleName;
 
         var isBuiltin = BUILTIN_ADAPTERS.indexOf(adapter) !== -1;
+        var loaded = true;
         if (isBuiltin) {
             version = juttleVersion;
             installPath = Module._resolveFilename(modulePath, module);
@@ -160,9 +161,10 @@ function list() {
                 installPath = '(unable to load adapter)';
                 version = '(unknown)';
                 moduleName = '(unknown)';
+                loaded = false;
             }
         }
-        adapters.push({adapter: adapter, builtin: isBuiltin, module: moduleName, version: version, path: installPath});
+        adapters.push({adapter: adapter, builtin: isBuiltin, module: moduleName, version: version, path: installPath, loaded: loaded});
     });
     return adapters;
 }

--- a/test/module-resolvers/file-resolver.spec.js
+++ b/test/module-resolvers/file-resolver.spec.js
@@ -2,6 +2,11 @@
 
 var expect = require('chai').expect;
 var path = require('path');
+
+// This loads some test adapters that the tests rely upon. The adapter
+// 'test' does have a module directory, while 'testAdapter' does not.
+var juttle_test_utils = require('../runtime/specs/juttle-test-utils'); //eslint-disable-line
+
 var FileResolver = require('../../lib/module-resolvers/file-resolver');
 
 function resolveWith(module, path, module_name, importer_path) {
@@ -89,4 +94,39 @@ describe('file-resolver', function() {
             expect(result.name).to.equal(`${__dirname}/input/modules1/foo.juttle`);
         });
     });
+
+    it('can resolve by adapter-prefixed path', function() {
+        return resolveWith(`adapters/test/index.juttle`, [], 'main')
+        .then(function(result) {
+            expect(result.name).to.equal('adapters/test/index.juttle');
+        });
+    });
+
+    it('can resolve by adapter-prefixed path with implied index.juttle', function() {
+        return resolveWith(`adapters/test`, [], 'main')
+        .then(function(result) {
+            expect(result.name).to.equal('adapters/test');
+        });
+    });
+
+    it('fails to resolve for adapter that does not not exist', function() {
+        return resolveWith(`adapters/noSuchAdapter/index.juttle`, [], 'main')
+        .then(function() {
+            throw Error('Previous statement should have failed');
+        })
+        .catch(function(err) {
+            expect(err.toString()).to.contain('could not find module: adapters/noSuchAdapter/index.juttle');
+        });
+    });
+
+    it('fails to resolve for adapter that does not have any modules', function() {
+        return resolveWith(`adapters/testTimeseries/index.juttle`, [], 'main')
+        .then(function() {
+            throw Error('Previous statement should have failed');
+        })
+        .catch(function(err) {
+            expect(err.toString()).to.contain('could not find module: adapters/testTimeseries/index.juttle');
+        });
+    });
+
 });

--- a/test/runtime/juttle-module.spec.js
+++ b/test/runtime/juttle-module.spec.js
@@ -32,7 +32,8 @@ describe('Juttle Module Tests', function() {
                 builtin: true,
                 module: '(builtin)',
                 version: version,
-                path: path.resolve(__dirname, '../../lib/adapters/file/index.js')
+                path: path.resolve(__dirname, '../../lib/adapters/file/index.js'),
+                loaded: true
             });
 
             expect(adapterList).to.contain({
@@ -40,7 +41,8 @@ describe('Juttle Module Tests', function() {
                 builtin: false,
                 version: '(unknown)',
                 module: '(unknown)',
-                path: '(unable to load adapter)'
+                path: '(unable to load adapter)',
+                loaded: false
             });
 
             expect(adapterList).to.contain({
@@ -48,7 +50,8 @@ describe('Juttle Module Tests', function() {
                 builtin: false,
                 module: 'test-adapter',
                 version: '0.1.0',
-                path: path.resolve(__dirname, './test-adapter')
+                path: path.resolve(__dirname, './test-adapter'),
+                loaded: true
             });
 
             expect(result.sinks.result).to.deep.equal(adapterList);

--- a/test/runtime/test-adapter/juttle/index.juttle
+++ b/test/runtime/test-adapter/juttle/index.juttle
@@ -1,0 +1,1 @@
+export const val = 10;


### PR DESCRIPTION
This adds support for per-adapter modules.

Should I bump the juttle api version for this? Following semver we'd want it to be 0.6.0, but maybe we could cheat and make it 0.5.3 instead.

After this merges I'll update the aws adapter and adapter template to provide examples.

This fixes #325.

@demmer @dmajda