### PR TITLE
Fold file resolver into test resolver.

### DIFF
--- a/test/runtime/specs/juttle-spec/stdlib/predict.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/predict.spec.md
@@ -2,7 +2,7 @@
 
 ## predict with features disabled returns previous value
 ### Juttle
-    import "predict.juttle" as predict;
+    import "predict" as predict;
     emit -limit 5 -from Date.new(0) -every :d:
     | put value = count()
     | predict.predict -over :w: -every :d: -detrend false -deseason false -denoise false -revise false
@@ -18,7 +18,7 @@
 
 ## predict can detrend a straight line
 ### Juttle
-    import "predict.juttle" as predict;
+    import "predict" as predict;
     emit -limit 14 -from Date.new(0) -every :d:
     | put value = count()
     | predict.predict -over :w: -every :d: -deseason false
@@ -30,7 +30,7 @@
 
 ## predict can deseasonalize a sinewave
 ### Juttle
-    import "predict.juttle" as predict;
+    import "predict" as predict;
     const every=:d:;
     const over=:w:;
     emit -from Date.new(0) -to Date.new(0)+4*over -every every
@@ -45,7 +45,7 @@
 
 ## predict can detrend and deseasonalize
 ### Juttle
-    import "predict.juttle" as predict;
+    import "predict" as predict;
     const every=:d:;
     const over=:w:;
     emit -from Date.new(0) -to Date.new(0)+4*over -every every

--- a/test/runtime/specs/juttle-spec/stdlib/random.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/random.spec.md
@@ -2,7 +2,7 @@
 
 ## exponential produces numbers > 0 for positive scale
 ### Juttle
-    import "random.juttle" as random;
+    import "random" as random;
     emit -limit 1000 -from Date.new(0)
     | put x= random.exponential(1)
     | filter x > 0
@@ -14,7 +14,7 @@
 
 ## normal produces some numbers
 ### Juttle
-    import "random.juttle" as random;
+    import "random" as random;
     emit -limit 1000 -from Date.new(0)
     | put x= random.normal(0, 1)
     | filter x > -Infinity and x < Infinity
@@ -26,7 +26,7 @@
 
 ## poisson produces integers >= 0
 ### Juttle
-    import "random.juttle" as random;
+    import "random" as random;
     emit -limit 1000 -from Date.new(0)
     | put x= random.poisson(10)
     | put winning = x >=0 && x == Math.floor(x)
@@ -39,7 +39,7 @@
 
 ## uniform produces numbers in (low...high)
 ### Juttle
-    import "random.juttle" as random;
+    import "random" as random;
     emit -limit 1000 -from Date.new(0)
     | put x= random.uniform(1, 10)
     | filter x > 1 and x < 10

--- a/test/runtime/specs/juttle-spec/stdlib/select.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/select.spec.md
@@ -2,7 +2,7 @@
 
 ## min selects the minimum value
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 5 -from Date.new(0)
     | put x = count()
     | select.min -field 'x'
@@ -14,7 +14,7 @@
 
 ## max selects the maximum value
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 5 -from Date.new(0)
     | put x = count()
     | select.max -field 'x'
@@ -26,7 +26,7 @@
 
 ## median selects the median value (odd)
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 5 -from Date.new(0)
     | put x = count()
     | select.median -field 'x'
@@ -38,7 +38,7 @@
 
 ## median selects the median value (even)
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 6 -from Date.new(0)
     | put x = count()
     | select.median -field 'x'
@@ -50,7 +50,7 @@
 
 ## percentile selects the 75th percentile point
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 10 -from Date.new(0)
     | put x = count()
     | select.percentile -field 'x' -p 0.75
@@ -62,7 +62,7 @@
 
 ## min selects the minimum value by group
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 10 -from Date.new(0)
     | put x = count(), parity = x % 2
     | select.min -field 'x' -by 'parity'
@@ -75,7 +75,7 @@
 
 ## max selects the maximum value by group
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 10 -from Date.new(0)
     | put x = count(), parity = x % 2
     | select.max -field 'x' -by 'parity'
@@ -88,7 +88,7 @@
 
 ## median selects the median value by group
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 10 -from Date.new(0)
     | put x = count(), parity = x % 2
     | select.median -field 'x' -by 'parity'
@@ -101,7 +101,7 @@
 
 ## percentile selects the 75th percentile point by group
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 20 -from Date.new(0)
     | put x = count(), parity = x % 2
     | select.percentile -field 'x' -p 0.75  -by 'parity'
@@ -114,7 +114,7 @@
 
 ## min selects the minimum value, batched
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 20 -from Date.new(0)
     | put x = count(), parity = x % 2
     | batch :10s:
@@ -131,7 +131,7 @@
 
 ## max selects the maximum value, batched
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 20 -from Date.new(0)
     | put x = count(), parity = x % 2
     | batch :10s:
@@ -148,7 +148,7 @@
 
 ## median selects the median value, batched
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 20 -from Date.new(0)
     | put x = count(), parity = x % 2
     | batch :10s:
@@ -165,7 +165,7 @@
 
 ## percentile selects the 75th percentile point, batched
 ### Juttle
-    import "select.juttle" as select;
+    import "select" as select;
     emit -limit 40 -from Date.new(0)
     | put x = count(), parity = x % 2
     | batch :20s:

--- a/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
@@ -2,7 +2,7 @@
 
 ## reducer demean(fld) subtracts the mean
 ### Juttle
-    import "stats.juttle" as stats;
+    import "stats" as stats;
     emit -limit 5 -from Date.new(0)
     | put x = 2 * count()
     | reduce x = last(x), u = avg(x), xmu = stats.demean(x)
@@ -13,7 +13,7 @@
 
 ## reducer stdev(fld) computes the right thing
 ### Juttle
-    import "stats.juttle" as stats;
+    import "stats" as stats;
     emit -limit 3 -from Date.new(0)
     | put x = 2 * count()
     | reduce s = stats.stdev(x)
@@ -26,7 +26,7 @@
 note the first output point is dropped because we
 tried to do Math.floor(null)
 ### Juttle
-    import "stats.juttle" as stats;
+    import "stats" as stats;
     emit -limit 3 -from Date.new(0)
     | put x = 2 * count()
     | reduce z = stats.z(x)
@@ -37,7 +37,7 @@ tried to do Math.floor(null)
 
 ## reducer relMean(fld) divides by the mean
 ### Juttle
-    import "stats.juttle" as stats;
+    import "stats" as stats;
     emit -limit 3 -from Date.new(0)
     | put x = 2 * count()
     | reduce x = last(x), u = avg(x), xdu = stats.relMean(x)
@@ -48,7 +48,7 @@ tried to do Math.floor(null)
 
 ## reducer cv(fld) computes the coefficient of variation
 ### Juttle
-    import "stats.juttle" as stats;
+    import "stats" as stats;
     emit -limit 100 -from Date.new(0)
     | put x = 2 * count()
     | reduce x = last(x), u = avg(x), sd = stats.stdev(x), cv = stats.cv(x)


### PR DESCRIPTION
Modify the resolver used by juttle-test-utils, which takes a
collection of modules and falls back to stdlib otherwise, to use the
file resolver as a backup instead of looking under the stdlib
directory itself.

This allows import statements within unit tests to use short names for
stdlib modules if desired. It also allows other test programs (like
the aws unit tests) to also utilize adapter modules.

@rlgomes and @dmajda this is the change we discussed at https://github.com/juttle/juttle/pull/591#issuecomment-198086588.