### PR TITLE
Show stack for internal errors.

### DIFF
--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -82,7 +82,7 @@ var handle_error = function(e, context) {
             console.error(error_string(e));
         }
     } else {
-        console.error('Error: ' + e.message);
+        console.error(e.stack);
     }
 };
 


### PR DESCRIPTION
Instead of just showing the message for internal errors, show the full
stack. This also includes the error class and message, so it's
strictly more information than we were showing.

This fixes #564.

@dmajda @go-oleg @rlgomes