### PR TITLE
oops-fanin.js - type check assignments to interval

### DIFF
--- a/lib/messages.json
+++ b/lib/messages.json
@@ -16,6 +16,7 @@
   "POINT-MISSING-TIME": "point is missing a time in {field}",
   "TIMELESS-POINTS": "encountered point(s) without the time field",
   "TYPE-ERROR": "{message}",
+  "VALUE-ERROR": "{message}",
   "NO-FREE-TEXT": "Free text search is not implemented in this context.",
   "ADAPTER-UNSUPPORTED-FILTER": "{filter} is not supported by {proc}.",
   "ADAPTER-UNSUPPORTED-TIME-OPTION": "Unsupported value for {option} option: {message}",

--- a/lib/runtime/errors.js
+++ b/lib/runtime/errors.js
@@ -63,6 +63,20 @@ var errors = {
 
         return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
     },
+
+    typeErrorInterval: function(value) {
+        var message = 'Invalid type assigned to interval: '
+            + values.typeDisplayName(values.typeOf(value)) + valueString(value) + '.';
+
+        return juttleErrors.runtimeError('TYPE-ERROR', { message: message });
+    },
+
+    valueErrorInterval: function(value) {
+        var message = 'Duration assigned to interval must be positive: '
+            + values.typeDisplayName(values.typeOf(value)) + valueString(value) + '.';
+
+        return juttleErrors.runtimeError('VALUE-ERROR', { message: message });
+    },
 };
 
 module.exports = errors;

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -14,6 +14,17 @@ class oops_fanin extends fanin {
         } else {
             this.watch_oops = false;
         }
+        if (params && params.lhs && params.lhs.indexOf('interval') >= 0) {
+            this.watch_intervals = true;
+        } else {
+            this.watch_intervals = false;
+        }
+    }
+    warn_interval(interval) {
+        this.trigger('warning', errors.typeErrorInterval(interval));
+    }
+    warn_interval_value(interval) {
+        this.trigger('warning', errors.valueErrorInterval(interval));
     }
     warn_oops(badTime, goodTime) {
         this.trigger('warning', this.runtime_error('TIME-OUT-OF-ORDER', {
@@ -40,6 +51,25 @@ class oops_fanin extends fanin {
                         continue;
                     } else {
                         this.last_output_time = time;
+                    }
+                }
+                i += 1;
+            }
+        }
+        if (this.watch_intervals) {
+            var i = 0;
+            while (i < points.length) {
+                var interval = points[i].interval;
+                if (interval) {
+                    if (!interval.duration) {
+                        this.warn_interval(interval);
+                        points.splice(i, 1); // drop that point!
+                        continue;
+                    }
+                    if (interval.unixms() <= 0) {
+                        this.warn_interval_value(interval);
+                        points.splice(i, 1); // drop that point!
+                        continue;
                     }
                 }
                 i += 1;

--- a/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-put.spec.md
@@ -64,6 +64,66 @@
     { time: "1970-01-01T00:00:00.000Z", n: 1 }
     { time: "1970-01-01T00:00:00.000Z", n: 3 }
 
+## Allows direct assignment to the `interval` field
+
+### Juttle
+
+    emit -from Date.new(0) -limit 3
+    | reduce -every :s: count()
+    | put interval = interval + :1m:
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:01.000Z", "interval":"00:01:01.000", "count": 1 }
+    { time: "1970-01-01T00:00:02.000Z", "interval":"00:01:01.000", "count": 1 }
+    { time: "1970-01-01T00:00:03.000Z", "interval":"00:01:01.000", "count": 1 }
+
+## Allows indirect assignment to the `interval` field
+
+### Juttle
+
+    emit -from Date.new(0) -limit 3
+    | reduce -every :s: count()
+    | put *"interval" = interval + :1m:
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:01.000Z", "interval":"00:01:01.000", "count": 1 }
+    { time: "1970-01-01T00:00:02.000Z", "interval":"00:01:01.000", "count": 1 }
+    { time: "1970-01-01T00:00:03.000Z", "interval":"00:01:01.000", "count": 1 }
+
+## complains about non-duration assignment to the `interval` field
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put n=count(), interval = n | view result
+
+### Warnings
+
+   * Invalid type assigned to interval: number (1).
+
+## complains about negative duration assignment to the `interval` field
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put n=count(), interval = -:24h: | view result
+
+### Warnings
+
+   * Duration assigned to interval must be positive: duration (-1d).
+
+## complains about empty duration assignment to the `interval` field
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put n=count(), interval = :0h: | view result
+
+### Warnings
+
+   * Duration assigned to interval must be positive: duration (00:00:00.000).
+
 ## the -acc option suppresses reducer reset
 
 ### Juttle


### PR DESCRIPTION
Allow assignments to interval field, but ensure it is a positive
duration.

Fix: #618
