### PR TITLE
view.js: emit event payload in a consistently named property

### DIFF
--- a/lib/runtime/procs/view.js
+++ b/lib/runtime/procs/view.js
@@ -27,17 +27,17 @@ class view extends sink {
     // include proc names including the error/warning.
 
     mark(mark) {
-        this.program.events.emit('view:mark', {channel: this.channel, mark: mark});
+        this.program.events.emit('view:mark', {channel: this.channel, data: mark});
     }
     tick(time) {
-        this.program.events.emit('view:tick', {channel: this.channel, time: time});
+        this.program.events.emit('view:tick', {channel: this.channel, data: time});
     }
     eof() {
         this.program.events.emit('view:eof', {channel: this.channel});
         this.done();
     }
     process(points) {
-        this.program.events.emit('view:points', {channel: this.channel, points: points});
+        this.program.events.emit('view:points', {channel: this.channel, data: points});
     }
 
     static get info() {

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -78,20 +78,20 @@ class ViewManager {
             });
         });
 
-        self.program.events.on('view:mark', function(data) {
-            self.views[data.channel].mark(data.mark);
+        self.program.events.on('view:mark', function(event) {
+            self.views[event.channel].mark(event.data);
         });
 
-        self.program.events.on('view:tick', function(data) {
-            self.views[data.channel].tick(data.time);
+        self.program.events.on('view:tick', function(event) {
+            self.views[event.channel].tick(event.data);
         });
 
-        self.program.events.on('view:eof', function(data) {
-            self.views[data.channel].eof();
+        self.program.events.on('view:eof', function(event) {
+            self.views[event.channel].eof();
         });
 
-        self.program.events.on('view:points', function(data) {
-            self.views[data.channel].consume(data.points);
+        self.program.events.on('view:points', function(event) {
+            self.views[event.channel].consume(event.data);
         });
 
         // Return a promise that resolves when all views have

--- a/test/runtime/specs/juttle-test-utils.js
+++ b/test/runtime/specs/juttle-test-utils.js
@@ -233,20 +233,20 @@ function run_juttle(prog, options) {
         var warnings = [];
 
         // Dispatch to correct test view
-        prog.events.on('view:mark', function(data) {
-            views[data.channel].mark(data.mark);
+        prog.events.on('view:mark', function(event) {
+            views[event.channel].mark(event.data);
         });
 
-        prog.events.on('view:tick', function(data) {
-            views[data.channel].tick(data.time);
+        prog.events.on('view:tick', function(event) {
+            views[event.channel].tick(event.data);
         });
 
-        prog.events.on('view:eof', function(data) {
-            views[data.channel].eof();
+        prog.events.on('view:eof', function(event) {
+            views[event.channel].eof();
         });
 
-        prog.events.on('view:points', function(data) {
-            views[data.channel].consume(data.points);
+        prog.events.on('view:points', function(event) {
+            views[event.channel].consume(event.data);
         });
 
         prog.events.on('error', function(err) {


### PR DESCRIPTION
For 'emit:mark', 'emit:tick', and 'emit:points' events, always put the payload for (e.g. mark, time, points) into a property called 'payload'.

The change in https://github.com/juttle/juttle/pull/567 requires making changes in a few places that receive marks and pass them on to somewhere else (https://github.com/juttle/juttle-service/issues/71 and https://github.com/juttle/juttle-client-library/issues/80). Since these places just pass-through the core payload of the event and only transform the surrounding event metadata, using a generic 'payload' allows us to future-proof against any changes we might make to the 'payload' contents. These intermediate steps shouldn't need to be changed every time - only the actual end-subscribers to the events (generally the views).

We can use 'data' instead of 'payload' if you guys think thats a more appropriate name.

@demmer @dmajda @mstemm