### PR TITLE
SemanticPass: Fix reducer args coercion

### DIFF
--- a/lib/compiler/semantic.js
+++ b/lib/compiler/semantic.js
@@ -988,17 +988,10 @@ class SemanticPass {
     sa_reducer_arg(arg) {
         // coerce a naked name to a string (ie a field name) if it
         // isn't visible as a variable.
-        if (arg.type === 'Variable'
-            && this.scope.lookup_variable(arg.name) === undefined) {
-            //XXX this shouldn't have to be special cased and we should
-            // just be passing down the opts argument and letting this
-            // happen in sa_Variable XXX that is, unless we want only
-            // single variable arguments to be coerced...? and other
-            // reducer undefined variables to be flagged as such...
-            // not sure
-            arg.type ='StringLiteral';
-            arg.value = arg.name;
-            delete arg.name;
+        if (arg.type === 'Variable') {
+            this.with_coercion_mode('string', () => {
+                this.sa_expr(arg);
+            });
         } else {
             // reducer *arguments* are evaluated at build time
             this.with_context('build', () => {

--- a/test/runtime/specs/juttle-spec/reducer-args.spec.md
+++ b/test/runtime/specs/juttle-spec/reducer-args.spec.md
@@ -1,0 +1,26 @@
+# Reducer arguments
+
+## Variables in reducer arguments are coerced to fields
+
+### Juttle
+
+    emit -from :0: -limit 1 | reduce min(time) | view result
+
+### Output
+
+    { min: "1970-01-01T00:00:00.000Z" }
+
+## Variables in reducer arguments are not coerced if they refer to entities in scope
+
+Regression test for #646.
+
+### Juttle
+
+    function f() {
+    }
+
+    emit -from :0: -limit 1 | reduce min(f) | view result
+
+### Errors
+
+  * CompileError: Cannot use a function as a variable


### PR DESCRIPTION
Before this PR, variables passed as reducer args were coerced into fields unless there was a const or var in scope with the same name. All other entities such as functions or reducers were ignored. This was inconsistent with by-lists and sort-lists where coercion in such cases lead to a `CANNOT-USE-AS-VARIABLE` error.

This PR makes coercion of reducer args work exactly the same as in by-lists and sort-lists (by utilizing the same code path).

Fixes #646.