### PR TITLE
add top and bottom subs to select module in stdlib

### DIFF
--- a/docs/stdlib/select.md
+++ b/docs/stdlib/select.md
@@ -66,3 +66,39 @@ Options      |         Description           | Required?
 
 Only the point with the exact median value for the `field` name
 provided will be forwarded.
+
+## top - sub
+
+```
+... | select.top -n number -by field | ...
+```
+
+Options  |                              Description                              | Required?
+-------- | --------------------------------------------------------------------- | --------- :
+`n`      | how many of the points with the highest values of `by` to keep        | Yes
+`by`     | name of the field to sort by before figuring out the top `n` to keep  | Yes
+`limit`  | the limit value to pass to sort if you happen to exceed the default limit | No, default: see [sort](../processors/sort.md) documentation
+
+Sort the inbound stream by the `by` field and return the `n` points that have
+highest value of the `by` field.
+
+**Note** Since `top` uses `sort` to sort by the `by` field we drop the `time` field
+from the individual points.
+
+## bottom - sub
+
+```
+... | select.bottom -n number -by field | ...
+```
+
+Options  |                                Description                                | Required?
+-------- | ------------------------------------------------------------------------- | --------- :
+`n`      | how many of the points with the lowest values of `by` to keep             | Yes
+`by`     | name of the field to sort by before figuring out the bottom `n` to keep   | Yes
+`limit`  | the limit value to pass to sort if you happen to exceed the default limit | No, default: see [sort](../processors/sort.md) documentation
+
+Sort the inbound stream by the `by` field and return the `n` points that have
+lowest value of the `by` field.
+
+**Note** Since `top` uses `sort` to sort by the `by` field we drop the `time` field
+from the individual points.

--- a/lib/stdlib/select.juttle
+++ b/lib/stdlib/select.juttle
@@ -59,3 +59,30 @@ export sub percentile(field, p, by=[]) {
 export sub median(field, by=[]) {
     percentile -field field -p 0.5 -by by
 }
+
+//
+// forward the top N points ordered by the `by` field provided
+//
+// Parameters:
+//
+//   * n: number of points to forward
+//   * by: field to sort by
+//   * limit: the limit to pass to sort
+//
+export sub top(n, by, limit=null) {
+    sort -limit limit by -desc | head n
+} 
+
+//
+// forward the bottom N points ordered by the `by` field provided
+//
+// Parameters:
+//
+//   * n: number of points to forward
+//   * by: field to sort by
+//   * limit: the limit to pass to sort
+//
+export sub bottom(n, by, limit=null) {
+    sort -limit limit by | head n
+} 
+

--- a/test/runtime/specs/juttle-spec/stdlib/select.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/select.spec.md
@@ -179,3 +179,133 @@
     {parity:1, x: 15}
     {parity:0, x: 36}
     {parity:1, x: 35}
+
+## top selects the 5 largest values
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 10 -from Date.new(0)
+    | put x = 10-count()
+    | select.top -n 5 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    {x: 9}
+    {x: 8}
+    {x: 7}
+    {x: 6}
+    {x: 5}
+
+## bottom selects the 5 smallest values
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 10 -from Date.new(0)
+    | put x = 10-count()
+    | select.bottom -n 5 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    {x: 0}
+    {x: 1}
+    {x: 2}
+    {x: 3}
+    {x: 4}
+
+## top selects the largest value per batch
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 9 -from Date.new(0)
+    | put x = count()
+    | batch -every :3s:
+    | select.top -n 1 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    { x: 3 }
+    { x: 6 }
+    { x: 9 }
+
+## bottom selects the smallest value per batch
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 9 -from Date.new(0)
+    | put x = count()
+    | batch -every :3s:
+    | select.bottom -n 1 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    { x: 1 }
+    { x: 4 }
+    { x: 7 }
+
+## top selects the 5 largest values from 3 element stream
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 3 -from Date.new(0)
+    | put x = 3-count()
+    | select.top -n 5 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    {x: 2}
+    {x: 1}
+    {x: 0}
+
+## bottom selects the 5 smallest values from 3 element stream
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 3 -from Date.new(0)
+    | put x = 3-count()
+    | select.bottom -n 5 -by 'x'
+    | keep x
+    | view result
+
+### Output
+    {x: 0}
+    {x: 1}
+    {x: 2}
+
+## top can correctly modify the underlying sort limit
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 6 -from Date.new(0)
+    | put x = 6-count()
+    | select.top -n 5 -by 'x' -limit 5
+    | keep x
+    | view result
+
+### Warnings
+ 
+  * sort limit of 5 exceeded, dropping points
+
+### Output
+    {x: 5}
+    {x: 4}
+    {x: 3}
+    {x: 2}
+    {x: 1}
+
+## bottom can correctly modify the underlying sort limit
+### Juttle
+    import "select.juttle" as select;
+    emit -limit 6 -from Date.new(0)
+    | put x = 6-count()
+    | select.bottom -n 5 -by 'x' -limit 5
+    | keep x
+    | view result
+
+### Warnings
+ 
+  * sort limit of 5 exceeded, dropping points
+
+### Output
+    {x: 1}
+    {x: 2}
+    {x: 3}
+    {x: 4}
+    {x: 5}


### PR DESCRIPTION
fixes #388

added `top` & `bottom` subs along with necessary tests and documentation