### PR TITLE
add a view mode to the cli to show either all text or raw

### DIFF
--- a/bin/juttle
+++ b/bin/juttle
@@ -47,7 +47,7 @@ var errors = require('../lib/errors');
 
 var modes = _.without(compiler.stageNames, 'eval').concat('run');
 function usage() {
-    console.log('usage: juttle [--version] [--adapters] [--mode <mode>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]');
+    console.log('usage: juttle [--version] [--adapters] [--mode <mode>] [--view-mode <cli|text|raw>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]');
     console.log('     --version show juttle CLI version');
     console.log('     --adapters show versions and paths to all configured adapters');
     console.log('     --mode <mode>: one of ' + modes.map(JSON.stringify).join(', '));
@@ -56,6 +56,7 @@ function usage() {
     console.log('     --show-locations displays locations in the parse tree');
     console.log('     --color/--no-color turns CLI output coloring on and off');
     console.log('     --input name=val defines input `name` with value `val`');
+    console.log('     --view-mode: render view mode either using cli views, always as text, or show the raw points');
     console.log('     --e <juttle-src>: run the juttle source and exit');
     console.log('     [juttle-file]: run the provided juttle file and exit');
     process.exit(1);
@@ -66,7 +67,8 @@ var defaults = {
     input: false,
     e: '',
     mode: 'run',
-    config: null
+    config: null,
+    'view-mode': 'cli'
 };
 
 var opts = minimist(process.argv.slice(2), {boolean: ['optimize']});
@@ -175,6 +177,7 @@ function perform_run(options) {
     return perform_compile(options).then(function(program) {
         var view_mgr = new ViewManager({
             program: program,
+            mode: opts['view-mode'],
             view_classes: view_classes
         },{ // env
             color: (opts.color ? true : false) && (opts.no_color ? false : true)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,15 +9,16 @@ For more complex visualizations, you can use [juttle engine](https://github.com/
 `juttle` is run as follows:
 
 ```
-usage: juttle [--version] [--mode <mode>] [--config <config>] [--color/--no-color]
-              [--show-locations] [--optimize] [--input name=val] [juttle-file]
+usage: juttle [--version] [--adapters] [--mode <mode>] [--view-mode <cli|text|raw>] [--config <config>] [--color/--no-color] [--show-locations] [--optimize] [--input name=val] [juttle-file]
      --version show juttle CLI version
+     --adapters show versions and paths to all configured adapters
      --mode <mode>: one of "parse", "semantic", "build", "flowgraph", "compile", "run"
      --config <config>: path to the juttle interpreter configuration file
      --optimize runs optimization
      --show-locations displays locations in the parse tree
      --color/--no-color turns CLI output coloring on and off
      --input name=val defines input `name` with value `val`
+     --view-mode: render view mode either using cli views, always as text, or show the raw points
      --e <juttle-src>: run the juttle source and exit
      [juttle-file]: run the provided juttle file and exit
 ```
@@ -109,6 +110,8 @@ clear, \c - clear the terminal screen
 
 ## Views
 
+By default the juttle CLI supports the following view types:
+
 ###table
 `juttle` supports [table](../sinks/view_table.md) and [text](../sinks/view_text.md) views:
 
@@ -133,6 +136,8 @@ juttle>
 ```
 
 If a program does not contain a view, `juttle` automatically adds one based on the value of the `implicit_view` configuration item (see below).
+
+By default, the CLI will reject any programs containing unsupported view types, such as those supported by `juttle-viz`. The `--view-mode` option allows for execution and debugging of these programs. When run with `--view-mode=text`, the CLI will map all views as if they were a simple `text` view, i.e. render the view output as JSON. When run with `--view-mode=raw`, the CLI will print the details of the underlying messages that would be sent to the visual views had the program been run in an environment like `juttle-engine`.
 
 ## Errors
 

--- a/lib/views/raw.js
+++ b/lib/views/raw.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var View = require('./view');
+
+class RawView extends View {
+    constructor(options, env) {
+        super(options, env);
+        this.name = 'raw';
+        this.data = [];
+        this.id = options.id;
+        this.fstream.write(JSON.stringify({view: this.id, options: options}, null, 4) + '\n');
+    }
+
+    consume(points) {
+        this.fstream.write(JSON.stringify({view: this.id, type: 'points', data: points}) + '\n');
+    }
+
+    // This is called when a batch finishes
+    mark(mark) {
+        this.fstream.write(JSON.stringify({view: this.id, type: 'mark', data: mark}) + '\n');
+    }
+
+    // Called for ticks
+    tick(tick) {
+        this.fstream.write(JSON.stringify({view: this.id, type: 'tick', data: tick}) + '\n');
+    }
+
+    // Called when the stream finishes
+    eof() {
+        this.fstream.write(JSON.stringify({view: this.id, type: 'eof'}) + '\n', () => {
+            this.events.emit('end');
+        });
+    }
+}
+
+module.exports = RawView;

--- a/lib/views/view-mgr.js
+++ b/lib/views/view-mgr.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var EventEmitter = require('eventemitter3');
 var Promise = require('bluebird');
 var JuttleErrors = require('../errors');
+var RawView = require('./raw');
 
 class ViewManager {
     constructor(options, env) {
@@ -13,6 +14,7 @@ class ViewManager {
         this.env = env;
 
         this.views = {};
+        this.mode = options.mode;
     }
 
     warning(msg, warn) {
@@ -38,11 +40,20 @@ class ViewManager {
         views.forEach(function(view) {
 
             var view_class;
-            if (_.has(self.view_classes, view.name)) {
-                view_class = self.view_classes[view.name];
+            var view_options = view.options;
+            if (self.mode === 'raw') {
+                view_class = RawView;
+                view_options.id = view.channel;
+            } else if (self.mode === 'text') {
+                view_class = self.view_classes['text'];
+                view_options = {};
             } else {
-                throw JuttleErrors.syntaxError('INVALID-VIEW', {view: view.name,
-                                                                   location: view.location});
+                if (_.has(self.view_classes, view.name)) {
+                    view_class = self.view_classes[view.name];
+                } else {
+                    throw JuttleErrors.syntaxError('INVALID-VIEW', {view: view.name,
+                                                                    location: view.location});
+                }
             }
 
             // Progressive output only makes sense if there is exactly one view
@@ -52,11 +63,11 @@ class ViewManager {
             // So, unless the user has explicitly set the progressive option,
             // make it default to true iff there is exactly one view in the
             // program.
-            if (view.options.progressive === undefined) {
-                view.options.progressive = (views.length === 1);
+            if (view_options.progressive === undefined) {
+                view_options.progressive = (views.length === 1);
             }
 
-            self.views[view.channel] = new view_class(view.options, self.env);
+            self.views[view.channel] = new view_class(view_options, self.env, view.channel);
 
             self.views[view.channel].events.on('warning', function(msg, warn) {
                 self.warning(msg, warn);

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -427,6 +427,79 @@ describe('Juttle CLI Tests', function() {
             });
         });
 
+        it('can output data for visual views in raw mode', function() {
+            return runJuttle([
+                '--view-mode=raw',
+                '-e',
+                'emit -from :0: -limit 5 | (view timechart; reduce count() | view barchart)'
+            ]).then(function(result) {
+                expect(result.stderr).to.equal('');
+                expect(result.code).to.equal(0);
+                expect(result.stdout.split('\n')).to.deep.equal([
+                    '{',
+                    '    "view": "view0",',
+                    '    "options": {',
+                    '        "_jut_time_bounds": [',
+                    '            {',
+                    '                "from": "1970-01-01T00:00:00.000Z",',
+                    '                "to": null,',
+                    '                "last": null',
+                    '            }',
+                    '        ],',
+                    '        "id": "view0",',
+                    '        "progressive": false',
+                    '    }',
+                    '}',
+                    '{',
+                    '    "view": "view1",',
+                    '    "options": {',
+                    '        "_jut_time_bounds": [',
+                    '            {',
+                    '                "from": "1970-01-01T00:00:00.000Z",',
+                    '                "to": null,',
+                    '                "last": null',
+                    '            }',
+                    '        ],',
+                    '        "id": "view1",',
+                    '        "progressive": false',
+                    '    }',
+                    '}',
+                    '{"view":"view0","type":"points","data":[{"time":"1970-01-01T00:00:00.000Z"}]}',
+                    '{"view":"view0","type":"points","data":[{"time":"1970-01-01T00:00:01.000Z"}]}',
+                    '{"view":"view0","type":"points","data":[{"time":"1970-01-01T00:00:02.000Z"}]}',
+                    '{"view":"view0","type":"points","data":[{"time":"1970-01-01T00:00:03.000Z"}]}',
+                    '{"view":"view0","type":"points","data":[{"time":"1970-01-01T00:00:04.000Z"}]}',
+                    '{"view":"view0","type":"eof"}',
+                    '{"view":"view1","type":"points","data":[{"count":5}]}',
+                    '{"view":"view1","type":"eof"}',
+                    ''
+                ]);
+            });
+        });
+
+        it('can output data for visual views in text mode', function() {
+            return runJuttle([
+                '--view-mode=text',
+                '-e',
+                'emit -from :0: -limit 5 | (view timechart; reduce count() | view barchart)'
+            ]).then(function(result) {
+                expect(result.stderr).to.equal('');
+                expect(result.code).to.equal(0);
+                expect(result.stdout.split('\n')).to.deep.equal([
+                    '[',
+                    '{"time":"1970-01-01T00:00:00.000Z"},',
+                    '{"time":"1970-01-01T00:00:01.000Z"},',
+                    '{"time":"1970-01-01T00:00:02.000Z"},',
+                    '{"time":"1970-01-01T00:00:03.000Z"},',
+                    '{"time":"1970-01-01T00:00:04.000Z"}',
+                    ']',
+                    '[',
+                    '{"count":5}',
+                    ']',
+                    ''
+                ]);
+            });
+        });
     });
 
     describe('juttle REPL', function() {


### PR DESCRIPTION
In order to help debug a juttle program in the CLI that contains
visual sinks, add a --view-mode option to the cli which can be either "text" in
which case all views are rendered as text), or "raw" in which case it just
prints out the raw underling data that would go to the views over the
websocket.

@go-oleg @mstemm