### PR TITLE
views_sourceinfo: get info from 'emit' nodes

### DIFF
--- a/lib/compiler/flowgraph/views_sourceinfo.js
+++ b/lib/compiler/flowgraph/views_sourceinfo.js
@@ -3,14 +3,16 @@
 var _ = require('underscore');
 
 
-// Returns a list of all the `read` nodes that are upstream of the passed-in node.
-function upstream_reads(g, node) {
+// Returns a list of all the source (`read` and `emit`) nodes that are upstream of the passed-in node.
+function upstream_sources(g, node) {
     var flatMap = _.compose(_.flatten, _.map);
     function rec(node) {
         var inputs = g.node_get_inputs(node);
-        var reads = _.where(inputs, {type: 'ReadProc'});
-        var nonreads = _.difference(inputs, reads);
-        return reads.concat(flatMap(nonreads, rec));
+        var sources = _.filter(inputs, (node) => {
+            return node.name === 'read' || node.name === 'emit';
+        });
+        var nonsources = _.difference(inputs, sources);
+        return sources.concat(flatMap(nonsources, rec));
     }
     return _.uniq(rec(node));
 }
@@ -19,11 +21,11 @@ function upstream_reads(g, node) {
 function views_sourceinfo(g) {
     var views = _.where(g.get_leaves(), {type: 'View'});
     _.each(views, function(view) {
-        var reads = upstream_reads(g, view);
-        var time_bounds = _.map(reads, function(read) {
-            return {from: g.node_get_option(read, 'from') || null,
-                    to: g.node_get_option(read, 'to') || null,
-                    last: g.node_get_option(read, 'last') || null};
+        var sources = upstream_sources(g, view);
+        var time_bounds = _.map(sources, function(source) {
+            return {from: g.node_get_option(source, 'from') || null,
+                    to: g.node_get_option(source, 'to') || null,
+                    last: g.node_get_option(source, 'last') || null};
         });
         g.node_set_option(view, '_jut_time_bounds', time_bounds);
     });

--- a/test/compiler/flowgraph/views_sourceinfo.spec.js
+++ b/test/compiler/flowgraph/views_sourceinfo.spec.js
@@ -45,8 +45,13 @@ describe('Views get info on source time bounds', function() {
     var last = JuttleMoment.duration(1, 'hour');
 
     test('read stochastic -source "cdn" -from :' + from.valueOf() + ': | view view ', [[{from: from, to: null, last: null}]]);
+    test('emit -from :' + from.valueOf() + ': | view view ', [[{from: from, to: null, last: null}]]);
+
     test('read stochastic -source "cdn" -from :' + from.valueOf() + ': -to :' + to.valueOf() + ': | view view ', [[{from: from, to: to, last: null}]]);
+    test('emit -from :' + from.valueOf() + ': -to :' + to.valueOf() + ': | view view ', [[{from: from, to: to, last: null}]]);
+
     test('read stochastic -last :' + last.valueOf() + ': -source "cdn" | view view ', [[{from: null, to: null, last: last}]]);
+    test('emit -last :' + last.valueOf() + ': | view view ', [[{from: null, to: null, last: last}]]);
 
     test('read stochastic -source "cdn" -from :' + from.valueOf() + ': | view view; read stochastic -last :' + last.valueOf() + ': -source "cdn"  | view view ',
          [[{from: from, to: null, last: null}], [{from: null, to: null, last: last}]]);

--- a/test/runtime/object-literals.spec.js
+++ b/test/runtime/object-literals.spec.js
@@ -13,7 +13,11 @@ describe('Juttle Object Literal Tests', function() {
 
     it('passes object literal to sink', function() {
         var optionObject = {
-            _jut_time_bounds: [],
+            _jut_time_bounds: [{
+                from: null,
+                to: null,
+                last: null
+            }],
             something: 3
         };
 

--- a/test/runtime/object-literals.spec.js
+++ b/test/runtime/object-literals.spec.js
@@ -28,7 +28,6 @@ describe('Juttle Object Literal Tests', function() {
 
     it('correctly deals with option precendence', function() {
         var optionObject = {
-            _jut_time_bounds: [],
             foo: 'bar',
             something: 3
         };
@@ -42,7 +41,7 @@ describe('Juttle Object Literal Tests', function() {
         })
             .then(function(res) {
                 var options = sink_options(res.prog, 0);
-                expect(_(options).omit('now')).to.deep.equal(_(optionObject).extend(optionObject2));
+                expect(_(options).omit('now', '_jut_time_bounds')).to.deep.equal(_(optionObject).extend(optionObject2));
             });
     });
 
@@ -51,7 +50,6 @@ describe('Juttle Object Literal Tests', function() {
             something: 3
         };
         var expectedObject = {
-            _jut_time_bounds: [],
             something: 4
         };
 
@@ -60,13 +58,12 @@ describe('Juttle Object Literal Tests', function() {
         })
             .then(function(res) {
                 var options = sink_options(res.prog, 0);
-                expect(_(options).omit('now')).to.deep.equal(expectedObject);
+                expect(_(options).omit('now', '_jut_time_bounds')).to.deep.equal(expectedObject);
             });
     });
 
     it('overrides option with object', function() {
         var optionObject = {
-            _jut_time_bounds: [],
             something: 3
         };
 
@@ -75,13 +72,12 @@ describe('Juttle Object Literal Tests', function() {
         })
             .then(function(res) {
                 var options = sink_options(res.prog, 0);
-                expect(_(options).omit('now')).to.deep.equal(optionObject);
+                expect(_(options).omit('now', '_jut_time_bounds')).to.deep.equal(optionObject);
             });
     });
 
     it('passes object literal to sink from const', function() {
         var optionObject = {
-            _jut_time_bounds: [],
             something: 3
         };
 
@@ -90,13 +86,12 @@ describe('Juttle Object Literal Tests', function() {
         })
             .then(function(res) {
                 var options = sink_options(res.prog, 0);
-                expect(_(options).omit('now')).to.deep.equal(optionObject);
+                expect(_(options).omit('now', '_jut_time_bounds')).to.deep.equal(optionObject);
             });
     });
 
     it('passes object literal to sink from function', function() {
         var optionObject = {
-            _jut_time_bounds: [],
             something: 3
         };
 
@@ -105,7 +100,7 @@ describe('Juttle Object Literal Tests', function() {
         })
             .then(function(res) {
                 var options = sink_options(res.prog, 0);
-                expect(_(options).omit('now')).to.deep.equal(optionObject);
+                expect(_(options).omit('now', '_jut_time_bounds')).to.deep.equal(optionObject);
             });
     });
 

--- a/test/runtime/sinks.spec.js
+++ b/test/runtime/sinks.spec.js
@@ -168,7 +168,11 @@ describe('Juttle sinks validation', function() {
     it('handles dots for nested sink arguments', function() {
         var program = 'emit -limit 1 | view result -foo.bar.baz 5';
         var nested = {
-            _jut_time_bounds: [],
+            _jut_time_bounds: [{
+                from: null,
+                to: null,
+                last: null
+            }],
             foo: {
                 bar: {
                     baz: 5


### PR DESCRIPTION
Previously we were grabbing from/last/to info from 'read' nodes. Grab the info from 'emit' as well.

Removed `_jut_time_bounds` verification from some tests because it felt a bit redundant.

@dmajda @bkutil @demmer