### PR TITLE
Implement nested field assignment

### DIFF
--- a/lib/compiler/graph-compiler.js
+++ b/lib/compiler/graph-compiler.js
@@ -513,6 +513,21 @@ class GraphCompiler extends CodeGenerator {
 
         return code;
     }
+    get_assigned_field(node) {
+        switch (node.type) {
+            case 'Field':
+                return node.name;
+
+            case 'UnaryExpression':
+                return node.argument.value;
+
+            case 'MemberExpression':
+                return this.get_assigned_field(node.object);
+
+            default:
+                throw new Error('Invalid node type: ' + node.type + '.');
+        }
+    }
     gen_ReifierProc(node, which) {
         var k;
 
@@ -524,15 +539,13 @@ class GraphCompiler extends CodeGenerator {
 
         maker = this.gen_reifier(node.reducers);
         var reducer_index = _.pluck(node.reducers, 'index');
-        var lhs = node.exprs.map(function(expr) {
-            return expr.left.type === 'Field' ? expr.left.name : expr.left.argument.value;
-        });
+        var assigned_fields = node.exprs.map(expr => this.get_assigned_field(expr.left));
 
         return this.gen_proc(node, which, {
             expr: expr,
             funcMaker: maker,
             $reducer_index: reducer_index,
-            $lhs: lhs
+            $assigned_fields: assigned_fields
         });
     }
 

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1321,10 +1321,36 @@ AssignmentLHS
       }
 
 StrictAssignmentLHS
-    = FieldReferenceExpression
-    / name:Identifier {
-          return createNode('Field', location(), {
-              name: name.name
+    = object:(
+            FieldReferenceExpression
+          / name:Identifier {
+                return createNode('Field', location(), {
+                    name: name.name
+                });
+            }
+      )
+      accessors:(
+            __ '[' __ property:Expression __ ']' {
+                return createNode('MemberExpressionProperty', location(), {
+                    property: property,
+                    computed: true
+                });
+            }
+          / __ '.' __ property:Identifier {
+                return createNode('MemberExpressionProperty', location(), {
+                    property: createNode('StringLiteral', property.location, {
+                        value: property.name
+                    }),
+                    computed: false
+                });
+            }
+      )* {
+          return buildTree(object, accessors, function(result, element) {
+              return createNode('MemberExpression', spanningLocation(result.location, element.location), {
+                  object: result,
+                  property: element.property,
+                  computed: element.computed
+              })
           });
       }
 

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -972,24 +972,6 @@ ArgumentList
 LeftHandSideExpression
     = CoreExpression
 
-RealLeftHandSideExpression
-    = '*' !'=' __ argument:UnaryExpression {
-          return createNode('UnaryExpression', location(), {
-              operator:   '*',
-              argument: argument
-          });
-      }
-
-// Coerce LHS to a Field Reference.
-RealCoercedLeftHandSideExpression
-    = name:Identifier {
-          return createNode('Field', location(), {
-              name: name.name
-          });
-      }
-    / FieldReferenceShortcut
-    / RealLeftHandSideExpression
-
 PostfixExpression
     = expression:LeftHandSideExpression _ operator:PostfixOperator {
           return createNode('PostfixExpression', location(), {
@@ -1301,7 +1283,7 @@ AssignmentExpressionToplevel 'expression'
     / ConditionalExpressionToplevel
 
 StrictAssignmentExpression 'field assignment'
-    = left:RealCoercedLeftHandSideExpression __
+    = left:StrictAssignmentLHS __
       operator:AssignmentOperator __
       right:AssignmentExpressionToplevel {
           return createNode('AssignmentExpression', location(), {
@@ -1335,6 +1317,23 @@ AssignmentLHS
                   property: element.property,
                   computed: element.computed
               })
+          });
+      }
+
+StrictAssignmentLHS
+    = FieldReferenceExpression
+    / name:Identifier {
+          return createNode('Field', location(), {
+              name: name.name
+          });
+      }
+
+FieldReferenceExpression
+    = FieldReferenceShortcut
+    / '*' !'=' __ argument:UnaryExpression {
+          return createNode('UnaryExpression', location(), {
+              operator:   '*',
+              argument: argument
           });
       }
 

--- a/lib/runtime/procs/oops-fanin.js
+++ b/lib/runtime/procs/oops-fanin.js
@@ -8,7 +8,7 @@ class oops_fanin extends fanin {
     // watch for out-of-order points and points with non-moment times when emitting
     constructor(options, params, location, program) {
         super(options, params, location, program);
-        if (params && params.lhs && params.lhs.indexOf('time') >= 0) {
+        if (params && params.assigned_fields && params.assigned_fields.indexOf('time') >= 0) {
             this.watch_oops = true; // true enables out-of-order checks during emit
             this.last_output_time = JuttleMoment.epsMoment(-Infinity); // only updated if watch_oops
         } else {

--- a/lib/runtime/procs/reduce.js
+++ b/lib/runtime/procs/reduce.js
@@ -57,7 +57,6 @@ class reduce_base extends periodic_fanin {
             });
         }
         this.expr = params.expr || {};
-        this.reducer_lhs = _.map(params.reducer_index, function get(i) { return params.lhs[i]; });
         this.accumulate = options.acc || (options.reset !== undefined && !options.reset);
         this.groups = new Groups(this, options, params.funcMaker);
         if (options.forget && this.accumulate) {

--- a/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-entities.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/dot-operator-lvalue-entities.spec.md
@@ -17,7 +17,7 @@
 
     { time: "1970-01-01T00:00:00.000Z", result: { a: 1, b: 5, c: 3 } }
 
-## (Skip) Assigns correctly when used on a point field
+## Assigns correctly when used on a point field
 
 ### Juttle
 

--- a/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-entities.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/get-operator-lvalue-entities.spec.md
@@ -17,7 +17,7 @@
 
     { time: "1970-01-01T00:00:00.000Z", result: [ 1, 5, 3 ] }
 
-## (Skip) Assigns correctly when used on a point field
+## Assigns correctly when used on a point field
 
 ### Juttle
 


### PR DESCRIPTION
Implement nested field assignment in `put`/`reduce`. This means code like this is completely valid now and works (assuming the `a` field contains appropriate Juttle value):

```juttle
put a[0].b[0] = 1
```

Final part for work on #419.