### PR TITLE
read: quantize from/to for optimized reduce -every

### DIFF
--- a/lib/compiler/optimize/optimize_reduce.js
+++ b/lib/compiler/optimize/optimize_reduce.js
@@ -9,7 +9,14 @@ function optimize_reduce(source, reduce, graph, adapter, optimization_info) {
     var optimizer = adapter.optimizer;
 
     if (optimizer && typeof optimizer.optimize_reduce === 'function') {
-        return optimizer.optimize_reduce(source, reduce, graph, optimization_info);
+        var successfully_optimized = optimizer.optimize_reduce(source, reduce, graph, optimization_info);
+        if (successfully_optimized && graph.node_has_option(reduce, 'every')) {
+            // stash the -every, this is used by read.js to quantize the time bounds
+            // for live optimized reads
+            optimization_info._reduce_every = graph.node_get_option(reduce, 'every');
+        }
+
+        return successfully_optimized;
     }
 }
 

--- a/lib/compiler/optimize/optimize_reduce.js
+++ b/lib/compiler/optimize/optimize_reduce.js
@@ -6,11 +6,17 @@ function optimize_reduce(source, reduce, graph, adapter, optimization_info) {
         throw new Error('optimizer encountered reduce proc with no downstream node');
     }
 
+    var has_reduce_every = graph.node_has_option(reduce, 'every');
+    var has_read_every = graph.node_has_option(source, 'every');
+    if (has_reduce_every && has_read_every) {
+        throw new Error('cannot read -every | reduce -every');
+    }
+
     var optimizer = adapter.optimizer;
 
     if (optimizer && typeof optimizer.optimize_reduce === 'function') {
         var successfully_optimized = optimizer.optimize_reduce(source, reduce, graph, optimization_info);
-        if (successfully_optimized && graph.node_has_option(reduce, 'every')) {
+        if (successfully_optimized && has_reduce_every) {
             // stash the -every, this is used by read.js to quantize the time bounds
             // for live optimized reads
             optimization_info._reduce_every = graph.node_get_option(reduce, 'every');

--- a/lib/runtime/procs/read.js
+++ b/lib/runtime/procs/read.js
@@ -126,6 +126,12 @@ class Read extends source {
             this.logger.debug('scheduling first live read at', firstRead.toJSON());
             this.program.scheduler.schedule(firstRead.unixms(), _.bind(this.run, this));
         }
+
+        if (this.params.optimization_info._reduce_every && this.to.isEnd()) {
+            var every = JuttleMoment.duration(this.params.optimization_info._reduce_every);
+            this.readTo = this.readFrom.quantize(every).add(every);
+            this.readEvery = every;
+        }
     }
 
     // Kick off a read iteration from the adapter.

--- a/test/adapters/stochastic.spec.js
+++ b/test/adapters/stochastic.spec.js
@@ -376,7 +376,7 @@ describe('stochastic -source "logs"', function() {
     });
     it('emits points continously to the live stream', function() {
         return check_juttle({
-            program: 'read stochastic -to :end: -source "cdn" -every :1s: ' +
+            program: 'read stochastic -to :end: -source "cdn" ' +
                 '| reduce -every :1s: count()' +
                 '| view result',
             deactivateAfter: 2000

--- a/test/runtime/adapter-read-timeseries.spec.js
+++ b/test/runtime/adapter-read-timeseries.spec.js
@@ -155,4 +155,13 @@ describe('read testTimeseries', function () {
             expect(result.graph.lag.milliseconds()).equal(1000);
         });
     });
+
+    it('rejects read -every | reduce -every', function() {
+        var failing_read = check_juttle({
+            program: 'read testTimeseries -every :s: | reduce -every :m: count()'
+        });
+
+        var message = 'cannot read -every | reduce -every';
+        return juttle_test_utils.expect_to_fail(failing_read, message);
+    });
 });


### PR DESCRIPTION
If we're doing an optimized reduce -every live program, we should only make one query per
batch. We start by going from from to the end of the first batch, then each
subsequent query is made over a full batch.
Will fix https://github.com/juttle/juttle-elastic-adapter/issues/108
@demmer @VladVega