### PR TITLE
modules: support importing procs from native js modules

### DIFF
--- a/lib/compiler/ast-visitor.js
+++ b/lib/compiler/ast-visitor.js
@@ -95,6 +95,7 @@ var NODE_CHILDREN = {
     ReducerDef:               ['args', 'elements'],
     SubDef:                   ['args', 'elements'],
     ModuleDef:                ['elements'],
+    NativeModuleDef:          [],
     MainModuleDef:            ['elements', 'modules'],
     FormalArg:                ['default']
 };

--- a/lib/compiler/build.js
+++ b/lib/compiler/build.js
@@ -57,7 +57,11 @@ class Build extends CodeGenerator {
         var self = this;
 
         _.each(ast.modules, function(ast) {
-            self.gen_ModuleDef(ast);
+            if (ast.type === 'ModuleDef') {
+                self.gen_ModuleDef(ast);
+            } else if (ast.type === 'NativeModuleDef') {
+                self.gen_NativeModuleDef(ast);
+            }
         } );
 
         this.gen_SubDef(ast, {path_info: {mod: '', sub: []}});
@@ -162,6 +166,23 @@ class Build extends CodeGenerator {
         this.emit(code);
         return node.uname;
     }
+    gen_native_proc_call(node) {
+        var code;
+        var proc = {
+            type: 'NativeModuleProc',
+            module: node.module_uname,
+            name: node.op.property.value,
+            uname: node.uname,
+            options: node.options
+        };
+        proc.pname = {type:'Eval', expr:'builder.alloc_pname()' };
+        code = 'var ' + proc.uname + ' = ';
+        this.build_options(proc);
+        code += this.build_code_ast(proc) + ';';
+        code += 'builder.add_node(' + proc.uname + ');\n';
+        this.emit(code);
+        return proc.uname;
+    }
     build_options(node) {
         var that = this;
         node.options = _.map(node.options, function(option) {
@@ -191,6 +212,7 @@ class Build extends CodeGenerator {
             case 'SequentialGraph':
             case 'ImportStatement':
             case 'ParallelGraph':
+            case 'NativeProcDef':
                 return this['gen_' + node.type](node, opts);
             default:
                 throw new Error('unrecognized statement type ' + node.type);
@@ -203,6 +225,18 @@ class Build extends CodeGenerator {
         // with unames
         //
         var self = this;
+        _.each(node.elements, function(stmt) {
+            self.gen_statement(stmt, {path_info: {mod: node.name, sub: []}});
+        } );
+    }
+    gen_NativeModuleDef(node) {
+        //
+        // just spit out the module elements in the main scope since
+        // the semantic pass flattened out all the module contents
+        // with unames
+        //
+        var self = this;
+        this.emit(`var ${node.uname} = builder.native_module("${node.uname}", "${node.name}", ${JSON.stringify(node.source)});\n`);
         _.each(node.elements, function(stmt) {
             self.gen_statement(stmt, {path_info: {mod: node.name, sub: []}});
         } );
@@ -524,7 +558,13 @@ class Build extends CodeGenerator {
         return this.gen_ReifierProc(node);
     }
     gen_FunctionProc(node) {
-        return this.gen_sub_call(node);
+        if (node.uname_sub) {
+            return this.gen_sub_call(node);
+        } else if (node.uname_proc) {
+            return this.gen_native_proc_call(node);
+        } else {
+            throw new Error('unknown node type ' + node);
+        }
     }
     gen_InputStatement(node, opts) {
         var self = this;

--- a/lib/compiler/graph-builder.js
+++ b/lib/compiler/graph-builder.js
@@ -11,11 +11,11 @@ function proc_name(node) {
 }
 
 function is_source(node) {
-    return node.type !== 'View' && procs[proc_name(node)].info.type === 'source';
+    return node.type !== 'NativeModuleProc' && node.type !== 'View' && procs[proc_name(node)].info.type === 'source';
 }
 
 function is_sink(node) {
-    return node.type === 'View' || procs[proc_name(node)].info.type === 'sink';
+    return node.type !== 'NativeModuleProc' && (node.type === 'View' || procs[proc_name(node)].info.type === 'sink');
 }
 
 function build_pname(index) {
@@ -28,6 +28,7 @@ class GraphBuilder {
         this.inputs = [];
         this.functions = [];
         this.reducers = [];
+        this.native_modules = [];
         this.nproc = 0;
         this.uid = 0;
         this.consts = {};
@@ -63,6 +64,7 @@ class GraphBuilder {
                 inputs: this.inputs,
                 functions: this.functions,
                 reducers: this.reducers,
+                native_modules: this.native_modules,
                 now: this.now,
                 stats: this.stats};
     }
@@ -257,6 +259,9 @@ class GraphBuilder {
         }
 
         return null;
+    }
+    native_module(uname, path, source) {
+        this.native_modules.push({uname: uname, path: path, source: source});
     }
 }
 

--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -56,6 +56,7 @@ class GraphCompiler extends CodeGenerator {
     }
     gen(graph) {
         var code, body, entry;
+        this.gen_nativeModules(graph.native_modules);
         this.gen_functionDefs(graph.functions);
         this.gen_reducerDefs(graph.reducers);
         entry = this.gen_procs(graph.nodes);
@@ -76,6 +77,12 @@ class GraphCompiler extends CodeGenerator {
     }
     emit(s) {
         this.code += s;
+    }
+    gen_nativeModules(modules) {
+        var k;
+        for (k = 0; k < modules.length; ++k) {
+            this.gen_NativeModule(modules[k]);
+        }
     }
     gen_functionDefs(fns) {
         var k;
@@ -109,6 +116,9 @@ class GraphCompiler extends CodeGenerator {
             }
         }
         return srcs;
+    }
+    gen_NativeModule(module) {
+        this.emit('var ' + module.uname + ' = ' + module.source + '(juttle);\n');
     }
     gen_procs(procs) {
         var k, i, first, proc, from, out, shorts, srcs;
@@ -163,6 +173,22 @@ class GraphCompiler extends CodeGenerator {
         // When everything is switched over, gen_proc can
         // take node.name from node and we don't need to pass it as arg
         return this.gen_proc(node, node.name);
+    }
+    gen_NativeModuleProc(node) {
+        var pname = node.pname;
+        var params = {};
+        params.$pname = pname;
+        var soptions = this.gen_options(node.options,
+                                        node.location,
+                                        params);
+        var code = 'var ' + pname + ' = ';
+        code += 'new ' + node.module + '.procs.' + node.name + '('
+            + soptions + ', '
+            + JSON.stringify(node.location) + ', '
+            + 'program'
+            + ');\n';
+        this.emit(code);
+        return pname;
     }
     gen_proc(node, procName, params) {
         var pname = node.pname;
@@ -352,6 +378,7 @@ class GraphCompiler extends CodeGenerator {
             BuiltinProc: this.gen_BuiltinProc,
             SequenceProc: this.gen_SequenceProc,
             FilterProc: this.gen_FilterProc,
+            NativeModuleProc: this.gen_NativeModuleProc,
             PutProc: this.gen_PutProc,
             ReadProc: this.gen_ReadProc,
             ReduceProc: this.gen_ReduceProc,

--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -110,6 +110,12 @@ class Scope {
         this.put(name, symbol);
         return symbol;
     }
+    define_native_proc(name, args, exported) {
+        var runtimeVar = this.alloc_var(name);
+        var symbol = { type: 'native_proc', exported: exported, uname: runtimeVar, args: args };
+        this.put(name, symbol);
+        return symbol;
+    }
     define_func(name, exported, arg_count) {
         var runtimeVar = this.alloc_var(name);
         var symbol = { type: 'function', exported: exported, arg_count: arg_count, uname: runtimeVar };

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -14,6 +14,9 @@ var reset_scope = require('./scope').reset;
 var StaticInputDetector = require('./static-input-detector');
 var errors = require('../errors');
 
+// Needed for native modules
+var runtime = require('../runtime/runtime');
+
 var is_builtin_reducer = require('../runtime/reducers').is_builtin_reducer;
 
 // Rather than do builtin proc analysis in this ad hoc way, we should add builtins
@@ -365,6 +368,15 @@ class SemanticPass {
             return { name: arg.name, required: !arg.default };
         });
     }
+    sa_native_proc_call(node, proc) {
+        node.uname = this.scope.alloc_var();
+        node.uname_proc = proc.uname;
+        node.module_uname = proc.module_uname;
+        node.options = _.map(node.options, (opt) => {
+            this.sa_expr(opt.expr);
+            return {id: opt.id, expr: opt.expr, location: opt.location};
+        });
+    }
     //XXX this one operates in place on the option expressions
     //  does not check params
     // XXX should extend this to check for illegal options
@@ -539,6 +551,17 @@ class SemanticPass {
                 throw new Error('unrecognized statement type ' + node.type);
         }
     }
+    sa_Module(node) {
+        if (node.type === 'ModuleDef') {
+            this.sa_ModuleDef(node);
+        }
+        else if (node.type === 'NativeModuleDef') {
+            this.sa_NativeModuleDef(node);
+        }
+        else {
+            throw new Error('unrecognized node type ' + node.type);
+        }
+    }
     sa_ModuleDef(node) {
         var k, elems = node.elements;
 
@@ -555,6 +578,28 @@ class SemanticPass {
         };
         this.scope = saved_scope;
     }
+    sa_NativeModuleDef(node) {
+        var code = '(function (juttle) {\n' +
+            'var module = {};\n' +
+            node.source + '\n' +
+            'return module.exports; })';
+        var module = eval(code)(runtime);
+        node.source = code;
+        var scope = new Scope(null, 'module');
+        node.elements = [];
+        node.uname = this.scope.alloc_var('module');
+        _.each(module.procs, (code, name) => {
+            this.enter_scope('sub');
+            var symbol = scope.define_native_proc(name, [], true);
+            symbol.module_uname = node.uname;
+            this.exit_scope();
+        });
+
+        this.modules[node.name] = {
+            exports: scope.exports()
+        };
+    }
+
     sa_SubDef(node) {
         var symbol, elems, k, has_graph;
 
@@ -847,7 +892,7 @@ class SemanticPass {
 
         if (module_ast !== undefined) {
             if (!this.modules.hasOwnProperty(modulename)) {
-                this.sa_ModuleDef(module_ast);
+                this.sa_Module(module_ast);
                 this.ordered_module_asts.push(module_ast);
             }
         } else {
@@ -1107,6 +1152,8 @@ class SemanticPass {
             if (node.op.symbol.type === 'sub') {
                 this.stats.subs++;
                 this.sa_sub_call(node, node.op.symbol);
+            } else if (node.op.symbol.type === 'native_proc') {
+                this.sa_native_proc_call(node, node.op.symbol);
             } else {
                 throw errors.compileError('NOT-A-SUB', {
                     name: this.function_name(node.op),

--- a/lib/module-resolvers/file-resolver.js
+++ b/lib/module-resolvers/file-resolver.js
@@ -48,7 +48,7 @@ class FileResolver {
             }
         }
 
-        if (path.extname(filename) !== '.juttle') {
+        if (path.extname(filename) === '') {
             filename = filename + '.juttle';
         }
 
@@ -137,4 +137,3 @@ class FileResolver {
 }
 
 module.exports = FileResolver;
-

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird');
 var _ = require('underscore');
 var errors = require('../errors');
 var parser = require('./parser');
+var path = require('path');
 
 // Parses a Juttle filter expression synchronously. Returns the resulting AST on
 // success, throws `errors.SyntaxError` on failure.
@@ -88,6 +89,16 @@ function parse(juttle, options) {
         // Don't break on cyclic imports and continue. There is a more proper
         // check in the semantic pass.
         if (_.has(asts, module.name)) {
+            return Promise.resolve();
+        }
+
+        // For native modules, stash the source in "asts" and continue.
+        if (path.extname(module.name) === '.js') {
+            asts[module.name] = {
+                type: 'NativeModuleDef',
+                name: module.name,
+                source: module.source
+            };
             return Promise.resolve();
         }
 
@@ -180,6 +191,16 @@ function parseSync(juttle, options) {
             return;
         }
 
+        // For native modules, stash the source in "asts" and continue.
+        if (path.extname(module.name) === '.js') {
+            asts[module.name] = {
+                type: 'NativeModuleDef',
+                name: module.name,
+                source: module.source
+            };
+            return;
+        }
+
         var ast = doParse(module.source, _.extend(options, { filename: module.name }));
         asts[module.name] = ast;
 
@@ -229,6 +250,9 @@ function checkImport(node) {
 
 function buildModuleDefs(asts, mainFilename) {
     return _.map(_.omit(asts, mainFilename), function(ast, name) {
+        if (ast.type === 'NativeModuleDef') {
+            return ast;
+        }
         return { type: 'ModuleDef', name: name, elements: ast.elements };
     });
 }

--- a/test/runtime/juttles/custom.js
+++ b/test/runtime/juttles/custom.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/* global juttle */
+let errors = juttle.errors;
+
+class TrackerProc extends juttle.procs.fanin {
+    procName() {
+        return 'tracker';
+    }
+
+    constructor(options, params, location, program) {
+        super(options, params, location, program);
+        this.seen = 0;
+    }
+
+    consume(points) {
+        this.seen += points.length;
+        super.consume(points);
+    }
+
+    teardown() {
+        this.trigger('warning', errors.runtimeError('INTERNAL-ERROR', {
+            error: 'tracker saw ' + this.seen + ' points'
+        }));
+    }
+}
+
+module.exports = {
+    procs: {
+        tracker: TrackerProc
+    }
+};

--- a/test/runtime/native-modules.spec.js
+++ b/test/runtime/native-modules.spec.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var juttle_test_utils = require('./specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+var expect = require('chai').expect;
+var FileResolver = require('../../lib/module-resolvers/file-resolver');
+
+describe('Native modules ', function() {
+    var file_resolver = new FileResolver();
+    it('can import a proc from a javascript file', function() {
+        return check_juttle({
+            moduleResolver: file_resolver.resolve,
+            program: `import "${__dirname}/juttles/custom.js" as custom; emit -limit 1 -from :2016-01-01: | custom.tracker`,
+        })
+        .then(function(res) {
+            expect(res.sinks.table).deep.equals([{time: '2016-01-01T00:00:00.000Z'}]);
+            expect(res.warnings).deep.equals(['internal error tracker saw 1 points']);
+            expect(res.errors).deep.equals([]);
+        });
+    });
+});


### PR DESCRIPTION
This adds rudimentary support for extending the runtime with procs
implemented in javascript by supporting `import "/path/to/file.js"`
in which the file exports an object containing the proc implementation.

To make this work, the module loader looks at the file extension, and for
.js files it simply inlines the source and returns it.

Then the semantic pass evals the blob of code and puts all the symbols from
the exported `procs` into scope.

The flowgraph builder generates a new type of natice proc call node and also
passes through the native modules so they can be carried through to the
built flowgraph.

Finally, the module source is inlined into the compiled code so it gets
evaluated again as part of the program itself.