### PR TITLE
improve sort no fields error

### DIFF
--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -50,9 +50,14 @@ var show_in_context = function(options) {
 
     // The + 5 here is to account for the width of the preceding
     // padded line number and colon.
+    // Also if start and end point to the same location, then pad the end by
+    // a column to make sure we print something.
     if (options.err.info.location.start.line === options.err.info.location.end.line) {
-        var highlight = Array(options.err.info.location.start.column + 5).join(' ') +
-            Array(options.err.info.location.end.column - options.err.info.location.start.column + 1).join('^');
+        var span = new Array(options.err.info.location.end.column - options.err.info.location.start.column + 1);
+        if (span.length === 1) {
+            span.length = 2;
+        }
+        var highlight = Array(options.err.info.location.start.column + 5).join(' ') + span.join('^');
         ret += highlight + '\n';
     }
 
@@ -80,6 +85,3 @@ module.exports = {
     show_in_context: show_in_context,
     handle_juttle_error: handle_juttle_error
 };
-
-
-

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1819,7 +1819,7 @@ ByElementList
           return buildList(head, tail, 3);
       }
 
-SortByList
+SortByList 'sort field(s)'
     = elements:SortFieldList  {
           return createNode('SortByList', location(), {
               elements: elements

--- a/lib/parser/parser.pegjs
+++ b/lib/parser/parser.pegjs
@@ -1806,7 +1806,7 @@ ByClause = elements:( __ ByToken __ ByList) {
     return extractOptional(elements, 3);
 }
 
-ByList
+ByList 'field(s)'
     = elements:ByElementList {
           return createNode('ByList', location(), {
               elements: elements


### PR DESCRIPTION
Add a description to `SortByList` in the grammar, and tweak the cli's handling of errors at the end of input to emit better errors when the user forgets to add a field for the sort:

```
# bin/juttle -e 'emit | sort'
<input>:1:12:
   1:emit | sort
                ^
Error: Expected sort field(s) but end of input found. (SYNTAX-ERROR-WITH-EXPECTED)

# bin/juttle -e 'emit | sort | head'
<input>:1:13:
   1:emit | sort | head
                 ^
Error: Expected option or sort field(s) but "|" found. (SYNTAX-ERROR-WITH-EXPECTED)
```

@rlgomes @dmajda @mstemm