### PR TITLE
allow adapter sort optimization

### DIFF
--- a/lib/compiler/optimize/optimize.js
+++ b/lib/compiler/optimize/optimize.js
@@ -5,6 +5,7 @@ var adapters = require('../../runtime/adapters');
 var utils = require('./optimize_utils');
 var optimize_head = require('./optimize_head');
 var optimize_tail = require('./optimize_tail');
+var optimize_sort = require('./optimize_sort');
 var optimize_reduce = require('./optimize_reduce');
 
 function outs_are_unoptimizable(outs, graph) {
@@ -52,6 +53,10 @@ function optimize_read(source_node, graph, Juttle) {
 
             case 'tail':
                 successfully_optimized = optimize_tail(source_node, next_node, graph, adapter, optimization_info);
+                break;
+                
+            case 'sort':
+                successfully_optimized = optimize_sort(source_node, next_node, graph, adapter, optimization_info);
                 break;
 
             case 'reduce':

--- a/lib/compiler/optimize/optimize_sort.js
+++ b/lib/compiler/optimize/optimize_sort.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var utils = require('./optimize_utils');
+
+var ALLOWED_OPTIONS = ['columns', 'limit', 'groupby'];
+
+function optimize_sort(source, sort, graph, adapter, optimization_info) {
+    if (! graph.node_contains_only_options(sort, ALLOWED_OPTIONS)) {
+        utils.optimization_disabled(graph, source, 'unsupported_sort_option');
+        return;
+    }
+
+    var optimizer = adapter.optimizer;
+    
+    if (optimizer && typeof optimizer.optimize_sort === 'function') {
+        return optimizer.optimize_sort(source, sort, graph, optimization_info);
+    }
+}
+
+module.exports = optimize_sort;

--- a/test/runtime/test-adapter/index.js
+++ b/test/runtime/test-adapter/index.js
@@ -42,6 +42,11 @@ function TestAdapter(config) {
             this.optimization_info = params.optimization_info;
 
             this.count = optimization_info.count;
+            
+            if (optimization_info.sort) {
+                this.sortField = optimization_info.sort;
+            }
+        
             if (optimization_info.hasOwnProperty('limit')) {
                 this.limit = optimization_info.limit;
             }
@@ -69,6 +74,10 @@ function TestAdapter(config) {
             // Otherwise just emit whatever is stored for the given key
             else {
                 points = store[this.key] || [];
+            }
+            
+            if (this.sortField) {
+                points = _.sortBy(points, this.sortField);
             }
 
             if (this.hasOwnProperty('limit')) {
@@ -115,6 +124,23 @@ function TestAdapter(config) {
 
             optimization_info.type = 'tail';
             optimization_info.limit = limit;
+            return true;
+        },
+        optimize_sort: function(read, sort, graph, optimization_info) {
+            if (optimization_info.type && optimization_info.type !== 'sort') {
+                return false;
+            }
+            
+            var sortCols = graph.node_get_option(sort, 'columns');
+            if (
+                sortCols.length !== 1 || sortCols[0].direction ||
+                graph.node_get_option(sort, 'limit') ||
+                graph.node_get_option(sort, 'groupby')
+                ) {
+                return false;
+            }
+            
+            optimization_info.sort = graph.node_get_option(sort, 'columns')[0].field;
             return true;
         },
         optimize_reduce: function(read, reduce, graph, optimization_info) {


### PR DESCRIPTION
Adapters can optimize `reduce`, `head`, and `tail` procs.
This PR will allow adapters to optimize sort. Full example here: https://github.com/juttle/juttle-sql-adapter-common/pull/55