### PR TITLE
Juttle grammar: Fix handling of unary operators on string literals

### DIFF
--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -993,7 +993,7 @@ UnaryExpression
           // escape field names containing special characters.
           //
           // See #483 for details.
-          if (argument.type === 'StringLiteral') {
+          if (operator === '*' && argument.type === 'StringLiteral') {
               return createNode('Field', location(), {
                   name: argument.value
               });

--- a/test/runtime/specs/juttle-spec/expressions/bitwise-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/bitwise-not-operator.spec.md
@@ -19,3 +19,15 @@
 ### Errors
 
   * Invalid operand type for "~": null.
+
+## Produces an error when used on a string literal
+
+Regression test for #650.
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = ~'abcd' | view result
+
+### Errors
+
+  * Invalid operand type for "~": string (abcd).

--- a/test/runtime/specs/juttle-spec/expressions/eager-logical-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/eager-logical-not-operator.spec.md
@@ -22,3 +22,15 @@
 ### Errors
 
   * Invalid operand type for "NOT": null.
+
+## Produces an error when used on a string literal
+
+Regression test for #650.
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = NOT 'abcd' | view result
+
+### Errors
+
+  * Invalid operand type for "NOT": string (abcd).

--- a/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-not-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/short-circuiting-logical-not-operator.spec.md
@@ -22,3 +22,15 @@
 ### Errors
 
   * "!" operator: Invalid operand type (null).
+
+## Produces an error when used on a string literal
+
+Regression test for #650.
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = !'abcd' | view result
+
+### Errors
+
+  * "!" operator: Invalid operand type (string).

--- a/test/runtime/specs/juttle-spec/expressions/unary-minus-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/unary-minus-operator.spec.md
@@ -29,3 +29,15 @@
 ### Errors
 
   * Invalid operand type for "-": null.
+
+## Produces an error when used on a string literal
+
+Regression test for #650.
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = -'abcd' | view result
+
+### Errors
+
+  * Invalid operand type for "-": string (abcd).

--- a/test/runtime/specs/juttle-spec/expressions/unary-plus-operator.spec.md
+++ b/test/runtime/specs/juttle-spec/expressions/unary-plus-operator.spec.md
@@ -29,3 +29,15 @@
 ### Errors
 
   * Invalid operand type for "+": null.
+
+## Produces an error when used on a string literal
+
+Regression test for #650.
+
+### Juttle
+
+    emit -from Date.new(0) -limit 1 | put result = +'abcd' | view result
+
+### Errors
+
+  * Invalid operand type for "+": string (abcd).


### PR DESCRIPTION
Add missing check so that unary operators on string literals don’t behave like unary `*`.

Fixes #650.