### PR TITLE
cli: send logging output to stderr instead of console

### DIFF
--- a/lib/cli/log-setup.js
+++ b/lib/cli/log-setup.js
@@ -27,7 +27,7 @@ function logSetup() {
 
     log4js.configure({
         levels: levels,
-        appenders: [{type: 'console'}]
+        appenders: [{type: __dirname + '/stderr-appender'}]
     });
 
     JuttleLogger.getLogger('cli').debug('set logging levels to', levels);

--- a/lib/cli/stderr-appender.js
+++ b/lib/cli/stderr-appender.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Use a custom appender until log4js supports stderr output:
+// https://github.com/nomiddlename/log4js-node/pull/364
+
+var layouts = require('log4js/lib/layouts');
+function stderrAppender(layout, timezoneOffset) {
+    layout = layout || layouts.colouredLayout;
+    return function(loggingEvent) {
+        process.stderr.write(layout(loggingEvent, timezoneOffset) + '\n');
+    };
+}
+
+function configure(config) {
+    var layout;
+    if (config.layout) {
+        layout = layouts.layout(config.layout.type, config.layout);
+    }
+    return stderrAppender(layout, config.timezoneOffset);
+}
+
+exports.appender = stderrAppender;
+exports.configure = configure;

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -480,9 +480,8 @@ describe('Juttle CLI Tests', function() {
                 '-e', 'emit -from :2016-01-01: -limit 1 | view text -format "jsonl"'
             ])
             .then(function(result) {
-                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
-                expect(result.stdout).to.not.match(/\[DEBUG\]/);
-                expect(result.stdout).to.not.match(/\[INFO\]/);
+                expect(result.stdout).to.equal('{"time":"2016-01-01T00:00:00.000Z"}\n');
+                expect(result.stderr).to.equal('');
             });
         });
 
@@ -494,10 +493,10 @@ describe('Juttle CLI Tests', function() {
                 }
             )
             .then(function(result) {
-                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
-                expect(result.stdout).to.match(/\[DEBUG\] cli/);
-                expect(result.stdout).to.match(/\[DEBUG\] juttle-adapter/);
-                expect(result.stdout).to.match(/\[DEBUG\] proc-emit/);
+                expect(result.stdout).to.equal('{"time":"2016-01-01T00:00:00.000Z"}\n');
+                expect(result.stderr).to.match(/\[DEBUG\] cli/);
+                expect(result.stderr).to.match(/\[DEBUG\] juttle-adapter/);
+                expect(result.stderr).to.match(/\[DEBUG\] proc-emit/);
             });
         });
 
@@ -509,10 +508,10 @@ describe('Juttle CLI Tests', function() {
                 }
             )
             .then(function(result) {
-                expect(result.stdout).to.contain('{"time":"2016-01-01T00:00:00.000Z"}');
-                expect(result.stdout).to.match(/\[DEBUG\] cli/);
-                expect(result.stdout).to.match(/\[DEBUG\] juttle-adapter/);
-                expect(result.stdout).to.not.match(/\[DEBUG\] proc-emit/);
+                expect(result.stdout).to.equal('{"time":"2016-01-01T00:00:00.000Z"}\n');
+                expect(result.stderr).to.match(/\[DEBUG\] cli/);
+                expect(result.stderr).to.match(/\[DEBUG\] juttle-adapter/);
+                expect(result.stderr).to.not.match(/\[DEBUG\] proc-emit/);
             });
         });
     });
@@ -531,7 +530,7 @@ describe('Juttle CLI Tests', function() {
                 }
             )
             .then(function(result) {
-                expect(result.stdout).to.match(/ctrl-c received, stopping current program/);
+                expect(result.stderr).to.match(/ctrl-c received, stopping current program/);
             });
         });
 
@@ -547,7 +546,7 @@ describe('Juttle CLI Tests', function() {
                 }
             )
             .then(function(result) {
-                expect(result.stdout).to.match(/ctrl-c received, stopping current program/);
+                expect(result.stderr).to.match(/ctrl-c received, stopping current program/);
             });
         });
 


### PR DESCRIPTION
Use a custom log4js appender to send the logging output to stderr
instead of through console.log.

Fixes #637