### PR TITLE
Revert "add a batch"

### DIFF
--- a/lib/compiler/flowgraph/implicit_views.js
+++ b/lib/compiler/flowgraph/implicit_views.js
@@ -12,7 +12,7 @@ function implicit_views(g, options) {
     var table;
     _.each(leaves, function(node) {
         if (!is_sink(node)) {
-            table = g.append_node('View', default_view);
+            table = g.add_node('View', default_view);
             g.add_edge(node, table);
         }
     });

--- a/lib/compiler/optimize/optimize.js
+++ b/lib/compiler/optimize/optimize.js
@@ -45,7 +45,6 @@ function optimize_read(source_node, graph, Juttle) {
     var next_node = outs[0];
 
     while (outs && !outs_are_unoptimizable(outs, graph)) {
-        var reduce_every = false;
         switch (next_node.name) {
             case 'head':
                 successfully_optimized = optimize_head(source_node, next_node, graph, adapter, optimization_info);
@@ -57,7 +56,6 @@ function optimize_read(source_node, graph, Juttle) {
 
             case 'reduce':
                 successfully_optimized = optimize_reduce(source_node, next_node, graph, adapter, optimization_info);
-                reduce_every = graph.node_has_option(next_node, 'every');
                 break;
 
             default:
@@ -71,22 +69,8 @@ function optimize_read(source_node, graph, Juttle) {
         first_node = false;
         if (successfully_optimized) {
             outs = graph.node_get_outputs(next_node);
-            var index = graph.index_of(next_node);
-            var old_next_node = next_node;
             graph.remove_node(next_node);
             next_node = outs[0];
-            if (reduce_every) {
-                // Splice a batch node after an optimized read | reduce -every
-                // so it'll emit marks like unoptimized reduce -every
-                var batch = graph.insert_node('BuiltinProc', 'batch', index);
-                graph.node_set_option(batch, 'every', graph.node_get_option(old_next_node, 'every'));
-                if (graph.node_has_option(old_next_node, 'on')) {
-                    graph.node_set_option(batch, 'on', graph.node_get_option(old_next_node, 'on'));
-                }
-                graph.add_edge(source_node, batch);
-                graph.remove_edge(source_node, next_node);
-                graph.add_edge(batch, next_node);
-            }
         } else {
             break;
         }

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -11,8 +11,21 @@ class Graph {
         return this.built_graph.inputs;
     }
 
-    append_node(type, name) {
-        return this.insert_node(type, name, this.get_nodes().length);
+    add_node(type, name) {
+        var index = this.get_nodes().length;
+        var new_pname = build_pname(index);
+
+        var node = { type: type,
+                     options: [],
+                     pname: new_pname,
+                     out: [],
+                     in: [],
+                     shortcuts: [] };
+        if (name) {
+            node.name = name;
+        }
+        this.built_graph.nodes.push(node);
+        return node;
     }
     get_roots() {
         return _.filter(this.built_graph.nodes, function(node) { return node.in.length === 0;});
@@ -25,24 +38,6 @@ class Graph {
     }
     get_nodes() {
         return this.built_graph.nodes;
-    }
-    index_of(node) {
-        return this.built_graph.nodes.indexOf(node);
-    }
-    insert_node(type, name, index) {
-        var new_pname = build_pname(index);
-
-        var node = { type: type,
-                     options: [],
-                     pname: new_pname,
-                     out: [],
-                     in: [],
-                     shortcuts: [] };
-        if (name) {
-            node.name = name;
-        }
-        this.built_graph.nodes.splice(index, 0, node);
-        return node;
     }
     node_get_outputs(node) {
         var self = this;

--- a/test/runtime/adapter.spec.js
+++ b/test/runtime/adapter.spec.js
@@ -106,48 +106,6 @@ describe('adapter API tests', function () {
         });
     });
 
-    it('optimizes reduce -every', function() {
-        var write_program = `
-            const points = [
-                {time: :2016-03-01T23:51:55.153Z:},
-                {time: :2016-03-01T23:52:55.155Z:},
-                {time: :2016-03-01T23:53:55.155Z:},
-                {time: :2016-03-01T23:54:55.155Z:},
-                {time: :2016-03-01T23:57:55.155Z:},
-            ];
-            emit -points points
-            | put message = "hello"
-            | write test -key "test_reduce_every"`;
-
-        return check_juttle({program: write_program})
-            .then(function() {
-                var read_program = `
-                    read test -key "test_reduce_every"
-                        | reduce -every :2m: count() | sort count -desc`;
-                return check_juttle({program: read_program});
-            })
-            .then(function(result) {
-                expect(result.sinks.table).deep.equal([
-                    { count: 1, time: '2016-03-01T23:52:00.000Z' },
-                    { count: 2, time: '2016-03-01T23:54:00.000Z' },
-                    { count: 1, time: '2016-03-01T23:56:00.000Z' },
-                    { count: 1, time: '2016-03-01T23:58:00.000Z' }
-                ]);
-                var read_program_with_on = `
-                    read test -key "test_reduce_every"
-                        | reduce -every :2m: -on :30s: count() | sort count -desc`;
-                return check_juttle({program: read_program_with_on});
-            })
-            .then(function(result) {
-                expect(result.sinks.table).deep.equal([
-                    { time: '2016-03-01T23:52:30.000Z', count: 1 },
-                    { time: '2016-03-01T23:54:30.000Z', count: 2 },
-                    { time: '2016-03-01T23:56:30.000Z', count: 1 },
-                    { time: '2016-03-01T23:58:30.000Z', count: 1 }
-                ]);
-            });
-    });
-
     it('optimizes multiple nodes', function() {
         var program = 'read test -key "test3" | head 4 | head 3 | head 1';
         return check_juttle({

--- a/test/runtime/graph-api.spec.js
+++ b/test/runtime/graph-api.spec.js
@@ -202,7 +202,7 @@ describe('Graph API', function() {
                 var sink = _.findWhere(graph.get_leaves(), {type: 'View'});
                 graph.remove_edge(put, sink);
                 // add a new sink just so that it doesn't complain about
-                graph.add_edge(put, graph.append_node('View', 'newView'));
+                graph.add_edge(put, graph.add_node('View', 'newView'));
             });
             return run_juttle(program).then(function(res) {
                 expect(res.sinks.result.sort()).deep.equal([

--- a/test/runtime/test-adapter/index.js
+++ b/test/runtime/test-adapter/index.js
@@ -12,7 +12,6 @@ var store = {};
 /* globals JuttleAdapterAPI */
 var AdapterRead = JuttleAdapterAPI.AdapterRead;
 var AdapterWrite = JuttleAdapterAPI.AdapterWrite;
-var JuttleMoment = require('../../../lib/runtime/types/juttle-moment');
 
 function TestAdapter(config) {
     class Read extends AdapterRead {
@@ -42,11 +41,7 @@ function TestAdapter(config) {
             }
             this.optimization_info = params.optimization_info;
 
-            if (optimization_info.count) {
-                this.count = optimization_info.count;
-            } else if (optimization_info.count_every) {
-                this.count_every = JuttleMoment.duration(optimization_info.count_every.value);
-            }
+            this.count = optimization_info.count;
             if (optimization_info.hasOwnProperty('limit')) {
                 this.limit = optimization_info.limit;
             }
@@ -82,16 +77,6 @@ function TestAdapter(config) {
 
             if (this.count) {
                 points = [{count: points.length}];
-            } else if (this.count_every) {
-                points = _.chain(points).groupBy((pt) => {
-                    return pt.time.quantize(this.count_every).milliseconds();
-                })
-                .map((pts) => {
-                    return {count: pts.length, time: pts[0].time};
-                })
-                .sortBy(function(pt) {
-                    return pt.time.milliseconds();
-                }).value();
             }
 
             return Promise.resolve({
@@ -135,21 +120,13 @@ function TestAdapter(config) {
         optimize_reduce: function(read, reduce, graph, optimization_info) {
             var reduce_is_count = reduce && reduce.reducers &&
                 reduce.reducers.length === 1 && reduce.reducers[0].name === 'count' &&
-                reduce.reducers[0].arguments.length === 0 && !reduce.groupby;
+                reduce.reducers[0].arguments.length === 0 && !reduce.groupby &&
+                !_.findWhere(reduce.options, {id: 'every'});
 
-            if (!reduce_is_count) {
-                return;
-            }
-
-            var every = _.findWhere(reduce.options, {id: 'every'});
-
-            if (every) {
-                optimization_info.count_every = every.val;
-            } else {
+            if (reduce_is_count) {
                 optimization_info.count = true;
+                return true;
             }
-
-            return true;
         }
     };
 


### PR DESCRIPTION
Now that reduce -every doesn't emit marks, we don't want optimized
reduce -every to do so either.

This reverts commit 4742fe12ac2463d5d32f2dcf3b50346dba7726da.

Reverts #499 
Fixes #594 

@davidvgalbraith