### PR TITLE
Bump adapter API version to 0.7.0

### DIFF
--- a/lib/adapters/api.js
+++ b/lib/adapters/api.js
@@ -10,7 +10,7 @@ let juttle_utils = require('../runtime/juttle-utils');
 // changes were made to the adapter API.
 //
 let AdapterAPI = {
-    version: '0.5.3',
+    version: '0.7.0',
     AdapterRead: require('./adapter-read'),
     AdapterWrite: require('./adapter-write'),
     compiler: {

--- a/test/runtime/test-adapter-clone/package.json
+++ b/test/runtime/test-adapter-clone/package.json
@@ -3,5 +3,5 @@
   "version": "0.1.0",
   "description": "",
   "author": "",
-  "juttleAdapterAPI": "^0.5.0"
+  "juttleAdapterAPI": "^0.7.0"
 }

--- a/test/runtime/test-adapter-timeseries/package.json
+++ b/test/runtime/test-adapter-timeseries/package.json
@@ -3,5 +3,5 @@
   "version": "0.1.0",
   "description": "",
   "author": "",
-  "juttleAdapterAPI": "^0.5.0"
+  "juttleAdapterAPI": "^0.7.0"
 }

--- a/test/runtime/test-adapter/package.json
+++ b/test/runtime/test-adapter/package.json
@@ -3,5 +3,5 @@
   "version": "0.1.0",
   "description": "",
   "author": "",
-  "juttleAdapterAPI": "^0.5.0"
+  "juttleAdapterAPI": "^0.7.0"
 }


### PR DESCRIPTION
This is needed because #384 introduces an incompatible change.