### PR TITLE
remove duplicate implementation of stdev

### DIFF
--- a/docs/stdlib/stats.md
+++ b/docs/stdlib/stats.md
@@ -27,18 +27,6 @@ Option    |                   Description                      | Required?
 --------- | -------------------------------------------------- | ---------:
 `-field`  | name of the field to apply the reduce operation on |  Yes
 
-## stdev - reducer
-
-Return the standard deviation of a specified field over a batch
-
-```
-... | reduce value=stdev(value) | ...
-```
-
-Option    |                   Description                      | Required?
---------- | -------------------------------------------------- | ---------:
-`-field`  | name of the field to apply the reduce operation on |  Yes
-
 ## z - reducer
 
 Return the sample Z-score of the specified field.

--- a/lib/stdlib/stats.juttle
+++ b/lib/stdlib/stats.juttle
@@ -20,7 +20,6 @@
 // Reducers:
 //
 //   * demean(field): de-mean the field
-//   * stdev(field): standard deviation of the field
 //   * z(field): standardized z-score wrt sample mean and stdev
 //   * relMean(field): field as a percentage of field mean
 //   * cv(field): coefficent of variation
@@ -76,41 +75,6 @@ export reducer demean(field) {
         var v = *field;
         if (v != null) {
             sum = sum - v;
-            n = n - 1;
-        }
-    }
-};
-
-// Return the standard deviation of a specified field over a batch
-//
-// Parameters:
-//
-//   * field:   fieldname
-//
-export reducer stdev(field) {
-    var sum = 0;
-    var ssum = 0;
-    var n = 0;
-    function update() {
-        var v = *field;
-        if (v != null) {
-            sum = sum + v;
-            ssum = ssum + v*v;
-            n = n + 1;
-        }
-    }
-    function result() {
-        if (n < 2 ) {
-            return null;
-        } else {
-            return Math.sqrt(1/n * (ssum - sum*sum/n));
-        }
-    }
-    function expire() {
-        var v = *field;
-        if (v != null) {
-            sum = sum - v;
-            ssum = ssum - v*v;
             n = n - 1;
         }
     }

--- a/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
+++ b/test/runtime/specs/juttle-spec/stdlib/stats.spec.md
@@ -22,28 +22,6 @@
 ### Output
     {x: 0, u:0, xmu: 0}
 
-## reducer stdev(fld) computes the right thing
-### Juttle
-    import "stats" as stats;
-    emit -limit 3 -from Date.new(0)
-    | put x = 2 * count()
-    | reduce s = stats.stdev(x)
-    | view result
-
-### Output
-    {s: 1.632993161855452}
-
-## reducer stdev(fld) handles a stream of zeros
-### Juttle
-    import "stats.juttle" as stats;
-    emit -limit 3 -from Date.new(0)
-    | put x = 0
-    | reduce s = stats.stdev(x)
-    | view result
-
-### Output
-    {s: 0}
-
 ## reducer z(fld) computes the right thing
 note the first output point is dropped because we
 tried to do Math.floor(null)
@@ -97,7 +75,7 @@ tried to do Math.floor(null)
     import "stats" as stats;
     emit -limit 100 -from Date.new(0)
     | put x = 2 * count()
-    | reduce x = last(x), u = avg(x), sd = stats.stdev(x), cv = stats.cv(x)
+    | reduce x = last(x), u = avg(x), sd = stdev(x), cv = stats.cv(x)
     | put winning = cv == sd / u
     | keep winning
     | view result
@@ -110,7 +88,7 @@ tried to do Math.floor(null)
     import "stats.juttle" as stats;
     emit -limit 5 -from Date.new(0)
     | put x = 0
-    | reduce x = last(x), u = avg(x), sd = stats.stdev(x), cv = stats.cv(x)
+    | reduce x = last(x), u = avg(x), sd = stdev(x), cv = stats.cv(x)
     | view result
 
 ### Output


### PR DESCRIPTION
found upon inspection of the stdlib and since we have a built-in stdev
implementation this is completely unnecessary