### PR TITLE
Make the “.” operator work properly in lvalues

### DIFF
--- a/lib/compiler/scope.js
+++ b/lib/compiler/scope.js
@@ -143,26 +143,6 @@ class Scope {
             uname: 'juttle.reducers.' + name + '.fn'
         };
     }
-
-    lookup_module_any(mod, name, type) {
-        var imp = this.get(mod);
-        if (!imp || imp.type !== 'import' || imp.exports[name] === undefined || imp.exports[name].type !== type) {
-            return undefined;
-        }
-        //
-        //XXX/sm changed the way module names are exported from a module
-        // to simplify things... we still do all the type tracking here
-        // in the semantic pass, but the module is flattened out and
-        // module export are simply accessed via the global uname
-        //
-        return imp.exports[name];
-    }
-    lookup_module_variable(mod, name) {
-        if (this.lookup_module_any(mod, name, 'const') !== undefined) {
-            return this.lookup_module_any(mod, name, 'const');
-        }
-        return undefined;
-    }
 }
 
 module.exports = {

--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -1424,20 +1424,7 @@ class SemanticPass {
             }
         }
 
-        if (this.expr_mode === 'assign' || this.expr_mode === 'update') {
-            if (!node.computed) {
-                symbol = this.scope.lookup_module_variable(node.object.name, node.property.value);
-                if (symbol === undefined) {
-                    throw errors.compileError('NOT-EXPORTED', {
-                        name: node.property.value,
-                        module: node.object.name,
-                        location: node.location
-                    });
-                }
-
-                node.symbol = this.scope.get(node.object.name).exports[node.property.value];
-            }
-        } else {
+        if (this.expr_mode !== 'assign' && this.expr_mode !== 'update') {
             if (node.computed) {
                 if (node.object.symbol) {
                     if (node.object.symbol.type !== 'const' && node.object.symbol.type !== 'var') {

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1312,20 +1312,19 @@ StrictAssignmentExpression 'field assignment'
       }
 
 AssignmentLHS
-    = left:Variable
+    = object:Variable
       accessors:(
-          __ '[' __ name:Expression __ ']' {
-              return {
-                  name: name,
-                  computed: true,
-                  location: locationWithFilename(location())
-              };
+          __ '[' __ property:Expression __ ']' {
+              return createNode('MemberExpressionProperty', location(), {
+                  property: property,
+                  computed: true
+              });
           }
       )* {
-          return buildTree(left, accessors, function(result, element) {
+          return buildTree(object, accessors, function(result, element) {
               return createNode('MemberExpression', spanningLocation(result.location, element.location), {
                   object: result,
-                  property: element.name,
+                  property: element.property,
                   computed: element.computed
               })
           });

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1314,12 +1314,20 @@ StrictAssignmentExpression 'field assignment'
 AssignmentLHS
     = object:Variable
       accessors:(
-          __ '[' __ property:Expression __ ']' {
-              return createNode('MemberExpressionProperty', location(), {
-                  property: property,
-                  computed: true
-              });
-          }
+            __ '[' __ property:Expression __ ']' {
+                return createNode('MemberExpressionProperty', location(), {
+                    property: property,
+                    computed: true
+                });
+            }
+          / __ '.' __ property:Identifier {
+                return createNode('MemberExpressionProperty', location(), {
+                    property: createNode('StringLiteral', property.location, {
+                        value: property.name
+                    }),
+                    computed: false
+                });
+            }
       )* {
           return buildTree(object, accessors, function(result, element) {
               return createNode('MemberExpression', spanningLocation(result.location, element.location), {

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-entities.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-entities.spec.md
@@ -1,0 +1,117 @@
+# The `.` operator (in lvalue, on entities)
+
+## Assigns correctly when used on a variable
+
+### Juttle
+
+    function f() {
+      var v = { a: 1, b: 2, c: 3 };
+      v.b = 5;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: { a: 1, b: 5, c: 3 } }
+
+## (Skip) Assigns correctly when used on a point field
+
+### Juttle
+
+    emit -from :0: -limit 1 | put f = { a: 1, b: 2, c: 3 } | put f.b = 5 | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", f: { a: 1, b: 5, c: 3 } }
+
+## Produces an error when used on a constant
+
+### Juttle
+
+    function f() {
+      const c = { a: 1, b: 2, c: 3 };
+      c.b = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "c" cannot be modified
+
+## Produces an error when used on a function
+
+### Juttle
+
+    function f() {
+      function g() {
+      }
+
+      g.b = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "g" cannot be modified
+
+## Produces an error when used on a reducer
+
+### Juttle
+
+    reducer r() {
+      function update() { }
+      function result() { }
+    }
+
+    function f() {
+      r.b = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "r" cannot be modified
+
+## Produces an error when used on a subgraph
+
+### Juttle
+
+    sub s() {
+      pass
+    }
+
+    function f() {
+      s.b = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "s" cannot be modified
+
+## Produces an error when used on a module
+
+### Module `m`
+
+    export const c = 5;
+
+### Juttle
+
+    import 'm' as m;
+
+    function f() {
+      m.b = 5;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Errors
+
+  * CompileError: Variable "m" cannot be modified

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-nested.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-nested.spec.md
@@ -1,0 +1,35 @@
+# The `.` operator (in lvalue, nested)
+
+## Assigns correctly when used in a nested expression
+
+### Juttle
+
+    function f() {
+      var v = { a: 1, b: { d: 4, e: { g: 7, h: 8, i: 9 }, f: 6, }, c: 3 };
+      v.b.e.h = 11;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", result: { a: 1, b: { d: 4, e: { g: 7, h: 11, i: 9 }, f: 6 }, c: 3 } }
+
+## Produces an error when an element in the middle of the chain is missing
+
+### Juttle
+
+    function f() {
+      var v = { a: 1, b: { d: 4, e: { g: 7, h: 8, i: 9 }, f: 6, }, c: 3 };
+      v.b.g.h = 11;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1 | put result = f() | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": null and string (h).

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-values.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-values.spec.md
@@ -1,0 +1,61 @@
+# The `.` operator (in lvalue, on values)
+
+## Assigns correctly when used on an `Object`
+
+### Juttle
+
+    function in1() {
+      var v = { a: 1, b: 2, c: 3 };
+      v.a = 4;
+
+      return v;
+    }
+
+    function in2() {
+      var v = { a: 1, b: 2, c: 3 };
+      v.b = 5;
+
+      return v;
+    }
+
+    function in3() {
+      var v = { a: 1, b: 2, c: 3 };
+      v.c = 6;
+
+      return v;
+    }
+
+    function out() {
+      var v = { a: 1, b: 2, c: 3 };
+      v.d = 4;
+
+      return v;
+    }
+
+    emit -from :0: -limit 1
+    | put in1 = in1()
+    | put in2 = in2()
+    | put in3 = in3()
+    | put out = out()
+    | view result
+
+### Output
+
+    { time: "1970-01-01T00:00:00.000Z", in1: { a: 4, b: 2, c: 3 }, in2: { a: 1, b: 5, c: 3 }, in3: { a: 1, b: 2, c: 6 }, out: { a: 1, b: 2, c: 3, d: 4 } }
+
+## Produces an error when used on a value of invalid type
+
+### Juttle
+
+    function f() {
+      var v = null;
+      v.b = 5;
+    }
+
+    emit -from :0: -limit 1
+    | put result = f()
+    | view result
+
+### Warnings
+
+  * Invalid operand types for "[]": null and string (b).


### PR DESCRIPTION
This PR adds tests that specify behavior of the `.` operator in lvalues and adjusts the implementation to match. Specifically, it extends the Juttle grammar and removes incorrect checks in the semantic pass.

Note that member assignment in `put`/`reduce` still isn't allowed. Making it work requires more substantial changes which will be done later.

Part of work on #419.