### PR TITLE
Report sort limit correctly

### DIFF
--- a/docs/processors/sort.md
+++ b/docs/processors/sort.md
@@ -23,7 +23,7 @@ Ordering is numeric (for number values) or alphabetical (for string
 values). It also supports multi-key sorting in ascending or descending
 order for alphabetical and numerical comparisons.
 
-:information_source: `Note:` Sorting is limited to 10,000 data points by default. To sort more points, use the -limit flag to set a higher value.
+:information_source: `Note:` Sorting is limited to 100,000 data points by default. To sort more points, use the -limit flag to set a higher value.
 
 _Example: Output a table of sorted random values_
 

--- a/lib/messages.json
+++ b/lib/messages.json
@@ -8,7 +8,7 @@
   "INCOMPATIBLE-ADAPTER": "adapter {type} incompatible with juttle {apiVersion} (wanted {adapterJuttleVersion})",
   "UNSUPPORTED-ADAPTER-METHOD": "adapter {type} does not implement {method}",
   "GROUP-BY-UNDEFINED": "group by undefined field \"{field}\"",
-  "BUFFER-LIMIT-EXCEEDED": "{buffer} limit exceeded, dropping points",
+  "BUFFER-LIMIT-EXCEEDED": "{buffer} limit of {limit} exceeded, dropping points",
   "POINTS-ARRIVED-LATE": "late arriving point(s) dropped by {proc}",
   "POINTS-OUT-OF-ORDER": "out-of-order point(s) dropped by {proc}",
   "TIME-OUT-OF-ORDER": "out-of-order assignment of time {badTime} after {goodTime}, point(s) dropped",

--- a/lib/runtime/procs/sort.js
+++ b/lib/runtime/procs/sort.js
@@ -65,6 +65,7 @@ class sort extends fanin {
         if (space_left < points.length) {
             this.trigger('warning', this.runtime_error('BUFFER-LIMIT-EXCEEDED', {
                 buffer: 'sort',
+                limit: this.limit,
                 field: this.sortBy
             }));
             if (!space_left)  {

--- a/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
+++ b/test/runtime/specs/juttle-spec/juttle-procs-sort.spec.md
@@ -12,7 +12,7 @@
 
 ### Warnings
 
-  * sort limit exceeded, dropping points
+  * sort limit of 1 exceeded, dropping points
 
 ## Limits: non-batched flow
 
@@ -58,8 +58,9 @@
 
 ### Warnings
 
-  * sort limit exceeded, dropping points
-  * sort limit exceeded, dropping points
+  * sort limit of 4 exceeded, dropping points
+  * sort limit of 4 exceeded, dropping points
+
 
 ## Limits: non-batched flow, point by point, by grouping
 
@@ -92,8 +93,8 @@
 
 ### Warnings
 
-  * sort limit exceeded, dropping points
-  * sort limit exceeded, dropping points
+  * sort limit of 4 exceeded, dropping points
+  * sort limit of 4 exceeded, dropping points
 
 ## Timestamps: unbatched flow
 


### PR DESCRIPTION
Ideally, the warning you get when running a program with `sort` on large input, `Warning: sort limit exceeded, dropping points` would also include the value of the limit - asking @rlgomes to add that. Here, fixing the doc which was wrong.